### PR TITLE
Fix three typos in comments

### DIFF
--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/codegen/ICompilerWorkflow.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/codegen/ICompilerWorkflow.java
@@ -68,7 +68,7 @@ public interface ICompilerWorkflow {
      *
      * @param token the credential the end user (at the terminal) and the brick have both agreed to use
      * @param programName name of the program
-     * @param transformer to acces the AST of program and configuration
+     * @param transformer to access the AST of program and configuration
      * @param language the locale to be used for messages
      * @return a message key in case of an error; null otherwise
      */
@@ -97,7 +97,7 @@ public interface ICompilerWorkflow {
     Key getWorkflowResult();
 
     /**
-     * set the program source code. Only to be called when native programs have to be compiles (rare case :-)
+     * set the program source code. Only to be called when native programs have to be compiled (rare case :-)
      */
     void setSourceCode(String sourceCode);
 

--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/factory/RobotFactory.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/factory/RobotFactory.java
@@ -28,7 +28,7 @@ public class RobotFactory implements IRobotFactory {
     protected final String programDefault;
     protected final String configurationToolbox;
     protected final String configurationDefault;
-    protected Map<String, IWorker> workers = new HashMap<>(); //worker type to impllementing class(es) collect->de.fhg.iais.roberta.visitor.collect.Ev3UsedHardwareCollectorWorker
+    protected Map<String, IWorker> workers = new HashMap<>(); //worker type to implementing class(es) collect->de.fhg.iais.roberta.visitor.collect.Ev3UsedHardwareCollectorWorker
     protected Map<String, List<String>> workflows = new HashMap<>(); //workflow name to a list of types of applicable workers: showsource->collect,generate
 
     public RobotFactory(PluginProperties pluginProperties) {
@@ -51,12 +51,12 @@ public class RobotFactory implements IRobotFactory {
     public BlocklyDropdownFactory getBlocklyDropdownFactory() {
         return this.blocklyDropdown2EnumFactory;
     }
-    
+
     @Override
     public final String getSourceCodeFileExtension() {
         return this.pluginProperties.getStringProperty("robot.plugin.fileExtension.source");
     }
-    
+
     @Override
     public final String getBinaryFileExtension() {
         return this.pluginProperties.getStringProperty("robot.plugin.fileExtension.binary");
@@ -192,7 +192,7 @@ public class RobotFactory implements IRobotFactory {
     public final Boolean hasWlanCredentials() {
         return this.pluginProperties.getStringProperty("robot.haswlan") != null;
     }
-    
+
     @Override
     public final String getFirmwareDefaultProgramName() {
         return this.pluginProperties.getStringProperty("robot.factory.default");


### PR DESCRIPTION
I've fixed three typos (acess -> access, compiles -> compiled, and impllementing -> implementing).