### PR TITLE
update Java JDK to openjdk11(LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk8
+  - openjdk11
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <source.level>1.8</source.level>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <source.level>11</source.level>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
 
         <guice.version>4.2.0</guice.version>
         <jersey.version>1.19.4</jersey.version>


### PR DESCRIPTION
Java JDK LTS is now at version 11,
The code successfully compiles, [travis CI build status](https://travis-ci.org/github/sachinsshetty/openroberta-lab/builds) .

Executed in local Ubuntu 18.04 with openjdk-11 and started server without error

Steps followed 
1. sudo apt install maven
2. sudo apt install openjdk-11-jdk
3. mvn clean install 
4. ./ora.sh create-empty-db
5. ./ora.sh start-from-git
6. access server from localhost:1999