### PR TITLE
Fix for wrong Calliope error handling 

### DIFF
--- a/RobotMbed/src/main/java/de/fhg/iais/roberta/visitor/validate/CalliopeSimValidatorVisitor.java
+++ b/RobotMbed/src/main/java/de/fhg/iais/roberta/visitor/validate/CalliopeSimValidatorVisitor.java
@@ -36,11 +36,13 @@ import de.fhg.iais.roberta.syntax.sensor.generic.CompassSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.GestureSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.GyroSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.HumiditySensor;
+import de.fhg.iais.roberta.syntax.sensor.generic.InfraredSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.LightSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.PinGetValueSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.PinTouchSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.SoundSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.TemperatureSensor;
+import de.fhg.iais.roberta.syntax.sensor.generic.UltrasonicSensor;
 import de.fhg.iais.roberta.syntax.sensor.mbed.RadioRssiSensor;
 import de.fhg.iais.roberta.typecheck.NepoInfo;
 import de.fhg.iais.roberta.visitor.hardware.IMbedVisitor;
@@ -93,6 +95,18 @@ public final class CalliopeSimValidatorVisitor extends AbstractSimValidatorVisit
 
     @Override
     public Void visitTemperatureSensor(TemperatureSensor<Void> temperatureSensor) {
+        return null;
+    }
+
+    @Override
+    public Void visitUltrasonicSensor(UltrasonicSensor<Void> ultrasonicSensor) {
+        ultrasonicSensor.addInfo(NepoInfo.warning("SIM_BLOCK_NOT_SUPPORTED"));
+        return null;
+    }
+
+    @Override
+    public Void visitInfraredSensor(InfraredSensor<Void> infraredSensor) {
+        infraredSensor.addInfo(NepoInfo.warning("SIM_BLOCK_NOT_SUPPORTED"));
         return null;
     }
 


### PR DESCRIPTION
## Description of the issue
When you use certain calliope sensors, the wrong error message is displayed.
## Type of change
Bug fix 

## Steps to reproduce behaviour
- Create a new program
- Use the 'show text' block in association with the ultrasonic sensor/infrared sensor block.
- Run the simulation

## Cause of the problem
As there was no implementation of the visitSensor methods of Infrared Sensor and Ultrasonic Sensor in CalliopeSimValidatorVisitor.java, the implementations of the respective methods in AbstractSimValidatorVisitor.java were used instead.
As a result the wrong error message was being displayed.

## Resolution
The visitUltrasonicSensor/visitInfrasonicSensor method was overriden in CalliopeSimValidatorVisitor.java and the appropriate error message was supplied.

**Behaviour prior to changes**
<img width="1280" alt="Screen Shot 2019-12-07 at 7 36 25 AM" src="https://user-images.githubusercontent.com/9400738/70369332-ba42cb00-18dd-11ea-8255-d228d6a497bc.png">


**Behaviour after changes**
<img width="1280" alt="Screen Shot 2019-12-07 at 8 27 03 AM" src="https://user-images.githubusercontent.com/9400738/70369335-c169d900-18dd-11ea-88b3-ef00db6714bf.png">