### PR TITLE
Add not supported message to sound sensor in EV3

### DIFF
--- a/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/validate/Ev3SimValidatorVisitor.java
+++ b/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/validate/Ev3SimValidatorVisitor.java
@@ -5,6 +5,7 @@ import de.fhg.iais.roberta.components.ConfigurationAst;
 import de.fhg.iais.roberta.syntax.action.ev3.ShowPictureAction;
 import de.fhg.iais.roberta.syntax.sensor.generic.CompassSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.IRSeekerSensor;
+import de.fhg.iais.roberta.syntax.sensor.generic.SoundSensor;
 import de.fhg.iais.roberta.typecheck.NepoInfo;
 import de.fhg.iais.roberta.visitor.hardware.IEv3Visitor;
 
@@ -24,6 +25,12 @@ public final class Ev3SimValidatorVisitor extends AbstractSimValidatorVisitor im
     public Void visitCompassSensor(CompassSensor<Void> compassSensor) {
         super.visitCompassSensor(compassSensor);
         compassSensor.addInfo(NepoInfo.warning("SIM_BLOCK_NOT_SUPPORTED"));
+        return null;
+    }
+    
+    @Override
+    public Void visitSoundSensor(SoundSensor<Void> soundSensor) {
+        soundSensor.addInfo(NepoInfo.warning("SIM_BLOCK_NOT_SUPPORTED"));
         return null;
     }
 


### PR DESCRIPTION
**Description**
The sound sensor does not show the unsupported message when used in the simulation

**Prior to changes**
<img width="1279" alt="Screen Shot 2020-01-04 at 6 43 26 PM" src="https://user-images.githubusercontent.com/9400738/71766219-892cd900-2f23-11ea-9daa-f8312bf7d038.png">

**After changes**
<img width="1280" alt="Screen Shot 2020-01-04 at 6 44 03 PM" src="https://user-images.githubusercontent.com/9400738/71766220-8d58f680-2f23-11ea-82b8-c9ffc361f766.png">
