### PR TITLE
Removed wrong switch LED matrix warning

### DIFF
--- a/RobotMbed/src/main/java/de/fhg/iais/roberta/visitor/validate/MbedBoardValidatorVisitor.java
+++ b/RobotMbed/src/main/java/de/fhg/iais/roberta/visitor/validate/MbedBoardValidatorVisitor.java
@@ -231,7 +231,6 @@ public final class MbedBoardValidatorVisitor extends AbstractBoardValidatorVisit
 
     @Override
     public Void visitSwitchLedMatrixAction(SwitchLedMatrixAction<Void> switchLedMatrixAction) {
-        switchLedMatrixAction.addInfo(NepoInfo.warning("SIM_BLOCK_NOT_SUPPORTED"));
         return null;
     }
 }


### PR DESCRIPTION
## Description of the issue
The wrong error message is displayed when the switch LED matrix block is used.

## Type of change
Bug fix

## Steps to reproduce behaviour
1. Create a new program under Calliope Mini.
2. Use the Switch LED matrix block.
3. Try to compile the code or open the source code view

## Resolution
The error message was coming from the implementation of the visitSwitchLedMatrixAction method in MbedBoardValidatorVisitor.java. The line switchLedMatrixAction.addInfo(NepoInfo.warning("SIM_BLOCK_NOT_SUPPORTED")); was removed.

## Behaviour prior to changes
<img width="675" alt="Screen Shot 2019-12-16 at 5 20 49 PM" src="https://user-images.githubusercontent.com/9400738/70904975-b7a44c00-2028-11ea-9a61-99077e06dc46.png">

## Behaviour after changes
<img width="545" alt="Screen Shot 2019-12-16 at 5 20 55 PM" src="https://user-images.githubusercontent.com/9400738/70904988-becb5a00-2028-11ea-9327-02d5fa19771a.png">
