### PR TITLE
Fix formatting for xml test

### DIFF
--- a/RobotEV3/src/test/resources/syntax/code_generator/java/java_code_generator12.xml
+++ b/RobotEV3/src/test/resources/syntax/code_generator/java/java_code_generator12.xml
@@ -1,32 +1,31 @@
-<block_set
-            xmlns="http://de.fhg.iais.roberta.blockly" robottype="ev3" xmlversion="2.0" description="" tags="">
-            <instance x="302" y="77">
-                <block type="robControls_start" id=".mkI.fv*T4kzH[Ge|K``" intask="true" deletable="false">
-                    <mutation declare="false"></mutation>
-                    <field name="DEBUG">FALSE</field>
-                </block>
-                <block type="robSensors_timer_reset" id="[X%lPz^j0|bzOKMg]|oS" intask="true">
-                    <field name="SENSORPORT">1</field>
-                </block>
-                <block type="robActions_display_text" id="]N!to42ZhyzOa(id)M=)" intask="true">
-                    <value name="OUT">
-                        <block type="robSensors_timer_getSample" id="1x9g9J[`Y73z9GyMzS]N" intask="true">
-                            <mutation mode="VALUE"></mutation>
-                            <field name="MODE">VALUE</field>
-                            <field name="SENSORPORT">1</field>
-                            <field name="SLOT"></field>
-                        </block>
-                    </value>
-                    <value name="COL">
-                        <block type="math_number" id="?vU?ppe;l9FkkGUX1Yr6" intask="true">
-                            <field name="NUM">0</field>
-                        </block>
-                    </value>
-                    <value name="ROW">
-                        <block type="math_number" id="a9r[:~Y{HG0_{SR^ax#e" intask="true">
-                            <field name="NUM">0</field>
-                        </block>
-                    </value>
-                </block>
-            </instance>
-        </block_set>
+<block_set xmlns="http://de.fhg.iais.roberta.blockly" robottype="ev3" xmlversion="2.0" description="" tags="">
+  <instance x="302" y="77">
+    <block type="robControls_start" id=".mkI.fv*T4kzH[Ge|K``" intask="true" deletable="false">
+      <mutation declare="false" />
+      <field name="DEBUG">FALSE</field>
+    </block>
+    <block type="robSensors_timer_reset" id="[X%lPz^j0|bzOKMg]|oS" intask="true">
+      <field name="SENSORPORT">1</field>
+    </block>
+    <block type="robActions_display_text" id="]N!to42ZhyzOa(id)M=)" intask="true">
+      <value name="OUT">
+        <block type="robSensors_timer_getSample" id="1x9g9J[`Y73z9GyMzS]N" intask="true">
+          <mutation mode="VALUE" />
+          <field name="MODE">VALUE</field>
+          <field name="SENSORPORT">1</field>
+          <field name="SLOT" />
+        </block>
+      </value>
+      <value name="COL">
+        <block type="math_number" id="?vU?ppe;l9FkkGUX1Yr6" intask="true">
+          <field name="NUM">0</field>
+        </block>
+      </value>
+      <value name="ROW">
+        <block type="math_number" id="a9r[:~Y{HG0_{SR^ax#e" intask="true">
+          <field name="NUM">0</field>
+        </block>
+      </value>
+    </block>
+  </instance>
+</block_set>

--- a/RobotEdison/src/test/resources/syntax/actor/tone_action.xml
+++ b/RobotEdison/src/test/resources/syntax/actor/tone_action.xml
@@ -1,20 +1,20 @@
-       <block_set xmlns="http://de.fhg.iais.roberta.blockly" robottype="edison" xmlversion="2.0" description="" tags="">
-            <instance x="330" y="113">
-                <block type="robControls_start" id="y{|T;U?~S1,ac5_y?GQ(" intask="true" deletable="false">
-                    <mutation declare="false"></mutation>
-                    <field name="DEBUG">TRUE</field>
+<block_set xmlns="http://de.fhg.iais.roberta.blockly" robottype="edison" xmlversion="2.0" description="" tags="">
+    <instance x="330" y="113">
+        <block type="robControls_start" id="y{|T;U?~S1,ac5_y?GQ(" intask="true" deletable="false">
+            <mutation declare="false" />
+            <field name="DEBUG">TRUE</field>
+        </block>
+        <block type="robActions_play_tone" id="#WG.Vw@S*_yQIyQL%!I," intask="true">
+            <value name="FREQUENCE">
+                <block type="math_integer" id="{^RQ-nLquPo%@m2MwnQt" intask="true">
+                    <field name="NUM">300</field>
                 </block>
-                <block type="robActions_play_tone" id="#WG.Vw@S*_yQIyQL%!I," intask="true">
-                    <value name="FREQUENCE">
-                        <block type="math_integer" id="{^RQ-nLquPo%@m2MwnQt" intask="true">
-                            <field name="NUM">300</field>
-                        </block>
-                    </value>
-                    <value name="DURATION">
-                        <block type="math_integer" id="Gf!2clPvY1g;V{~R_s%T" intask="true">
-                            <field name="NUM">20</field>
-                        </block>
-                    </value>
+            </value>
+            <value name="DURATION">
+                <block type="math_integer" id="Gf!2clPvY1g;V{~R_s%T" intask="true">
+                    <field name="NUM">20</field>
                 </block>
-            </instance>
-        </block_set>
+            </value>
+        </block>
+    </instance>
+</block_set>


### PR DESCRIPTION
Fixed some formatting errors in xml files.

There have also been some redundant blocks in some of the xml files, such as an extra math "0" block hanging around, not attached to the actual program. 

For different robots, the indent spacing is different (ev3 has 2 spaced indents, while edison xml files have 4 spaced indents). Is this done purposely?