### PR TITLE
Fixed Edison IRSeeker Compiler Error

### DIFF
--- a/RobotEdison/src/main/java/de/fhg/iais/roberta/visitor/collect/EdisonUsedHardwareCollectorVisitor.java
+++ b/RobotEdison/src/main/java/de/fhg/iais/roberta/visitor/collect/EdisonUsedHardwareCollectorVisitor.java
@@ -36,6 +36,10 @@ public class EdisonUsedHardwareCollectorVisitor extends AbstractUsedHardwareColl
         this.usedMethodBeanBuilder.addUsedMethod(EdisonMethods.MOTORON);
         this.usedMethodBeanBuilder.addUsedMethod(EdisonMethods.SHORTEN); //used inside helper method
         this.usedMethodBeanBuilder.addUsedMethod(EdisonMethods.GETDIR);
+        motorOnAction.getParam().getSpeed().accept(this);
+        if ( motorOnAction.getParam().getDuration() != null ) {
+            motorOnAction.getDurationValue().accept(this);
+        }
         return null;
     }
 
@@ -74,6 +78,10 @@ public class EdisonUsedHardwareCollectorVisitor extends AbstractUsedHardwareColl
         this.usedMethodBeanBuilder.addUsedMethod(EdisonMethods.DIFFDRIVE);
         this.usedMethodBeanBuilder.addUsedMethod(EdisonMethods.SHORTEN); //used inside helper method
         this.usedMethodBeanBuilder.addUsedMethod(EdisonMethods.GETDIR);
+        driveAction.getParam().getSpeed().accept(this);
+        if ( driveAction.getParam().getDuration() != null ) {
+            driveAction.getParam().getDuration().getValue().accept(this);
+        }
         return null;
     }
 
@@ -92,6 +100,11 @@ public class EdisonUsedHardwareCollectorVisitor extends AbstractUsedHardwareColl
         this.usedMethodBeanBuilder.addUsedMethod(EdisonMethods.DIFFCURVE);
         this.usedMethodBeanBuilder.addUsedMethod(EdisonMethods.SHORTEN); //used inside helper method
         this.usedMethodBeanBuilder.addUsedMethod(EdisonMethods.GETDIR);
+        curveAction.getParamLeft().getSpeed().accept(this);
+        curveAction.getParamRight().getSpeed().accept(this);
+        if ( curveAction.getParamLeft().getDuration() != null ) {
+            curveAction.getParamLeft().getDuration().getValue().accept(this);
+        }
         return null;
     }
 
@@ -109,6 +122,10 @@ public class EdisonUsedHardwareCollectorVisitor extends AbstractUsedHardwareColl
         this.usedMethodBeanBuilder.addUsedMethod(EdisonMethods.DIFFTURN);
         this.usedMethodBeanBuilder.addUsedMethod(EdisonMethods.SHORTEN); //used inside helper method
         this.usedMethodBeanBuilder.addUsedMethod(EdisonMethods.GETDIR);
+        turnAction.getParam().getSpeed().accept(this);
+        if ( turnAction.getParam().getDuration() != null ) {
+            turnAction.getParam().getDuration().getValue().accept(this);
+        }
         return null;
     }
 


### PR DESCRIPTION
Fixed Issue #464 by generating definitions for values inside the parameters of the motion blocks.

Before Changes: <img alt="Screen Shot 2020-01-01 at 5 58 23 PM" width="1276" src="https://user-images.githubusercontent.com/9400738/71641363-b0d03700-2cc0-11ea-9cb9-f9fa4376277e.png">

After Changes:
![IRSeekerDriveForwardFix](https://user-images.githubusercontent.com/58920989/72120548-29f90b00-330d-11ea-93a6-150e01c7e0b1.PNG)
![IRSeekerMotorLeft](https://user-images.githubusercontent.com/58920989/72120553-2e252880-330d-11ea-8e8c-ccaa9fed7fb0.PNG)
![IRSeekerSteerForwardsFix](https://user-images.githubusercontent.com/58920989/72120561-32e9dc80-330d-11ea-9979-66b329fb047f.PNG)
![IRSeekerTurnFix](https://user-images.githubusercontent.com/58920989/72120567-3a10ea80-330d-11ea-9a29-375cb8419af6.PNG)
