### PR TITLE
Remove random int from beginner toolbox

### DIFF
--- a/RobotMbed/src/main/resources/calliope/program.toolbox.beginner.xml
+++ b/RobotMbed/src/main/resources/calliope/program.toolbox.beginner.xml
@@ -78,18 +78,6 @@
   <category name="TOOLBOX_MATH" svg="true">
     <block type="math_number"/>
     <block type="math_arithmetic"/>
-    <block type="math_random_int">
-      <value name="FROM">
-        <block type="math_number">
-          <field name="NUM">1</field>
-        </block>
-      </value>
-      <value name="TO">
-        <block type="math_number">
-          <field name="NUM">100</field>
-        </block>
-      </value>
-    </block>
   </category>
   <category name="TOOLBOX_TEXT" svg="true">
     <block type="text"/>

--- a/RobotMbed/src/main/resources/microbit/program.toolbox.beginner.xml
+++ b/RobotMbed/src/main/resources/microbit/program.toolbox.beginner.xml
@@ -68,18 +68,6 @@
   <category name="TOOLBOX_MATH" svg="true">
     <block type="math_number"/>
     <block type="math_arithmetic"/>
-    <block type="math_random_int">
-      <value name="FROM">
-        <block type="math_number">
-          <field name="NUM">1</field>
-        </block>
-      </value>
-      <value name="TO">
-        <block type="math_number">
-          <field name="NUM">100</field>
-        </block>
-      </value>
-    </block>
   </category>
   <category name="TOOLBOX_TEXT" svg="true">
     <block type="text"/>

--- a/RobotWeDo/src/main/resources/wedo.program.toolbox.beginner.xml
+++ b/RobotWeDo/src/main/resources/wedo.program.toolbox.beginner.xml
@@ -75,18 +75,6 @@
   <category name="TOOLBOX_MATH" svg="true">
     <block type="math_number"/>
     <block type="math_arithmetic"/>
-    <block type="math_random_int">
-      <value name="FROM">
-        <block type="math_number">
-          <field name="NUM">1</field>
-        </block>
-      </value>
-      <value name="TO">
-        <block type="math_number">
-          <field name="NUM">100</field>
-        </block>
-      </value>
-    </block>
   </category>
   <category name="TOOLBOX_TEXT" svg="true">
     <block type="text"/>


### PR DESCRIPTION
Fixes #669 for WeDo and MBed (calliope + microbit) by removing the block from the beginner toolbox. The random integer function is present in the expert toolboxes of those two robot types. 