### PR TITLE
Fix 1071

### DIFF
--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/components/ConfigurationAst.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/components/ConfigurationAst.java
@@ -14,7 +14,7 @@ import de.fhg.iais.roberta.util.dbc.DbcException;
 
 /**
  * An AST representation of the old/new configurations. Contains an insertion ordered Map of {@link ConfigurationComponent}s. May have subclasses with hardcoded
- * configurations which can reuse the {@link Builder} using the generic {@link Builder#build(Class)}.
+ * configurations which can reuse the {@link Builder} using the generic {@link Builder#build()}.
  */
 public final class ConfigurationAst {
     // LinkedHashMap to preserve insertion order of elements. Helps to recreate the same XML output as XML input.
@@ -31,7 +31,7 @@ public final class ConfigurationAst {
     private final String password;
     private String robotName;
 
-    protected ConfigurationAst(
+    private ConfigurationAst(
         Iterable<ConfigurationComponent> configurationComponents,
         String robotType,
         String xmlVersion,
@@ -212,7 +212,12 @@ public final class ConfigurationAst {
     }
 
     public String getFirstMotorPort(String side) {
-        return getFirstMotor(side).getUserDefinedPortName();
+        ConfigurationComponent firstMotor = getFirstMotor(side);
+        if ( firstMotor == null ) {
+            return null;
+        } else {
+            return firstMotor.getUserDefinedPortName();
+        }
     }
 
     public ConfigurationComponent getFirstMotor(String side) {


### PR DESCRIPTION
# Description
`getFirstMotor(side)` might results in `null` value and calling `getUserDefinedPortName()` on top of that will throw NPE. which then fails to open source code editor. 

Fixes # (issue)
- #1071 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?
The source code editor is now working properly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes