### PR TITLE
Fixed issue of setting the display to 0 brightness not working

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.mbed.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.mbed.js
@@ -260,7 +260,7 @@ define([ 'simulation.simulation', 'interpreter.constants', 'util', 'simulation.r
                     }
                 }
             }
-            if (display.brightness) {
+            if (display.brightness || display.brightness === 0) {
                 this.display.brightness = Math.round(display.brightness * 255.0 / 9.0, 0);
             }
         }


### PR DESCRIPTION
Fixed Issue #473. Not entirely sure why if(display.brightness) was not true when display.brightness was equal to 0 but adding this snippet of code fixes the issue.