### PR TITLE
Add negative sound duration handling

### DIFF
--- a/RobotArdu/src/main/java/de/fhg/iais/roberta/visitor/codegen/ArduinoCppVisitor.java
+++ b/RobotArdu/src/main/java/de/fhg/iais/roberta/visitor/codegen/ArduinoCppVisitor.java
@@ -26,6 +26,7 @@ import de.fhg.iais.roberta.syntax.actors.arduino.RelayAction;
 import de.fhg.iais.roberta.syntax.lang.blocksequence.MainTask;
 import de.fhg.iais.roberta.syntax.lang.expr.ColorConst;
 import de.fhg.iais.roberta.syntax.lang.expr.Expr;
+import de.fhg.iais.roberta.syntax.lang.expr.NumConst;
 import de.fhg.iais.roberta.syntax.lang.expr.RgbColor;
 import de.fhg.iais.roberta.syntax.lang.expr.Var;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
@@ -161,6 +162,10 @@ public final class ArduinoCppVisitor extends AbstractCommonArduinoCppVisitor imp
 
     @Override
     public Void visitToneAction(ToneAction<Void> toneAction) {
+        NumConst<Void> toneActionConst = (NumConst<Void>) toneAction.getDuration();
+        if ( Integer.valueOf(toneActionConst.getValue()) <= 0 ) {
+            return null;
+        }
         //9 - sound port
         this.sb.append("tone(_spiele_" + toneAction.getPort() + ",");
         toneAction.getFrequency().accept(this);

--- a/RobotArdu/src/main/java/de/fhg/iais/roberta/visitor/codegen/BotnrollCppVisitor.java
+++ b/RobotArdu/src/main/java/de/fhg/iais/roberta/visitor/codegen/BotnrollCppVisitor.java
@@ -25,6 +25,7 @@ import de.fhg.iais.roberta.syntax.action.sound.PlayNoteAction;
 import de.fhg.iais.roberta.syntax.action.sound.ToneAction;
 import de.fhg.iais.roberta.syntax.lang.blocksequence.MainTask;
 import de.fhg.iais.roberta.syntax.lang.expr.Expr;
+import de.fhg.iais.roberta.syntax.lang.expr.NumConst;
 import de.fhg.iais.roberta.syntax.lang.expr.SensorExpr;
 import de.fhg.iais.roberta.syntax.sensor.ExternalSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.ColorSensor;
@@ -113,6 +114,10 @@ public final class BotnrollCppVisitor extends AbstractCommonArduinoCppVisitor im
 
     @Override
     public Void visitToneAction(ToneAction<Void> toneAction) {
+        NumConst<Void> toneActionConst = (NumConst<Void>) toneAction.getDuration();
+        if ( Integer.valueOf(toneActionConst.getValue()) <= 0 ) {
+            return null;
+        }
         //9 - sound port
         this.sb.append("tone(9, ");
         toneAction.getFrequency().accept(this);

--- a/RobotArdu/src/main/java/de/fhg/iais/roberta/visitor/codegen/MbotCppVisitor.java
+++ b/RobotArdu/src/main/java/de/fhg/iais/roberta/visitor/codegen/MbotCppVisitor.java
@@ -45,6 +45,7 @@ import de.fhg.iais.roberta.syntax.lang.blocksequence.MainTask;
 import de.fhg.iais.roberta.syntax.lang.expr.ColorConst;
 import de.fhg.iais.roberta.syntax.lang.expr.EmptyExpr;
 import de.fhg.iais.roberta.syntax.lang.expr.Expr;
+import de.fhg.iais.roberta.syntax.lang.expr.NumConst;
 import de.fhg.iais.roberta.syntax.lang.expr.RgbColor;
 import de.fhg.iais.roberta.syntax.lang.expr.Var;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
@@ -246,6 +247,10 @@ public final class MbotCppVisitor extends AbstractCommonArduinoCppVisitor implem
 
     @Override
     public Void visitToneAction(ToneAction<Void> toneAction) {
+        NumConst<Void> toneActionConst = (NumConst<Void>) toneAction.getDuration();
+        if ( Integer.valueOf(toneActionConst.getValue()) <= 0 ) {
+            return null;
+        }
         //8 - sound port
         this.sb.append("_meBuzzer.tone(8, ");
         toneAction.getFrequency().accept(this);

--- a/RobotArdu/src/main/java/de/fhg/iais/roberta/visitor/codegen/SenseboxCppVisitor.java
+++ b/RobotArdu/src/main/java/de/fhg/iais/roberta/visitor/codegen/SenseboxCppVisitor.java
@@ -31,6 +31,7 @@ import de.fhg.iais.roberta.syntax.actors.arduino.sensebox.SendDataAction;
 import de.fhg.iais.roberta.syntax.lang.blocksequence.MainTask;
 import de.fhg.iais.roberta.syntax.lang.expr.ColorConst;
 import de.fhg.iais.roberta.syntax.lang.expr.Expr;
+import de.fhg.iais.roberta.syntax.lang.expr.NumConst;
 import de.fhg.iais.roberta.syntax.lang.expr.RgbColor;
 import de.fhg.iais.roberta.syntax.lang.expr.Var;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
@@ -201,6 +202,10 @@ public class SenseboxCppVisitor extends AbstractCommonArduinoCppVisitor implemen
 
     @Override
     public Void visitToneAction(ToneAction<Void> toneAction) {
+        NumConst<Void> toneActionConst = (NumConst<Void>) toneAction.getDuration();
+        if ( Integer.valueOf(toneActionConst.getValue()) <= 0 ) {
+            return null;
+        }
         this.sb.append("tone(_buzzer_").append(toneAction.getPort()).append(", ");
         toneAction.getFrequency().accept(this);
         this.sb.append(");");

--- a/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/codegen/Ev3StackMachineVisitor.java
+++ b/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/codegen/Ev3StackMachineVisitor.java
@@ -131,6 +131,10 @@ public class Ev3StackMachineVisitor<V> extends AbstractStackMachineVisitor<V> im
 
     @Override
     public V visitToneAction(ToneAction<V> toneAction) {
+        NumConst<Void> toneActionConst = (NumConst<Void>) toneAction.getDuration();
+        if ( Integer.valueOf(toneActionConst.getValue()) <= 0 ) {
+            return null;
+        }
         toneAction.getFrequency().accept(this);
         toneAction.getDuration().accept(this);
         JSONObject o = mk(C.TONE_ACTION);

--- a/RobotEdison/src/main/java/de/fhg/iais/roberta/visitor/codegen/EdisonPythonVisitor.java
+++ b/RobotEdison/src/main/java/de/fhg/iais/roberta/visitor/codegen/EdisonPythonVisitor.java
@@ -674,6 +674,10 @@ public class EdisonPythonVisitor extends AbstractPythonVisitor implements IEdiso
      */
     @Override
     public Void visitToneAction(ToneAction<Void> toneAction) {
+        NumConst<Void> toneActionConst = (NumConst<Void>) toneAction.getDuration();
+        if ( Integer.valueOf(toneActionConst.getValue()) <= 0 ) {
+            return null;
+        }
         this.sb.append("Ed.PlayTone(8000000/");
         toneAction.getFrequency().accept(this);
         this.sb.append(", ");

--- a/RobotEdison/src/test/java/de/fhg/iais/roberta/syntax/codegen/edison/PythonVisitorTest.java
+++ b/RobotEdison/src/test/java/de/fhg/iais/roberta/syntax/codegen/edison/PythonVisitorTest.java
@@ -206,7 +206,7 @@ public class PythonVisitorTest extends EdisonAstTest {
 
     @Test
     public void visitToneActionTest() throws Exception {
-        String expectedResult = "Ed.PlayTone(8000000/300,0)Ed.TimeWait(0,Ed.TIME_MILLISECONDS)";
+        String expectedResult = "Ed.PlayTone(8000000/300,20)Ed.TimeWait(20,Ed.TIME_MILLISECONDS)";
         UnitTestHelper.checkGeneratedSourceEqualityWithProgramXmlAndSourceAsString(testFactory, expectedResult, "/syntax/actor/tone_action.xml", false);
     }
 

--- a/RobotEdison/src/test/resources/syntax/actor/tone_action.xml
+++ b/RobotEdison/src/test/resources/syntax/actor/tone_action.xml
@@ -1,15 +1,20 @@
-<block_set xmlns="http://de.fhg.iais.roberta.blockly" robottype="edison" xmlversion="2.0" description="" tags="">
-    <instance x="330" y="113">
-        <block type="robControls_start" id="y{|T;U?~S1,ac5_y?GQ(" intask="true" deletable="false">
-            <mutation declare="false"></mutation>
-            <field name="DEBUG">TRUE</field>
-        </block>
-        <block type="robActions_play_tone" id="#WG.Vw@S*_yQIyQL%!I," intask="true">
-            <value name="FREQUENCE">
-                <block type="math_integer" id="{^RQ-nLquPo%@m2MwnQt" intask="true">
-                    <field name="NUM">300</field>
+       <block_set xmlns="http://de.fhg.iais.roberta.blockly" robottype="edison" xmlversion="2.0" description="" tags="">
+            <instance x="330" y="113">
+                <block type="robControls_start" id="y{|T;U?~S1,ac5_y?GQ(" intask="true" deletable="false">
+                    <mutation declare="false"></mutation>
+                    <field name="DEBUG">TRUE</field>
                 </block>
-            </value>
-        </block>
-    </instance>
-</block_set>
+                <block type="robActions_play_tone" id="#WG.Vw@S*_yQIyQL%!I," intask="true">
+                    <value name="FREQUENCE">
+                        <block type="math_integer" id="{^RQ-nLquPo%@m2MwnQt" intask="true">
+                            <field name="NUM">300</field>
+                        </block>
+                    </value>
+                    <value name="DURATION">
+                        <block type="math_integer" id="Gf!2clPvY1g;V{~R_s%T" intask="true">
+                            <field name="NUM">20</field>
+                        </block>
+                    </value>
+                </block>
+            </instance>
+        </block_set>

--- a/RobotMbed/src/main/java/de/fhg/iais/roberta/visitor/codegen/CalliopeCppVisitor.java
+++ b/RobotMbed/src/main/java/de/fhg/iais/roberta/visitor/codegen/CalliopeCppVisitor.java
@@ -57,6 +57,7 @@ import de.fhg.iais.roberta.syntax.lang.expr.EmptyExpr;
 import de.fhg.iais.roberta.syntax.lang.expr.Expr;
 import de.fhg.iais.roberta.syntax.lang.expr.ListCreate;
 import de.fhg.iais.roberta.syntax.lang.expr.MathConst;
+import de.fhg.iais.roberta.syntax.lang.expr.NumConst;
 import de.fhg.iais.roberta.syntax.lang.expr.RgbColor;
 import de.fhg.iais.roberta.syntax.lang.expr.StringConst;
 import de.fhg.iais.roberta.syntax.lang.expr.Var;
@@ -370,6 +371,10 @@ public final class CalliopeCppVisitor extends AbstractCppVisitor implements IMbe
 
     @Override
     public Void visitToneAction(ToneAction<Void> toneAction) {
+        NumConst<Void> toneActionConst = (NumConst<Void>) toneAction.getDuration();
+        if ( Integer.valueOf(toneActionConst.getValue()) <= 0 ) {
+            return null;
+        }
         this.sb.append("_uBit.soundmotor.soundOn(");
         toneAction.getFrequency().accept(this);
         this.sb.append("); ").append("_uBit.sleep(");

--- a/RobotMbed/src/main/java/de/fhg/iais/roberta/visitor/codegen/MbedStackMachineVisitor.java
+++ b/RobotMbed/src/main/java/de/fhg/iais/roberta/visitor/codegen/MbedStackMachineVisitor.java
@@ -45,6 +45,7 @@ import de.fhg.iais.roberta.syntax.expr.mbed.PredefinedImage;
 import de.fhg.iais.roberta.syntax.functions.mbed.ImageInvertFunction;
 import de.fhg.iais.roberta.syntax.functions.mbed.ImageShiftFunction;
 import de.fhg.iais.roberta.syntax.lang.expr.ColorConst;
+import de.fhg.iais.roberta.syntax.lang.expr.NumConst;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.CompassSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.GestureSensor;
@@ -146,6 +147,10 @@ public class MbedStackMachineVisitor<V> extends AbstractStackMachineVisitor<V> i
 
     @Override
     public V visitToneAction(ToneAction<V> toneAction) {
+        NumConst<Void> toneActionConst = (NumConst<Void>) toneAction.getDuration();
+        if ( Integer.valueOf(toneActionConst.getValue()) <= 0 ) {
+            return null;
+        }
         toneAction.getFrequency().accept(this);
         toneAction.getDuration().accept(this);
         JSONObject o = mk(C.TONE_ACTION);

--- a/RobotNXT/src/main/java/de/fhg/iais/roberta/visitor/codegen/NxtStackMachineVisitor.java
+++ b/RobotNXT/src/main/java/de/fhg/iais/roberta/visitor/codegen/NxtStackMachineVisitor.java
@@ -36,6 +36,7 @@ import de.fhg.iais.roberta.syntax.action.sound.ToneAction;
 import de.fhg.iais.roberta.syntax.action.sound.VolumeAction;
 import de.fhg.iais.roberta.syntax.lang.expr.ColorConst;
 import de.fhg.iais.roberta.syntax.lang.expr.ConnectConst;
+import de.fhg.iais.roberta.syntax.lang.expr.NumConst;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.ColorSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.CompassSensor;
@@ -133,6 +134,10 @@ public class NxtStackMachineVisitor<V> extends AbstractStackMachineVisitor<V> im
 
     @Override
     public V visitToneAction(ToneAction<V> toneAction) {
+        NumConst<Void> toneActionConst = (NumConst<Void>) toneAction.getDuration();
+        if ( Integer.valueOf(toneActionConst.getValue()) <= 0 ) {
+            return null;
+        }
         toneAction.getFrequency().accept(this);
         toneAction.getDuration().accept(this);
         JSONObject o = mk(C.TONE_ACTION);

--- a/RobotWeDo/src/main/java/de/fhg/iais/roberta/visitor/WeDoStackMachineVisitor.java
+++ b/RobotWeDo/src/main/java/de/fhg/iais/roberta/visitor/WeDoStackMachineVisitor.java
@@ -16,6 +16,7 @@ import de.fhg.iais.roberta.syntax.action.motor.MotorOnAction;
 import de.fhg.iais.roberta.syntax.action.motor.MotorStopAction;
 import de.fhg.iais.roberta.syntax.action.sound.PlayNoteAction;
 import de.fhg.iais.roberta.syntax.action.sound.ToneAction;
+import de.fhg.iais.roberta.syntax.lang.expr.NumConst;
 import de.fhg.iais.roberta.syntax.lang.stmt.AssertStmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.DebugAction;
 import de.fhg.iais.roberta.syntax.sensor.generic.GetSampleSensor;
@@ -169,6 +170,10 @@ public final class WeDoStackMachineVisitor<V> extends AbstractStackMachineVisito
         ConfigurationComponent toneBlock = getConfigurationComponent(toneAction.getPort());
         String brickName = toneBlock.getProperty("VAR");
         if ( brickName != null ) {
+            NumConst<Void> toneActionConst = (NumConst<Void>) toneAction.getDuration();
+            if ( Integer.valueOf(toneActionConst.getValue()) <= 0 ) {
+                return null;
+            }
             toneAction.getFrequency().accept(this);
             toneAction.getDuration().accept(this);
             JSONObject o = mk(C.TONE_ACTION).put(C.NAME, brickName);


### PR DESCRIPTION
Important: There was a test case in Edison that had a play tone block with a duration of 0. Since the new handling has been added, that test now fails. Therefore I have changed the tone duration to 20 ms, as well as the corresponding XML file so that the JUnit test runs successfully.

Fixed issue #469 for all robot types that support visitToneAction. For example, in WeDo,

Previously: 
![wedoNegativeDuration](https://user-images.githubusercontent.com/58920989/71770038-08e38500-2edd-11ea-8612-b307efadd821.PNG)

Now it skips over negative sound duration: 
![ignoringWedoNegativeSoundDuration](https://user-images.githubusercontent.com/58920989/71770044-16007400-2edd-11ea-9da4-33884ae4ace3.PNG)

