### PR TITLE
Fixed lab tour switching to ev3

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
+++ b/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
@@ -628,7 +628,7 @@ define([ 'exports', 'log', 'util', 'message', 'comm', 'robot.controller', 'socke
 
         $('#takeATour').onWrap('click', function(event) {
             if (GUISTATE_C.getRobotGroup() !== 'ev3') {
-                ROBOT_C.switchRobot('ev3lejos', true);
+                ROBOT_C.switchRobot('ev3lejosv1', true);
             }
             if (GUISTATE_C.getProgramToolboxLevel() !== 'beginner') {
                 $('#beginner').trigger('click');


### PR DESCRIPTION
Fixed issue [#331](https://github.com/OpenRoberta/openroberta-lab/issues/331), tour now switches to ev3 bot.
