### PR TITLE
Fix Incorrect Error Message Displayed In EV3 Lejos Compiler

### DIFF
--- a/RobotEV3/src/main/java/de/fhg/iais/roberta/components/ev3lejos/JavaSourceCompiler.java
+++ b/RobotEV3/src/main/java/de/fhg/iais/roberta/components/ev3lejos/JavaSourceCompiler.java
@@ -76,6 +76,13 @@ public class JavaSourceCompiler {
     public void compileAndPackage(String pathToCrosscompilerBaseDir, String token) {
         compile();
         File jarFile;
+
+        if ( this.fileManager.getClassJavaFileObject() == null ) {
+            this.success = false;
+            this.compilerResponse = "The program body is empty";
+            return;
+        }
+
         if ( this.success ) {
             ByteArrayOutputStream jarArchive = createJarArchive();
             jarFile = new File(pathToCrosscompilerBaseDir + "/" + token + "/" + this.programName + "/target/" + this.programName + ".jar");


### PR DESCRIPTION
Fix to Issue #611.
Now displays a correct error message that states that the program body is empty if the new source code view is empty.