### PR TITLE
Fix for WeDo server error with empty port

### DIFF
--- a/RobotWeDo/src/main/java/de/fhg/iais/roberta/visitor/validate/WedoBrickValidatorVisitor.java
+++ b/RobotWeDo/src/main/java/de/fhg/iais/roberta/visitor/validate/WedoBrickValidatorVisitor.java
@@ -118,7 +118,7 @@ public final class WedoBrickValidatorVisitor<V> extends AbstractBrickValidatorVi
     @Override
     public Void visitToneAction(ToneAction<Void> toneAction) {
         if ( toneAction.getInfos().getErrorCount() == 0 ) {
-            ConfigurationComponent usedConfigurationBlock = this.robotConfiguration.getConfigurationComponent(toneAction.getPort());
+            ConfigurationComponent usedConfigurationBlock = this.robotConfiguration.optConfigurationComponent(toneAction.getPort());
             if ( usedConfigurationBlock == null ) {
                 toneAction.addInfo(NepoInfo.error("CONFIGURATION_ERROR_ACTOR_MISSING"));
                 this.errorCount++;


### PR DESCRIPTION
**Description of issue**
When the 'buzzer' block in robot configuration is deleted and the 'play frequency' block is used,
the user receives a server error.

**Before Changes**
<img width="1067" alt="Screen Shot 2020-01-04 at 6 17 03 PM" src="https://user-images.githubusercontent.com/9400738/71765781-72d04e80-2f1e-11ea-9f62-511f7c9aced5.png">


**After Changes**
<img width="1020" alt="Screen Shot 2020-01-04 at 6 08 34 PM" src="https://user-images.githubusercontent.com/9400738/71765721-2422b480-2f1e-11ea-91f3-b5a1a6a0d11f.png">
