### PR TITLE
Added robot type to failed import popup

### DIFF
--- a/OpenRobertaServer/src/main/java/de/fhg/iais/roberta/javaServer/restServices/all/controller/ClientProgramController.java
+++ b/OpenRobertaServer/src/main/java/de/fhg/iais/roberta/javaServer/restServices/all/controller/ClientProgramController.java
@@ -344,6 +344,7 @@ public class ClientProgramController {
                     UtilForREST.addSuccessInfo(response, Key.PROGRAM_IMPORT_SUCCESS);
                     Statistics.info("ProgramImport", "success", true);
                 } else {
+                    response.put("robot", robotType1);
                     UtilForREST.addErrorInfo(response, Key.PROGRAM_IMPORT_ERROR_WRONG_ROBOT_TYPE);
                     Statistics.info("ProgramImport", "success", false);
                 }

--- a/OpenRobertaServer/staticResources/js/app/roberta/controller/import.controller.js
+++ b/OpenRobertaServer/staticResources/js/app/roberta/controller/import.controller.js
@@ -1,6 +1,6 @@
 define([ 'exports', 'comm', 'message', 'log', 'util', 'guiState.controller', 'program.controller', 'configuration.controller', 'program.model',
-        'robot.controller', 'blocks', 'jquery', 'jquery-validate', 'blocks-msg' ], function(exports, COMM, MSG, LOG, UTIL, GUISTATE_C, PROGRAM_C,
-        CONFIGURATION_C, PROGRAM, ROBOT_C, Blockly, $) {
+        'robot.controller', 'prettify', 'blocks', 'jquery', 'jquery-validate', 'blocks-msg' ], function(exports, COMM, MSG, LOG, UTIL, GUISTATE_C, PROGRAM_C,
+        CONFIGURATION_C, PROGRAM, ROBOT_C, Prettify, Blockly, $) {
 
     function init(callback) {
         $('#fileSelector').val(null);
@@ -26,13 +26,6 @@ define([ 'exports', 'comm', 'message', 'log', 'util', 'guiState.controller', 'pr
         $('#fileSelector').trigger('click'); // opening dialog 
     }
     exports.importXml = importXml;
-    
-    function importSourceCode(callback) {
-        init(callback);
-        $('#fileSelector').attr("accept", "." + GUISTATE_C.getSourceCodeFileExtension());
-        $('#fileSelector').trigger('click'); // opening dialog 
-    }
-    exports.importSourceCode = importSourceCode;
 
     function openProgramFromXML(target) {
         var robotType = target[1];
@@ -82,6 +75,8 @@ define([ 'exports', 'comm', 'message', 'log', 'util', 'guiState.controller', 'pr
                 }
             } else {
                 MSG.displayInformation(result, "", result.message, name);
+                var popupMessage = $('#message').html();
+                $('#message').html(popupMessage+"<br>Type of robot: " + result.robot);
             }
         });
     }


### PR DESCRIPTION
> When importing a program from a different robot type, the following message will occur.
> ![importProgramFailure](https://user-images.githubusercontent.com/58920989/71488760-17dc8000-27d7-11ea-96dd-c1818202ee80.PNG)
> 
> Now it has been changed to show the robot type of the program wanting to be imported.
> ![importProgramSuccess](https://user-images.githubusercontent.com/58920989/71488790-478b8800-27d7-11ea-8b3d-5efb9ee96301.PNG)

