### PR TITLE
Add function to menu back button

### DIFF
--- a/OpenRobertaServer/staticResources/index.html
+++ b/OpenRobertaServer/staticResources/index.html
@@ -241,7 +241,6 @@ limitations under the License.
                             <li><a href="#" id="menuSimMath" class="simMath menuSim typcn typcn-image " lkey="Blockly.Msg.MENU_SIM_MATH">Math Scene</a></li>
                             <li class="divider"></li>
                             <li><a href="#" class="simStop typcn typcn-media-stop" lkey="Blockly.Msg.MENU_SIM_STOP">Stop</a></li>
-                            <li><a href="#" class="simBack typcn typcn-arrow-left-thick" lkey="Blockly.Msg.MENU_SIM_BACK">Back</a></li>
                         </ul></li>
                 </ul>
             </div>
@@ -256,7 +255,6 @@ limitations under the License.
                 <li><a href="#" id="menuSimMath" class="simMath menuSim typcn typcn-image " lkey="Blockly.Msg.MENU_SIM_MATH">Math Scene</a></li>
                 <li class="divider visible-xs"></li>
                 <li><a href="#" class="simStop typcn typcn-media-stop" lkey="Blockly.Msg.MENU_SIM_STOP">Stop</a></li>
-                <li><a href="#" class="simBack typcn typcn-arrow-left-thick" lkey="Blockly.Msg.MENU_SIM_BACK">Back</a></li>
             </ul>
         </div>
         <!-- Roberta-Logo -->


### PR DESCRIPTION
Fixes issue #631 

The back option button will be disabled when there are no previous backgrounds, and if there are previous backgrounds in the stack, then clicking the button will allow the user to switch to the previous background.

Notice in the click function that .pop() is done two times - the first one is to get rid of the current background from the array, and the second one will give the number of the previous background.


Upon opening simulation:
![Screenshot (105)](https://user-images.githubusercontent.com/58920989/73237536-c95e3080-414a-11ea-97ee-1a1a7e7f5db8.png)
After opening a new background:
![Screenshot (106)](https://user-images.githubusercontent.com/58920989/73237537-c95e3080-414a-11ea-9701-37477751d76c.png)
After clicking "back":
![Screenshot (107)](https://user-images.githubusercontent.com/58920989/73237538-c95e3080-414a-11ea-9b20-b800a20a6201.png)



