### PR TITLE
Add server side support for updating ev3dev updates.

### DIFF
--- a/RobotEV3/src/main/java/de/fhg/iais/roberta/javaServer/restServices/robot/ev3/ev3dev/Update.java
+++ b/RobotEV3/src/main/java/de/fhg/iais/roberta/javaServer/restServices/robot/ev3/ev3dev/Update.java
@@ -1,0 +1,49 @@
+package de.fhg.iais.roberta.javaServer.restServices.robot.ev3.ev3dev;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+import de.fhg.iais.roberta.factory.IRobotFactory;
+import de.fhg.iais.roberta.util.AliveData;
+
+/**
+ * REST service for updating brick libraries and menu.<br>
+ */
+@Path("/update/ev3dev")
+public class Update {
+    private static final Logger LOG = LoggerFactory.getLogger(Update.class);
+
+    private final String robotUpdateResourcesDir;
+
+    @Inject
+    public Update(@Named("robotPluginMap") Map<String, IRobotFactory> robotPluginMap) {
+        this.robotUpdateResourcesDir = robotPluginMap.get("ev3dev").getPluginProperties().getUpdateDir();
+    }
+
+    @GET
+    @Path("/runtime")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    public Response getRuntime() throws FileNotFoundException {
+        AliveData.rememberRobotCall(-1);
+        LOG.info("/update/ev3dev/runtime called");
+        File bin = new File(this.robotUpdateResourcesDir + "roberta.zip");
+        Response.ResponseBuilder response = Response.ok(new FileInputStream(bin));
+        response.header("Content-Disposition", "attachment; filename=roberta.zip");
+        response.header("Filename", "roberta.zip");
+        return response.build();
+    }
+}

--- a/RobotEV3/src/main/resources/ev3dev.properties
+++ b/RobotEV3/src/main/resources/ev3dev.properties
@@ -1,7 +1,7 @@
 robot.plugin.group = ev3
 robot.plugin.factory = de.fhg.iais.roberta.factory.EV3Factory
 robot.plugin.compiler.resources.dir = RobotEV3/crossCompilerResources/
-robot.plugin.update.dir = RobotEV3/updateResources/
+robot.plugin.update.dir = RobotEV3/updateResources/ev3dev/
 
 robot.plugin.fileExtension.source = py
 robot.plugin.fileExtension.binary = py
@@ -33,9 +33,11 @@ robot.sim = true
 robot.multisim = true
 
 robot.connection = token
-
 robot.descriptor = classpath:/ev3.yml
 robot.helperMethods = classpath:/ev3dev.methods.yml
+
+# Uncomment once a 1.7.5 has been released
+# robot.menu.version = 1.7.5
 
 robot.plugin.worker.validate.robot = de.fhg.iais.roberta.worker.validate.Ev3BrickValidatorWorker
 robot.plugin.worker.validate.sim = de.fhg.iais.roberta.worker.validate.Ev3SimValidatorWorker


### PR DESCRIPTION
It is still disabled until we have an ev3dev image containing a 1.7.5
version out.

See #730 