### PR TITLE
Fix for steer, turn and drive blocks

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/wedoInterpreter/interpreter.robotMbedBehaviour.js
+++ b/OpenRobertaServer/staticResources/js/app/wedoInterpreter/interpreter.robotMbedBehaviour.js
@@ -181,14 +181,15 @@ define(["require", "exports", "interpreter.aRobotBehaviour", "interpreter.consta
             if (this.hardwareState.actions.motors == undefined) {
                 this.hardwareState.actions.motors = {};
             }
-            if (direction != C.FOREWARD) {
+            // This is to handle negative values entered in the distance parameter in the drive block
+            if ((direction != C.FOREWARD && distance > 0) || (direction == C.FOREWARD && distance < 0)) {
                 speed *= -1;
             }
             this.hardwareState.actions.motors[C.MOTOR_LEFT] = speed;
             this.hardwareState.actions.motors[C.MOTOR_RIGHT] = speed;
             this.hardwareState.motors[C.MOTOR_LEFT] = speed;
             this.hardwareState.motors[C.MOTOR_RIGHT] = speed;
-            var rotations = distance / (C.WHEEL_DIAMETER * Math.PI);
+            var rotations = Math.abs(distance) / (C.WHEEL_DIAMETER * Math.PI);
             var rotationPerSecond = C.MAX_ROTATION * Math.abs(speed) / 100.0;
             if (rotationPerSecond == 0.0) {
                 return 0;
@@ -204,7 +205,8 @@ define(["require", "exports", "interpreter.aRobotBehaviour", "interpreter.consta
             if (this.hardwareState.actions.motors == undefined) {
                 this.hardwareState.actions.motors = {};
             }
-            if (direction != C.FOREWARD) {
+            // This is to handle negative values entered in the distance parameter in the steer block
+            if ((direction != C.FOREWARD && distance > 0) || (direction == C.FOREWARD && distance < 0)) {
                 speedL *= -1;
                 speedR *= -1;
             }
@@ -212,7 +214,7 @@ define(["require", "exports", "interpreter.aRobotBehaviour", "interpreter.consta
             this.hardwareState.actions.motors[C.MOTOR_RIGHT] = speedR;
             this.hardwareState.motors[C.MOTOR_LEFT] = speedL;
             this.hardwareState.motors[C.MOTOR_RIGHT] = speedR;
-            var rotations = distance / (C.WHEEL_DIAMETER * Math.PI);
+            var rotations = Math.abs(distance) / (C.WHEEL_DIAMETER * Math.PI);
             var avgSpeed = 0.5 * (Math.abs(speedL) + Math.abs(speedR));
             var rotationPerSecond = C.MAX_ROTATION * avgSpeed / 100.0;
             if (rotationPerSecond == 0.0) {
@@ -229,8 +231,12 @@ define(["require", "exports", "interpreter.aRobotBehaviour", "interpreter.consta
             if (this.hardwareState.actions.motors == undefined) {
                 this.hardwareState.actions.motors = {};
             }
+            // This is to handle negative values entered in the degree parameter in the turn block 
+            if((direction == C.LEFT && angle < 0)|| (direction == C.RIGHT && angle < 0)){
+                speed *= -1;
+            }
             this.setTurnSpeed(speed, direction);
-            var rotations = C.TURN_RATIO * (angle / 720.);
+            var rotations = C.TURN_RATIO * (Math.abs(angle) / 720.);
             var rotationPerSecond = C.MAX_ROTATION * Math.abs(speed) / 100.0;
             if (rotationPerSecond == 0.0) {
                 return 0;


### PR DESCRIPTION
**Description of the problem**:
The steer, turn and drive blocks do not work correctly when a negative distance is entered.

**Resolution**:
While calculating the variable _rotations_ for both the steer and drive blocks, the absolute value of _distance_ was taken so that the robot moves the correct distance even when the distance is negative.
Similarly, for calculating the variable _rotations_ in the turn block, the absolute value of _angle_ is taken for the same reason.

After the fix, if a negative distance is entered when the direction is 'forwards', the robot moves backwards. If a negative distance is entered when the direction is 'backwards', the robot moves forwards. Similarly for the turn block, if a negative degree is entered, the robot moves in the opposite direction.

**Prior to the changes**
![ezgif com-optimize (1)](https://user-images.githubusercontent.com/9400738/72340058-7b2e4380-36ed-11ea-9e94-6df71b1f8408.gif)

**After changes**
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/9400738/72340118-a1ec7a00-36ed-11ea-81c7-b3f8b79ce15a.gif)
