### PR TITLE
Test block paranthesis

### DIFF
--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/lang/codegen/prog/AbstractJavaVisitor.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/lang/codegen/prog/AbstractJavaVisitor.java
@@ -609,12 +609,13 @@ public abstract class AbstractJavaVisitor extends AbstractLanguageVisitor {
 
     @Override
     protected void generateCodeFromTernary(IfStmt<Void> ifStmt) {
-        this.sb.append("(" + whitespace());
+        this.sb.append("(" + whitespace() + "(" + whitespace());
         ifStmt.getExpr().get(0).accept(this);
         this.sb.append(whitespace() + ")" + whitespace() + "?" + whitespace());
         ((ExprStmt<Void>) ifStmt.getThenList().get(0).get().get(0)).getExpr().accept(this);
         this.sb.append(whitespace() + ":" + whitespace());
         ((ExprStmt<Void>) ifStmt.getElseList().get().get(0)).getExpr().accept(this);
+        this.sb.append(whitespace() + ")");
     }
 
     @Override

--- a/RobotEV3/src/test/java/de/fhg/iais/roberta/syntax/expr/LogicExprTest.java
+++ b/RobotEV3/src/test/java/de/fhg/iais/roberta/syntax/expr/LogicExprTest.java
@@ -38,7 +38,7 @@ public class LogicExprTest extends Ev3LejosAstTest {
 
     @Test
     public void logicTernary() throws Exception {
-        String a = "\n( 0 == 0 ) ? false : true}";
+        String a = "\n( ( 0 == 0 ) ? false : true )}";
 
         UnitTestHelper.checkGeneratedSourceEqualityWithProgramXmlAndSourceAsString(testFactory, a, "/syntax/expr/logic_ternary.xml", false);
     }


### PR DESCRIPTION
fixes #763

I have updated the Java Visitor to always enclose a test block (i.e. ternary expression) inside parentheses. Additionally, the Logical Expression test has also been modified to include parentheses around the ternary expression.
This is my first contribution, please let me know if you have any feedback!