### PR TITLE
Fix for empty set variable error

### DIFF
--- a/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/codegen/Ev3StackMachineVisitor.java
+++ b/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/codegen/Ev3StackMachineVisitor.java
@@ -41,6 +41,7 @@ import de.fhg.iais.roberta.syntax.action.sound.VolumeAction;
 import de.fhg.iais.roberta.syntax.action.speech.SayTextAction;
 import de.fhg.iais.roberta.syntax.action.speech.SetLanguageAction;
 import de.fhg.iais.roberta.syntax.lang.expr.ColorConst;
+import de.fhg.iais.roberta.syntax.lang.expr.EmptyExpr;
 import de.fhg.iais.roberta.syntax.lang.expr.NumConst;
 import de.fhg.iais.roberta.syntax.sensor.ev3.HTColorSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
@@ -499,6 +500,10 @@ public class Ev3StackMachineVisitor<V> extends AbstractStackMachineVisitor<V> im
 
     @Override
     public V visitBluetoothWaitForConnectionAction(BluetoothWaitForConnectionAction<V> bluetoothWaitForConnection) {
+        return null;
+    }
+    @Override
+    public V visitEmptyExpr(EmptyExpr<V> emptyExpr) {
         return null;
     }
 

--- a/RobotMbed/src/main/java/de/fhg/iais/roberta/visitor/codegen/MbedStackMachineVisitor.java
+++ b/RobotMbed/src/main/java/de/fhg/iais/roberta/visitor/codegen/MbedStackMachineVisitor.java
@@ -45,6 +45,7 @@ import de.fhg.iais.roberta.syntax.expr.mbed.PredefinedImage;
 import de.fhg.iais.roberta.syntax.functions.mbed.ImageInvertFunction;
 import de.fhg.iais.roberta.syntax.functions.mbed.ImageShiftFunction;
 import de.fhg.iais.roberta.syntax.lang.expr.ColorConst;
+import de.fhg.iais.roberta.syntax.lang.expr.EmptyExpr;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.CompassSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.GestureSensor;
@@ -434,6 +435,11 @@ public class MbedStackMachineVisitor<V> extends AbstractStackMachineVisitor<V> i
 
     @Override
     public V visitLedBarSetAction(LedBarSetAction<V> ledBarSetAction) {
+        return null;
+    }
+    
+    @Override
+    public V visitEmptyExpr(EmptyExpr<V> emptyExpr) {
         return null;
     }
 }

--- a/RobotNXT/src/main/java/de/fhg/iais/roberta/visitor/codegen/NxtStackMachineVisitor.java
+++ b/RobotNXT/src/main/java/de/fhg/iais/roberta/visitor/codegen/NxtStackMachineVisitor.java
@@ -36,6 +36,7 @@ import de.fhg.iais.roberta.syntax.action.sound.ToneAction;
 import de.fhg.iais.roberta.syntax.action.sound.VolumeAction;
 import de.fhg.iais.roberta.syntax.lang.expr.ColorConst;
 import de.fhg.iais.roberta.syntax.lang.expr.ConnectConst;
+import de.fhg.iais.roberta.syntax.lang.expr.EmptyExpr;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.ColorSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.CompassSensor;
@@ -469,6 +470,11 @@ public class NxtStackMachineVisitor<V> extends AbstractStackMachineVisitor<V> im
     @Override
     public V visitConnectConst(ConnectConst<V> connectConst) {
         // Overrides default implementation so that server error is not produced
+        return null;
+    }
+    
+    @Override
+    public V visitEmptyExpr(EmptyExpr<V> emptyExpr) {
         return null;
     }
 


### PR DESCRIPTION
Fixed server error for the set variable block in Calliope, NXT, Microbit and EV3.