### PR TITLE
issue #289 removed dead code

### DIFF
--- a/RobotArdu/src/main/java/de/fhg/iais/roberta/visitor/validate/ArduinoBrickValidatorVisitor.java
+++ b/RobotArdu/src/main/java/de/fhg/iais/roberta/visitor/validate/ArduinoBrickValidatorVisitor.java
@@ -14,7 +14,6 @@ import de.fhg.iais.roberta.syntax.action.serial.SerialWriteAction;
 import de.fhg.iais.roberta.syntax.action.sound.PlayNoteAction;
 import de.fhg.iais.roberta.syntax.action.sound.ToneAction;
 import de.fhg.iais.roberta.syntax.actors.arduino.RelayAction;
-import de.fhg.iais.roberta.syntax.sensor.ExternalSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.DropSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.EncoderSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.HumiditySensor;
@@ -101,33 +100,6 @@ public final class ArduinoBrickValidatorVisitor extends AbstractBrickValidatorVi
     public Void visitEncoderSensor(EncoderSensor<Void> encoderSensor) {
         checkSensorPort(encoderSensor);
         return null;
-    }
-
-    @Override
-    protected void checkSensorPort(ExternalSensor<Void> sensor) {
-        //TODO should super(sensor) be called here?
-        ConfigurationComponent usedConfigurationBlock = this.robotConfiguration.optConfigurationComponent(sensor.getPort());
-        if ( usedConfigurationBlock == null ) {
-            sensor.addInfo(NepoInfo.error("CONFIGURATION_ERROR_SENSOR_MISSING"));
-            this.errorCount++;
-        } else {
-            switch ( usedConfigurationBlock.getComponentType() ) {
-                case "INFRARED_SENSING":
-                    if ( !usedConfigurationBlock.getComponentType().equals(SC.INFRARED) ) {
-                        sensor.addInfo(NepoInfo.error("CONFIGURATION_ERROR_SENSOR_WRONG"));
-                        this.errorCount++;
-                    }
-                    break;
-                case "GYRO_SENSING":
-                    if ( !usedConfigurationBlock.getComponentType().equals(SC.GYRO) ) {
-                        sensor.addInfo(NepoInfo.error("CONFIGURATION_ERROR_SENSOR_WRONG"));
-                        this.errorCount++;
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
The switch case is not being hit. 
The configuration block's component type does not match the case conditions: "INFRARED_SENSING" and "GYRO_SENSING". The component type does not have the "_SENSING" suffix. 
In the super method the switch statement works as the name attribute of the sensor matches the case clause. The super method has been called and the unnecessary code has been removed.