### PR TITLE
Fix to yellow colors not being registered properly

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/math.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/math.js
@@ -253,7 +253,7 @@ define([ 'exports', 'simulation.constants' ], function(exports, CONSTANTS) {
         if ((hsv[0] < 10 || hsv[0] > 350) && hsv[1] > 90 && hsv[2] > 50) {
             return CONSTANTS.COLOR_ENUM.RED;
         }
-        if (hsv[0] > 40 && hsv[0] < 70 && hsv[1] > 90 && hsv[2] > 50) {
+        if (hsv[0] > 40 && hsv[0] < 70 && hsv[1] > 80 && hsv[2] > 50) {
             return CONSTANTS.COLOR_ENUM.YELLOW;
         }
         if (hsv[0] < 50 && hsv[1] > 50 && hsv[1] < 100 && hsv[2] < 50) {


### PR DESCRIPTION
Fix to Issue #594.
The reason this change was done in the Math file rather than just changed in blockly is the case that somebody has an old background made which currently uses the displayed RGB values which may cause for the background to not work as the yellow will not be recognized without this change.