### PR TITLE
Add negative sound duration handling

### DIFF
--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/validate/AbstractProgramValidatorVisitor.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/validate/AbstractProgramValidatorVisitor.java
@@ -278,6 +278,12 @@ public abstract class AbstractProgramValidatorVisitor extends AbstractCollectorV
 
     @Override
     public Void visitToneAction(ToneAction<Void> toneAction) {
+        NumConst<Void> toneActionConst = (NumConst<Void>) toneAction.getDuration();
+        if ( Integer.valueOf(toneActionConst.getValue()) <= 0 ) {
+            toneAction.addInfo(NepoInfo.warning("BLOCK_NOT_EXECUTED"));
+            this.errorCount++;
+            return null;
+        }
         toneAction.getDuration().accept(this);
         toneAction.getFrequency().accept(this);
         return null;

--- a/RobotEdison/src/test/java/de/fhg/iais/roberta/syntax/codegen/edison/PythonVisitorTest.java
+++ b/RobotEdison/src/test/java/de/fhg/iais/roberta/syntax/codegen/edison/PythonVisitorTest.java
@@ -206,7 +206,7 @@ public class PythonVisitorTest extends EdisonAstTest {
 
     @Test
     public void visitToneActionTest() throws Exception {
-        String expectedResult = "Ed.PlayTone(8000000/300,0)Ed.TimeWait(0,Ed.TIME_MILLISECONDS)";
+        String expectedResult = "Ed.PlayTone(8000000/300,20)Ed.TimeWait(20,Ed.TIME_MILLISECONDS)";
         UnitTestHelper.checkGeneratedSourceEqualityWithProgramXmlAndSourceAsString(testFactory, expectedResult, "/syntax/actor/tone_action.xml", false);
     }
 

--- a/RobotEdison/src/test/resources/syntax/actor/tone_action.xml
+++ b/RobotEdison/src/test/resources/syntax/actor/tone_action.xml
@@ -1,15 +1,20 @@
-<block_set xmlns="http://de.fhg.iais.roberta.blockly" robottype="edison" xmlversion="2.0" description="" tags="">
-    <instance x="330" y="113">
-        <block type="robControls_start" id="y{|T;U?~S1,ac5_y?GQ(" intask="true" deletable="false">
-            <mutation declare="false"></mutation>
-            <field name="DEBUG">TRUE</field>
-        </block>
-        <block type="robActions_play_tone" id="#WG.Vw@S*_yQIyQL%!I," intask="true">
-            <value name="FREQUENCE">
-                <block type="math_integer" id="{^RQ-nLquPo%@m2MwnQt" intask="true">
-                    <field name="NUM">300</field>
+       <block_set xmlns="http://de.fhg.iais.roberta.blockly" robottype="edison" xmlversion="2.0" description="" tags="">
+            <instance x="330" y="113">
+                <block type="robControls_start" id="y{|T;U?~S1,ac5_y?GQ(" intask="true" deletable="false">
+                    <mutation declare="false"></mutation>
+                    <field name="DEBUG">TRUE</field>
                 </block>
-            </value>
-        </block>
-    </instance>
-</block_set>
+                <block type="robActions_play_tone" id="#WG.Vw@S*_yQIyQL%!I," intask="true">
+                    <value name="FREQUENCE">
+                        <block type="math_integer" id="{^RQ-nLquPo%@m2MwnQt" intask="true">
+                            <field name="NUM">300</field>
+                        </block>
+                    </value>
+                    <value name="DURATION">
+                        <block type="math_integer" id="Gf!2clPvY1g;V{~R_s%T" intask="true">
+                            <field name="NUM">20</field>
+                        </block>
+                    </value>
+                </block>
+            </instance>
+        </block_set>


### PR DESCRIPTION
Important: There was a test case in Edison that had a play tone block with a duration of 0. Since the new handling has been added, that test now fails. Therefore I have changed the tone duration to 20 ms, as well as the corresponding XML file so that the JUnit test runs successfully.

Fixed issue #469 for all robot types that support visitToneAction. For example, in Ev3

Previously: 
![ev3NegativeSoundHandling](https://user-images.githubusercontent.com/58920989/71773044-1f083a00-2f0b-11ea-9adf-ba8b124ea7c3.PNG)


Now it shows an error message:
![ev3NegativeSoundHandlingCorrect](https://user-images.githubusercontent.com/58920989/71773055-50810580-2f0b-11ea-884e-a6502491508a.PNG)


