### PR TITLE
Part of Issue#861 , MultipleRobotsTable now remembers selected Program

### DIFF
--- a/OpenRobertaServer/staticResources/index.html
+++ b/OpenRobertaServer/staticResources/index.html
@@ -1132,7 +1132,7 @@ limitations under the License.
                     <h3 id="#headMulipleRobots" class="modal-title" lkey="Blockly.Msg.POPUP_MULTIPLE_ROBOTS">Meine Programme</h3>
                 </div>
                 <div class="modal-body">
-                    <table id="multipleRobotsTable"></table>
+                    <table id="multipleRobotsTable" data-maintain-selected="true"></table>
                 </div>
                 <div class="modal-footer">
                     <button type="button" id="loadMultipleSimPrograms" class="btn btn-primary">Ok</button>


### PR DESCRIPTION
When Selecting multiple programs for the simulation, the selection table now remembers which programs are selected when changing the page. Therefore its now possible to run Robots from different pages in the multiple robot simulation.