### PR TITLE
Fix for bluetooth blocks of EV3

### DIFF
--- a/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/codegen/Ev3StackMachineVisitor.java
+++ b/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/codegen/Ev3StackMachineVisitor.java
@@ -17,6 +17,10 @@ import de.fhg.iais.roberta.syntax.BlockTypeContainer;
 import de.fhg.iais.roberta.syntax.MotorDuration;
 import de.fhg.iais.roberta.syntax.Phrase;
 import de.fhg.iais.roberta.syntax.SC;
+import de.fhg.iais.roberta.syntax.action.communication.BluetoothConnectAction;
+import de.fhg.iais.roberta.syntax.action.communication.BluetoothReceiveAction;
+import de.fhg.iais.roberta.syntax.action.communication.BluetoothSendAction;
+import de.fhg.iais.roberta.syntax.action.communication.BluetoothWaitForConnectionAction;
 import de.fhg.iais.roberta.syntax.action.display.ClearDisplayAction;
 import de.fhg.iais.roberta.syntax.action.display.ShowTextAction;
 import de.fhg.iais.roberta.syntax.action.ev3.ShowPictureAction;
@@ -466,5 +470,25 @@ public class Ev3StackMachineVisitor<V> extends AbstractStackMachineVisitor<V> im
             app(mk(C.EXPR).put(C.EXPR, C.NUM_CONST).put(C.VALUE, 0));
         }
     }
+    @Override
+    public V visitBluetoothReceiveAction(BluetoothReceiveAction<V> bluetoothReceiveAction) {
+        return null;
+    }
+
+    @Override
+    public V visitBluetoothConnectAction(BluetoothConnectAction<V> bluetoothConnectAction) {
+        return null;
+    }
+
+    @Override
+    public V visitBluetoothSendAction(BluetoothSendAction<V> bluetoothSendAction) {
+        return null;
+    }
+
+    @Override
+    public V visitBluetoothWaitForConnectionAction(BluetoothWaitForConnectionAction<V> bluetoothWaitForConnection) {
+        return null;
+    }
+
 
 }


### PR DESCRIPTION
## Description of the issue
When using the blocks from the message category, the user receives a server error.

## Type of change
Bug fix 

## Steps to reproduce behaviour
1. Create a new program
2. Create a connection variable and use it in association with a block from the messages Category.
3. Open the simulator

## Resolution
The default implementations of the VisitBluetoothAction methods were overriden in Ev3StackMachineVisitor.java.

## Behaviour prior to changes
<img width="1280" alt="Screen Shot 2019-12-11 at 8 32 49 AM" src="https://user-images.githubusercontent.com/9400738/70587922-4fe99d80-1bf1-11ea-9ba1-90943220a105.png">


## Behaviour after changes
<img width="1278" alt="Screen Shot 2019-12-10 at 7 31 16 PM" src="https://user-images.githubusercontent.com/9400738/70587940-58da6f00-1bf1-11ea-92fd-3f19a2fb4437.png">
