### PR TITLE
Fixed server error in NXT message blocks

### DIFF
--- a/RobotNXT/src/main/java/de/fhg/iais/roberta/visitor/codegen/NxtStackMachineVisitor.java
+++ b/RobotNXT/src/main/java/de/fhg/iais/roberta/visitor/codegen/NxtStackMachineVisitor.java
@@ -15,6 +15,9 @@ import de.fhg.iais.roberta.mode.action.TurnDirection;
 import de.fhg.iais.roberta.syntax.MotorDuration;
 import de.fhg.iais.roberta.syntax.Phrase;
 import de.fhg.iais.roberta.syntax.SC;
+import de.fhg.iais.roberta.syntax.action.communication.BluetoothCheckConnectAction;
+import de.fhg.iais.roberta.syntax.action.communication.BluetoothReceiveAction;
+import de.fhg.iais.roberta.syntax.action.communication.BluetoothSendAction;
 import de.fhg.iais.roberta.syntax.action.display.ClearDisplayAction;
 import de.fhg.iais.roberta.syntax.action.display.ShowTextAction;
 import de.fhg.iais.roberta.syntax.action.light.LightAction;
@@ -32,6 +35,7 @@ import de.fhg.iais.roberta.syntax.action.sound.PlayNoteAction;
 import de.fhg.iais.roberta.syntax.action.sound.ToneAction;
 import de.fhg.iais.roberta.syntax.action.sound.VolumeAction;
 import de.fhg.iais.roberta.syntax.lang.expr.ColorConst;
+import de.fhg.iais.roberta.syntax.lang.expr.ConnectConst;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.ColorSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.CompassSensor;
@@ -442,6 +446,30 @@ public class NxtStackMachineVisitor<V> extends AbstractStackMachineVisitor<V> im
         } else {
             app(mk(C.EXPR).put(C.EXPR, C.NUM_CONST).put(C.VALUE, 0));
         }
+    }
+    
+    @Override
+    public V visitBluetoothSendAction(BluetoothSendAction<V> bluetoothSendAction) {
+        // Overrides default implementation so that server error is not produced
+        return null;
+    }
+
+    @Override
+    public V visitBluetoothCheckConnectAction(BluetoothCheckConnectAction<V> bluetoothCheckConnectAction) {
+        // Overrides default implementation so that server error is not produced
+        return null;
+    }
+
+    @Override
+    public V visitBluetoothReceiveAction(BluetoothReceiveAction<V> bluetoothReceiveAction) {
+        // Overrides default implementation so that server error is not produced
+        return null;
+    }
+
+    @Override
+    public V visitConnectConst(ConnectConst<V> connectConst) {
+        // Overrides default implementation so that server error is not produced
+        return null;
     }
 
 }


### PR DESCRIPTION
## Description of the issue
When using the blocks from the 'messages' category, the user receives a server error.

## Type of change
Bug fix 

## Steps to reproduce behaviour
1. Create a new program in the NXT robot
2. Use a block from the 'messages' Category.
3. Open the simulator

## Resolution
The default implementations of the visitBluetoothSendAction, visitBluetoothCheckConnectAction, visitBluetoothReceiveAction and the visitConnectConst methods were overriden in NxtStackMachineVisitor.java.

## Behaviour prior to changes
<img width="1037" alt="Screen Shot 2019-12-23 at 4 56 01 PM" src="https://user-images.githubusercontent.com/9400738/71356746-20e80a00-25a9-11ea-9aa9-d556ae27bb76.png">


## Behaviour after changes
<img width="990" alt="Screen Shot 2019-12-23 at 4 16 05 PM" src="https://user-images.githubusercontent.com/9400738/71356761-29d8db80-25a9-11ea-995d-bc79df1f2d94.png">

