### PR TITLE
Allow up and down arrows to move robot

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
@@ -597,10 +597,16 @@ define(['exports', 'simulation.scene', 'simulation.math', 'program.controller', 
         var keyName = e.key;
         switch (keyName) {
             case "ArrowUp":
+                robots[robotIndex].pose.x += Math.cos(robots[robotIndex].pose.theta);
+                robots[robotIndex].pose.y += Math.sin(robots[robotIndex].pose.theta);
+                break;
             case "ArrowLeft":
                 robots[robotIndex].pose.theta -= Math.PI / 180;
                 break;
             case "ArrowDown":
+                robots[robotIndex].pose.x -= Math.cos(robots[robotIndex].pose.theta);
+                robots[robotIndex].pose.y -= Math.sin(robots[robotIndex].pose.theta);
+                break;
             case "ArrowRight":
                 robots[robotIndex].pose.theta += Math.PI / 180;
                 break;


### PR DESCRIPTION
Fixes issue #612 

The up key will allow the robot to continue forward in its current direction, and the down key will allow the robot to move backwards in the current direction

Here's a video showing the process:
![ezgif com-crop](https://user-images.githubusercontent.com/58920989/73037683-d0143d00-3e04-11ea-857f-599fded6d034.gif)
