### PR TITLE
Fix for EV3 simulator colour sensor

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/scene.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/scene.js
@@ -588,7 +588,7 @@ define([ 'simulation.simulation', 'simulation.math', 'util', 'interpreter.consta
                 this.robots[r].colorSensor.lightValue = ((red + green + blue) / 3 / 2.55);
 
                 values.color.light = this.robots[r].colorSensor.lightValue;
-                values.color.rgb = [UTIL.round(red / 2.55, 0), UTIL.round(green / 2.55, 0), UTIL.round(blue / 2.55, 0)];
+                values.color.rgb = [UTIL.round(red, 0), UTIL.round(green, 0), UTIL.round(blue, 0)];
                 values.color.ambientlight = 0;
 
                 values.light.light = this.robots[r].colorSensor.lightValue;


### PR DESCRIPTION
## Description of the issue
When the RGB value from the colour sensor is printed, the range of values is from 0 - 100 instead of 0 - 255.

## Steps to reproduce behaviour
1. Create a new program
2. Use the 'show text' block with the 'get RGB colour' sensor block.
3. Start the simulation

## Resolution
The problem was being caused because the red, blue and green values from the sensor were being modified in scene.js to fit in the range of of 0 - 100 . These statements were changed such that the values are not modified. 

## Behaviour prior to changes
<img width="383" alt="Screen Shot 2019-12-17 at 7 04 22 PM" src="https://user-images.githubusercontent.com/9400738/70999797-1dafd280-2100-11ea-94f9-2e231af4aaf6.png">

## Behaviour after changes
<img width="429" alt="Screen Shot 2019-12-17 at 7 02 43 PM" src="https://user-images.githubusercontent.com/9400738/70999806-24d6e080-2100-11ea-96e8-25a3fe5fe22d.png">

