### PR TITLE
Fix issue #899 ev3 image (for show text, ...) frozen after sim run

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
@@ -1604,7 +1604,6 @@ define(['exports', 'simulation.scene', 'simulation.constants', 'util', 'interpre
         $("#robotLayer").off();
         $("#simDiv").off();
         $("#canvasDiv").off();
-        $("#simRobotModal").off();
         $("#robotIndex").off();
         $("#blocklyDiv").off("click touchstart", setFocusBlocklyDiv);
     }


### PR DESCRIPTION
Removed robotModal.off() from removeMouseEvents() so its always interactable when visible. This works for all robots.