### PR TITLE
Prevent source code view from closing multi sim

### DIFF
--- a/OpenRobertaServer/staticResources/blockly/msg/js/en.js
+++ b/OpenRobertaServer/staticResources/blockly/msg/js/en.js
@@ -1126,6 +1126,7 @@ Blockly.Msg.POPUP_STARTUP_HELP_TEXT = "In our detailed help, we will explain eve
 Blockly.Msg.POPUP_STARTUP_HIDE = "Okay, don't show this window again and remember my choice with a bookmark.";
 Blockly.Msg.POPUP_STARTUP_START = "Choose your system!";
 Blockly.Msg.POPUP_STARTUP_TOUR_TEXT = "Would you like to get started, but do not know exactly how? We will show you the first steps in an interactive tutorial.";
+Blockly.Msg.POPUP_SWITCH_SOURCE_CODE_MULTI_SIM = "Visiting the source code will close the multiple robot simulation. <br> Would you like to continue?";
 Blockly.Msg.POPUP_TOUR = "take a tour";
 Blockly.Msg.POPUP_USERNAME = "Username";
 Blockly.Msg.POPUP_USERNAME_LOGOFF = "You are not logged in.";

--- a/OpenRobertaServer/staticResources/js/app/roberta/controller/progCode.controller.js
+++ b/OpenRobertaServer/staticResources/js/app/roberta/controller/progCode.controller.js
@@ -1,5 +1,5 @@
-define([ 'exports', 'message', 'log', 'util', 'guiState.controller', 'program.controller', 'program.model', 'blocks', 'codeflask', 'jquery', 'blocks-msg' ], function(
-        exports, MSG, LOG, UTIL, GUISTATE_C, PROG_C, PROGRAM, Blockly, CodeFlask, $) {
+define([ 'exports', 'message', 'log', 'util', 'guiState.controller', 'program.controller', 'simulation.simulation', 'program.model', 'blocks', 'codeflask', 'jquery', 'blocks-msg' ], function(
+        exports, MSG, LOG, UTIL, GUISTATE_C, PROG_C, SIM, PROGRAM, Blockly, CodeFlask, $) {
 
     const INITIAL_WIDTH = 0.5;
     var blocklyWorkspace;
@@ -50,7 +50,11 @@ define([ 'exports', 'message', 'log', 'util', 'guiState.controller', 'program.co
     function initEvents() {
         $('#codeButton').off('click touchend');
         $('#codeButton').on('click touchend', function(event) {
-            toggleCode();
+            if (SIM.getNumRobots() > 1 && $('#simButton').hasClass('rightActive')) {
+                toggleCodeConfirm();
+            } else {
+                toggleCode();
+            }
             return false;
         });
         $('#codeDownload').onWrap('click', function(event) {
@@ -83,7 +87,28 @@ define([ 'exports', 'message', 'log', 'util', 'guiState.controller', 'program.co
             });
         }, 'code refresh clicked');
     }
-
+    
+    function toggleCodeConfirm() {
+        $('#show-message-confirm').one('shown.bs.modal', function(e) {
+            $('#confirm').off();
+            $('#confirm').on('click', function(e) {
+                e.preventDefault();
+                toggleCode();
+            });
+            $('#confirmCancel').off();
+            $('#confirmCancel').on('click', function(e) {
+                e.preventDefault();
+                $('.modal').modal('hide');
+            });
+        });
+        var messageId = "POPUP_SWITCH_SOURCE_CODE_MULTI_SIM";
+        var lkey = 'Blockly.Msg.' + messageId;
+        var value = Blockly.Msg[messageId];
+        $('#message').attr('lkey', lkey);
+        $('#messageConfirm').html(Blockly.Msg[messageId]);
+        $("#show-message-confirm").modal("show");
+    }
+    
     function toggleCode() {
         Blockly.hideChaff();
         if ($('#codeButton').hasClass('rightActive')) {


### PR DESCRIPTION
Fixes #546 

Added a popup that allows the user to choose whether to open the source code view (and close multi sim) or keep working in multi sim (and not open source code view). If there is only one robot, the popup will not occur.

The structure of the code, including the function toggleCodeConfirm(), is similar to other "confirmation" functions. "simulation.js" has a function called getNumRobots, which returns the number of robots. If it is a multiple robot simulation (over 2 robots) then I will call the special confirmation popup. If there is only one robot, then the code will continue on regularly.

**After Changes**
If there is one robot, it will behave the same:
![simendONEsim](https://user-images.githubusercontent.com/58920989/72702598-23864280-3b08-11ea-8fbd-ecb210c4dafa.PNG)
![simendONEFINALYESSFINALLYFINFALYYFINALLYFINALLY](https://user-images.githubusercontent.com/58920989/72702603-26813300-3b08-11ea-8e0a-cdf8e4e1792f.PNG)

If there are two or more robots, there will be a popup asking whether the user wants to continue. 'OK' will open source code view, 'CANCEL' will not.

![simendONEsim](https://user-images.githubusercontent.com/58920989/72702621-3d278a00-3b08-11ea-96f0-ab7839c9f474.PNG)
![simendTWOCONTINUE](https://user-images.githubusercontent.com/58920989/72702629-4153a780-3b08-11ea-9b63-a35995bd1fe8.PNG)
- If user presses 'OK'
![simendTWOFINALYAYAYYAYAYAYAYYAYAYAYYA](https://user-images.githubusercontent.com/58920989/72702636-457fc500-3b08-11ea-8ef4-415e2d6c586f.PNG)
- If user presses 'CANCEL'
![simendTWOLETSGOYAYAYAYYA](https://user-images.githubusercontent.com/58920989/72703184-cc816d00-3b09-11ea-93f8-8545aac3ad8d.PNG)
