### PR TITLE
issue#1013 fixed resetting the outline of objects

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
@@ -1546,9 +1546,8 @@ define(['exports', 'simulation.scene', 'simulation.constants', 'util', 'interpre
             scene.drawColorAreas(highLightCorners);
             return;
         }
-        highLightCorners = []
-        scene.drawObstacles(highLightCorners);
-        scene.drawColorAreas(highLightCorners);
+        scene.drawObstacles([]);
+        scene.drawColorAreas([]);
     }
 
     function addMouseEvents() {

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
@@ -1532,18 +1532,16 @@ define(['exports', 'simulation.scene', 'simulation.constants', 'util', 'interpre
             scale = Math.min(scaleX, scaleY) - 0.05;
             scene.resizeBackgrounds(scale);
             scene.drawRuler();
-
-            if(selectedObstacle >= 0){
+            if (selectedObstacle >= 0) {
                 scene.drawObstacles(highLightCorners);
                 scene.drawColorAreas([]);
                 return;
             }
-            if(selectedColorArea >= 0){
+            if (selectedColorArea >= 0) {
                 scene.drawObstacles([]);
                 scene.drawColorAreas(highLightCorners);
                 return;
             }
-
             scene.drawObstacles([]);
             scene.drawColorAreas([]);
         }
@@ -1626,14 +1624,9 @@ define(['exports', 'simulation.scene', 'simulation.constants', 'util', 'interpre
         scene.drawRobots();
         addMouseEvents();
         disableChangeObjectButtons();
-
-        if(selectedObstacle >= 0){
-            highLightCorners = calculateCorners(obstacleList[selectedObstacle]);
-        }
-        if(selectedColorArea >= 0){
-            highLightCorners = calculateCorners(colorAreaList[selectedColorArea]);
-        }
-        
+        highLightCorners = [];
+        selectedObstacle = -1;
+        selectedColorArea = -1;
         if (robots[0].colorRange) {
             colorpicker = new HUEBEE('#colorpicker', {
                 shades: 1,

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
@@ -1531,9 +1531,21 @@ define(['exports', 'simulation.scene', 'simulation.constants', 'util', 'interpre
             var scaleY = scene.playground.h / (ground.h + 20);
             scale = Math.min(scaleX, scaleY) - 0.05;
             scene.resizeBackgrounds(scale);
-            scene.drawObstacles(highLightCorners);
-            scene.drawColorAreas(highLightCorners);
             scene.drawRuler();
+
+            if(selectedObstacle >= 0){
+                scene.drawObstacles(highLightCorners);
+                scene.drawColorAreas([]);
+                return;
+            }
+            if(selectedColorArea >= 0){
+                scene.drawObstacles([]);
+                scene.drawColorAreas(highLightCorners);
+                return;
+            }
+
+            scene.drawObstacles([]);
+            scene.drawColorAreas([]);
         }
     }
 
@@ -1611,13 +1623,17 @@ define(['exports', 'simulation.scene', 'simulation.constants', 'util', 'interpre
 
     function initScene() {
         scene = new Scene(imgObjectList[currentBackground], robots, imgPattern, ruler);
-        scene.drawObstacles(highLightCorners);
-        scene.drawColorAreas(highLightCorners);
-        scene.drawRuler();
         scene.drawRobots();
         addMouseEvents();
         disableChangeObjectButtons();
 
+        if(selectedObstacle >= 0){
+            highLightCorners = calculateCorners(obstacleList[selectedObstacle]);
+        }
+        if(selectedColorArea >= 0){
+            highLightCorners = calculateCorners(colorAreaList[selectedColorArea]);
+        }
+        
         if (robots[0].colorRange) {
             colorpicker = new HUEBEE('#colorpicker', {
                 shades: 1,

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
@@ -1104,6 +1104,7 @@ define(['exports', 'simulation.scene', 'simulation.constants', 'util', 'interpre
         if (!downRuler && rulerIsDown) {
             downRuler = true;
             selectedRobot = -1;
+            highLightCorners = [];
             if (selectedObstacle >= 0) {
                 selectedObstacle = -1;
                 updateObstacleLayer();
@@ -1113,7 +1114,6 @@ define(['exports', 'simulation.scene', 'simulation.constants', 'util', 'interpre
                 updateColorAreaLayer();
             }
             downCorner = -1;
-            highLightCorners = [];
             return;
         }
         if (selectedObstacle >= 0) {
@@ -1510,8 +1510,7 @@ define(['exports', 'simulation.scene', 'simulation.constants', 'util', 'interpre
         if (zoom) {
             scene.resizeBackgrounds(scale);
             scene.drawRuler();
-            scene.drawObstacles(highLightCorners);
-            scene.drawColorAreas(highLightCorners);
+            updateSelectedObjects();
             e.stopPropagation();
         }
     }
@@ -1532,19 +1531,24 @@ define(['exports', 'simulation.scene', 'simulation.constants', 'util', 'interpre
             scale = Math.min(scaleX, scaleY) - 0.05;
             scene.resizeBackgrounds(scale);
             scene.drawRuler();
-            if (selectedObstacle >= 0) {
-                scene.drawObstacles(highLightCorners);
-                scene.drawColorAreas([]);
-                return;
-            }
-            if (selectedColorArea >= 0) {
-                scene.drawObstacles([]);
-                scene.drawColorAreas(highLightCorners);
-                return;
-            }
-            scene.drawObstacles([]);
-            scene.drawColorAreas([]);
+            updateSelectedObjects();
         }
+    }
+
+    function updateSelectedObjects() {
+        if (selectedObstacle >= 0) {
+            scene.drawObstacles(highLightCorners);
+            scene.drawColorAreas([]);
+            return;
+        }
+        if (selectedColorArea >= 0) {
+            scene.drawObstacles([]);
+            scene.drawColorAreas(highLightCorners);
+            return;
+        }
+        highLightCorners = []
+        scene.drawObstacles(highLightCorners);
+        scene.drawColorAreas(highLightCorners);
     }
 
     function addMouseEvents() {
@@ -1622,11 +1626,9 @@ define(['exports', 'simulation.scene', 'simulation.constants', 'util', 'interpre
     function initScene() {
         scene = new Scene(imgObjectList[currentBackground], robots, imgPattern, ruler);
         scene.drawRobots();
+        resetSelection();
         addMouseEvents();
         disableChangeObjectButtons();
-        highLightCorners = [];
-        selectedObstacle = -1;
-        selectedColorArea = -1;
         if (robots[0].colorRange) {
             colorpicker = new HUEBEE('#colorpicker', {
                 shades: 1,


### PR DESCRIPTION
fixed resetting the outline of objects: initScene() and resizeAll() called the scene methods drawObstacles() and drawColoredAreas() with the same value for highlightCorners, so even only e.g an obstacle is selected it would draw the outlines for a coloredArea