### PR TITLE
Changed Link for Blockly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Furthermore, the project OpenRobertaServer contains in directory staticResources
 * HTML and CSS
 * Javascript libraries based on jquery and bootstrap for the frontend
   * assertions (DBC), ajax-based server calls (COMM), logging (LOG) and
-  * javascript resources for blockly (see: http://code.google.com/p/blockly/)
+  * javascript resources for blockly (see: developers.google.com/blockly)
   * controller and models written in Javascript, which implement the GUI
 
 To run tests, use `mvn test`. Running `mvn clean install` will make a stable, reproducible build with all unit tests executed.


### PR DESCRIPTION
Provided Link for 'javascript resources for blockly' has moved to some other link So changing this link So that one can directly reach to the other link.