### PR TITLE
Fix for share view closing

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/roberta/controller/progShare.controller.js
+++ b/OpenRobertaServer/staticResources/js/app/roberta/controller/progShare.controller.js
@@ -327,7 +327,6 @@ define([ 'require', 'exports', 'log', 'util', 'message', 'comm', 'guiState.contr
                             }
                         });
                     }
-                    MSG.displayInformation(result, result.message, result.message, values.shareWithInput);
                     LOG.info("share program " + row.name + " with '" + values.shareWithInput + " having right '" + right + "'");
                     $('#progList').find('button[name="refresh"]').trigger('click');
                 } else {


### PR DESCRIPTION
Fixes issue #294. Now multiple users can be added at once without the share view closing.

Resolution:
MSG.displayInformation(result, result.message, result.message, values.shareWithInput); on line 330 has been deleted since this calls on a function from the file msg.js which closes all popups.

The parameters of the function call are result, result.message and values.shareWithInput.

"result" refers to the object being passed to the function and contains the following properties:
- rc 
- message 
- cause

"values.shareWithInput" refers to the user the program is being shared with.

If the user has been added correctly, one would see properties like so for the result object:
rc: "ok" 
message: "ORA_ACCESS_RIGHT_CHANGED" 
cause: "ORA_ACCESS_RIGHT_CHANGED"