### PR TITLE
Add function to menu stop button

### DIFF
--- a/OpenRobertaServer/staticResources/index.html
+++ b/OpenRobertaServer/staticResources/index.html
@@ -240,7 +240,7 @@ limitations under the License.
                             <li><a href="#" id="menuSimWRO" class="simWRO menuSim typcn typcn-image " lkey="Blockly.Msg.MENU_SIM_WRO">WRO Scene</a></li>
                             <li><a href="#" id="menuSimMath" class="simMath menuSim typcn typcn-image " lkey="Blockly.Msg.MENU_SIM_MATH">Math Scene</a></li>
                             <li class="divider"></li>
-                            <li><a href="#" class="simStop typcn typcn-media-stop" lkey="Blockly.Msg.MENU_SIM_STOP">Stop</a></li>
+                            <li><a href="#" id="menuSimStop" class="simStop typcn typcn-media-stop" lkey="Blockly.Msg.MENU_SIM_STOP">Stop</a></li>
                             <li><a href="#" class="simBack typcn typcn-arrow-left-thick" lkey="Blockly.Msg.MENU_SIM_BACK">Back</a></li>
                         </ul></li>
                 </ul>

--- a/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
+++ b/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
@@ -255,6 +255,7 @@ define([ 'exports', 'log', 'util', 'message', 'comm', 'robot.controller', 'socke
         proto.find('.img-beta').css('visibility', 'hidden');
         proto.find('a[href]').css('visibility', 'hidden');
         $('#show-startup-message>.modal-body').append('<input type="button" class="btn backButton hidden" data-dismiss="modal" lkey="Blockly.Msg.POPUP_CANCEL"></input>');
+        $('.simStop').parent().addClass('disabled');
         USER.getStatusText(function(result) {
             if (result.statustext[0] !== "" && result.statustext[1] !== "") {
 //                $('#statustext-en').html("<span class='typcn typcn-info-large'></span> " + result.statustext[0]);
@@ -517,6 +518,10 @@ define([ 'exports', 'log', 'util', 'message', 'comm', 'robot.controller', 'socke
             case 'menuSimMath':
                 $('.simMath').parent().addClass('disabled');
                 SIM.setBackground(7, SIM.setBackground);
+                break;
+            case 'menuSimStop':
+                $('.simStop').parent().addClass('disabled');
+                SIM.stopProgram();
                 break;
             default:
                 break;

--- a/OpenRobertaServer/staticResources/js/app/roberta/controller/progSim.controller.js
+++ b/OpenRobertaServer/staticResources/js/app/roberta/controller/progSim.controller.js
@@ -35,7 +35,7 @@ define([ 'exports', 'message', 'log', 'util', 'simulation.simulation', 'guiState
                     var xmlConfigText = GUISTATE_C.isConfigurationAnonymous() ? GUISTATE_C.getConfigurationXML() : undefined;
 
                     var language = GUISTATE_C.getLanguage();
-
+                    $('.simStop').parent().removeClass('disabled');
                     PROGRAM.runInSim(GUISTATE_C.getProgramName(), configName, xmlTextProgram, xmlConfigText, language, function(result) {
                         if (result.rc == "ok") {
                             MSG.displayMessage("MESSAGE_EDIT_START", "TOAST", GUISTATE_C.getProgramName());
@@ -54,14 +54,15 @@ define([ 'exports', 'message', 'log', 'util', 'simulation.simulation', 'guiState
                 } else {
                     $('#simControl').addClass('typcn-media-play-outline').removeClass('typcn-media-stop');
                     $('#simControl').attr('data-original-title', Blockly.Msg.MENU_SIM_START_TOOLTIP);
+                    $('.simStop').parent().addClass('disabled');
                     SIM.stopProgram();
-
                 }
             } else {
                 if ($('#simControl').hasClass('typcn-media-play-outline')) {
                     MSG.displayMessage("MESSAGE_EDIT_START", "TOAST", "multiple simulation");
                     $('#simControl').addClass('typcn-media-stop').removeClass('typcn-media-play-outline');
                     $('#simControl').attr('data-original-title', Blockly.Msg.MENU_SIM_STOP_TOOLTIP);
+                    $('.simStop').parent().removeClass('disabled');
                     SIM.run(false, GUISTATE_C.getRobotGroup());
                     setTimeout(function() {
                         SIM.setPause(false);
@@ -69,6 +70,7 @@ define([ 'exports', 'message', 'log', 'util', 'simulation.simulation', 'guiState
                 } else {
                     $('#simControl').addClass('typcn-media-play-outline').removeClass('typcn-media-stop');
                     $('#simControl').attr('data-original-title', Blockly.Msg.MENU_SIM_START_TOOLTIP);
+                    $('.simStop').parent().addClass('disabled');
                     SIM.stopProgram();
                 }
             }


### PR DESCRIPTION
Fixed issue #630 .
Clicking the stop button in the menu will stop the program for single and multi robot simulations.
The button will be disabled when the program is not running, and enabled when the program is running. 

![Screenshot (102)](https://user-images.githubusercontent.com/58920989/73226624-a53c2880-4125-11ea-875c-0391c7564790.png)
![Screenshot (103)](https://user-images.githubusercontent.com/58920989/73226625-a53c2880-4125-11ea-9454-253cc107d296.png)
![Screenshot (104)](https://user-images.githubusercontent.com/58920989/73226626-a53c2880-4125-11ea-891b-93749f66edb2.png)

