### PR TITLE
Fix for steer and drive block calculations

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/wedoInterpreter/interpreter.robotMbedBehaviour.js
+++ b/OpenRobertaServer/staticResources/js/app/wedoInterpreter/interpreter.robotMbedBehaviour.js
@@ -181,7 +181,8 @@ define(["require", "exports", "interpreter.aRobotBehaviour", "interpreter.consta
             if (this.hardwareState.actions.motors == undefined) {
                 this.hardwareState.actions.motors = {};
             }
-            if (direction != C.FOREWARD) {
+            // This is to handle negative values entered in the distance parameter in the drive block
+            if ((direction != C.FOREWARD && distance > 0) || (direction == C.FOREWARD && distance < 0)) {
                 speed *= -1;
             }
             this.hardwareState.actions.motors[C.MOTOR_LEFT] = speed;
@@ -204,7 +205,8 @@ define(["require", "exports", "interpreter.aRobotBehaviour", "interpreter.consta
             if (this.hardwareState.actions.motors == undefined) {
                 this.hardwareState.actions.motors = {};
             }
-            if (direction != C.FOREWARD) {
+            // This is to handle negative values entered in the distance parameter in the steer block
+            if ((direction != C.FOREWARD && distance > 0) || (direction == C.FOREWARD && distance < 0)) {
                 speedL *= -1;
                 speedR *= -1;
             }


### PR DESCRIPTION
**Description of the problem**:
The steer and drive blocks do not work correctly when a negative distance is entered.

**Resolution**:
After the fix, if a negative distance is entered when the direction is 'forwards', the robot moves backwards.
If a negative distance is entered when the direction is 'backwards', the robot moves forwards.

**Prior to the changes**
![ezgif com-optimize (1)](https://user-images.githubusercontent.com/9400738/72340058-7b2e4380-36ed-11ea-9e94-6df71b1f8408.gif)

**After changes**
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/9400738/72340118-a1ec7a00-36ed-11ea-81c7-b3f8b79ce15a.gif)
