### PR TITLE
Add negative sound duration handling

### DIFF
--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/validate/AbstractProgramValidatorVisitor.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/validate/AbstractProgramValidatorVisitor.java
@@ -280,6 +280,13 @@ public abstract class AbstractProgramValidatorVisitor extends AbstractCollectorV
     public Void visitToneAction(ToneAction<Void> toneAction) {
         toneAction.getDuration().accept(this);
         toneAction.getFrequency().accept(this);
+        if (toneAction.getKind().hasName("NUM_CONST")) {
+            Double toneActionConst = Double.valueOf(((NumConst<Void>) toneAction.getDuration()).getValue());
+            if (toneActionConst <= 0) {
+                toneAction.addInfo(NepoInfo.warning("BLOCK_NOT_EXECUTED"));
+                this.warningCount++;
+            }
+        }
         return null;
     }
 

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.calliope.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.calliope.js
@@ -271,11 +271,11 @@ define([ 'simulation.simulation', 'simulation.robot.mbed' ], function(SIM, Mbed)
         var tone = this.robotBehaviour.getActionState("tone", true);
         if (tone && this.webAudio.context) {
             var ts = this.webAudio.context.currentTime;
-            if (tone.frequency !== undefined) {
+            if (tone.frequency && tone.duration > 0) {
                 this.webAudio.oscillator.frequency.setValueAtTime(tone.frequency, ts);
                 this.webAudio.gainNode.gain.setValueAtTime(this.webAudio.volume, ts);
             }
-            if (tone.duration !== undefined) {
+            if (tone.duration > 0) {
                 ts += tone.duration / 1000.0;
                 this.webAudio.gainNode.gain.setValueAtTime(0, ts);
             }

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.ev3.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.ev3.js
@@ -499,11 +499,11 @@ define([ 'simulation.simulation', 'interpreter.constants', 'simulation.robot', '
         var tone = this.robotBehaviour.getActionState("tone", true);
         if (tone && this.webAudio.context) {
             var ts = this.webAudio.context.currentTime;
-            if (tone.frequency) {
+            if (tone.frequency && tone.duration > 0) {
                 this.webAudio.oscillator.frequency.setValueAtTime(tone.frequency, ts);
                 this.webAudio.gainNode.gain.setValueAtTime(this.webAudio.volume, ts);
             }
-            if (tone.duration) {
+            if (tone.duration > 0) {
                 ts += tone.duration / 1000.0;
                 this.webAudio.gainNode.gain.setValueAtTime(0, ts);
             }

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.nxt.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.nxt.js
@@ -239,11 +239,11 @@ define([ 'simulation.simulation', 'interpreter.constants', 'simulation.robot.ev3
         var tone = this.robotBehaviour.getActionState("tone", true);
         if (tone && this.webAudio.context) {
             var ts = this.webAudio.context.currentTime;
-            if (tone.frequency) {
+            if (tone.frequency && tone.duration > 0) {
                 this.webAudio.oscillator.frequency.setValueAtTime(tone.frequency, ts);
                 this.webAudio.gainNode.gain.setValueAtTime(this.webAudio.volume, ts);
             }
-            if (tone.duration) {
+            if (tone.duration > 0) {
                 ts += tone.duration / 1000.0;
                 this.webAudio.gainNode.gain.setValueAtTime(0, ts);
             }

--- a/RobotEdison/src/test/java/de/fhg/iais/roberta/syntax/codegen/edison/PythonVisitorTest.java
+++ b/RobotEdison/src/test/java/de/fhg/iais/roberta/syntax/codegen/edison/PythonVisitorTest.java
@@ -206,7 +206,7 @@ public class PythonVisitorTest extends EdisonAstTest {
 
     @Test
     public void visitToneActionTest() throws Exception {
-        String expectedResult = "Ed.PlayTone(8000000/300,0)Ed.TimeWait(0,Ed.TIME_MILLISECONDS)";
+        String expectedResult = "Ed.PlayTone(8000000/300,20)Ed.TimeWait(20,Ed.TIME_MILLISECONDS)";
         UnitTestHelper.checkGeneratedSourceEqualityWithProgramXmlAndSourceAsString(testFactory, expectedResult, "/syntax/actor/tone_action.xml", false);
     }
 

--- a/RobotEdison/src/test/resources/syntax/actor/tone_action.xml
+++ b/RobotEdison/src/test/resources/syntax/actor/tone_action.xml
@@ -1,15 +1,20 @@
-<block_set xmlns="http://de.fhg.iais.roberta.blockly" robottype="edison" xmlversion="2.0" description="" tags="">
-    <instance x="330" y="113">
-        <block type="robControls_start" id="y{|T;U?~S1,ac5_y?GQ(" intask="true" deletable="false">
-            <mutation declare="false"></mutation>
-            <field name="DEBUG">TRUE</field>
-        </block>
-        <block type="robActions_play_tone" id="#WG.Vw@S*_yQIyQL%!I," intask="true">
-            <value name="FREQUENCE">
-                <block type="math_integer" id="{^RQ-nLquPo%@m2MwnQt" intask="true">
-                    <field name="NUM">300</field>
+       <block_set xmlns="http://de.fhg.iais.roberta.blockly" robottype="edison" xmlversion="2.0" description="" tags="">
+            <instance x="330" y="113">
+                <block type="robControls_start" id="y{|T;U?~S1,ac5_y?GQ(" intask="true" deletable="false">
+                    <mutation declare="false"></mutation>
+                    <field name="DEBUG">TRUE</field>
                 </block>
-            </value>
-        </block>
-    </instance>
-</block_set>
+                <block type="robActions_play_tone" id="#WG.Vw@S*_yQIyQL%!I," intask="true">
+                    <value name="FREQUENCE">
+                        <block type="math_integer" id="{^RQ-nLquPo%@m2MwnQt" intask="true">
+                            <field name="NUM">300</field>
+                        </block>
+                    </value>
+                    <value name="DURATION">
+                        <block type="math_integer" id="Gf!2clPvY1g;V{~R_s%T" intask="true">
+                            <field name="NUM">20</field>
+                        </block>
+                    </value>
+                </block>
+            </instance>
+        </block_set>


### PR DESCRIPTION
Important: There was a test case in Edison that had a play tone block with a duration of 0. Since the new handling has been added, that test now fails. Therefore I have changed the tone duration to 20 ms, as well as the corresponding XML file so that the JUnit test runs successfully.

Fixed issue #469 for all robot types that support playing a tone. For example, in Ev3

Previously: 
![ev3NegativeSoundHandling](https://user-images.githubusercontent.com/58920989/71773044-1f083a00-2f0b-11ea-9adf-ba8b124ea7c3.PNG)


Now it alerts the user that the block has no effect upon execution. The play tone block will be skipped, allowing the next block to be performed.
![ev3negativesoundnoeffect](https://user-images.githubusercontent.com/58920989/71773391-0d299580-2f11-11ea-9b40-fbbc1723f15d.PNG)



