### PR TITLE
Show sharee dropdown

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/roberta/controller/progList.controller.js
+++ b/OpenRobertaServer/staticResources/js/app/roberta/controller/progList.controller.js
@@ -38,6 +38,7 @@ define([ 'require', 'exports', 'log', 'util', 'comm', 'message', 'progList.model
                 title : "<span lkey='Blockly.Msg.DATATABLE_CREATED_BY'>" + (Blockly.Msg.DATATABLE_CREATED_BY || "Erzeugt von") + "</span>",
                 sortable : true,
             }, {
+                events : eventsRelations,
                 title : "<span class='typcn typcn-flow-merge'></span>",
                 sortable : true,
                 sorter : sortRelations,
@@ -190,7 +191,15 @@ define([ 'require', 'exports', 'log', 'util', 'comm', 'message', 'progList.model
             $('#programNameTable').find('[rel="tooltip"]').tooltip();
         }
     }
-
+    
+    var eventsRelations = {
+        'click .showRelations' : function(e, value, row, index) {
+            e.stopPropagation();
+            var collapseName = '.relation' + index;
+            $(collapseName).collapse('toggle');
+        }
+    }
+    
     var eventsDeleteShareLoad = {
         'click .delete' : function(e, value, row, index) {
             e.stopPropagation();


### PR DESCRIPTION
Fixed issue #293 

After Changes: 
![dropdownworking!!](https://user-images.githubusercontent.com/58920989/72394391-e9bdd200-36ea-11ea-93b8-6c4ef6d68ea9.PNG)
![dropdownworkingv2!!](https://user-images.githubusercontent.com/58920989/72394633-cc3d3800-36eb-11ea-8927-e8d6c4c69321.PNG)


The problem was that both the dropdown list and row were registered as clicked, so both actions occurred simultaneously.

This have been solved by only allowing the top-most click to go through and afterwards manually toggling the collapse.
