### PR TITLE
Refactored heritage structure of MotorValidatorAndCollectorVisitor 

### DIFF
--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/syntax/SC.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/syntax/SC.java
@@ -2,9 +2,11 @@ package de.fhg.iais.roberta.syntax;
 
 public interface SC {
     String ROBOT = "ROBOT";
+    String MOTOR = "MOTOR";
     String MOTOR_REGULATION = "MOTOR_REGULATION";
     String MOTOR_REVERSE = "MOTOR_REVERSE";
     String MOTOR_DRIVE = "MOTOR_DRIVE";
+    String DIFFERENTIALDRIVE = "DIFFERENTIALDRIVE";
     String ON = "ON";
     String OFF = "OFF";
     String TRUE = "TRUE";

--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/validate/DifferentialMotorValidatorAndCollectorVisitor.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/validate/DifferentialMotorValidatorAndCollectorVisitor.java
@@ -1,0 +1,144 @@
+package de.fhg.iais.roberta.visitor.validate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ClassToInstanceMap;
+
+import de.fhg.iais.roberta.bean.IProjectBean;
+import de.fhg.iais.roberta.components.ConfigurationAst;
+import de.fhg.iais.roberta.components.ConfigurationComponent;
+import de.fhg.iais.roberta.components.UsedActor;
+import de.fhg.iais.roberta.syntax.SC;
+import de.fhg.iais.roberta.syntax.action.Action;
+import de.fhg.iais.roberta.syntax.action.motor.differential.CurveAction;
+import de.fhg.iais.roberta.syntax.action.motor.differential.DriveAction;
+import de.fhg.iais.roberta.syntax.action.motor.differential.MotorDriveStopAction;
+import de.fhg.iais.roberta.syntax.action.motor.differential.TurnAction;
+import de.fhg.iais.roberta.syntax.lang.expr.Expr;
+import de.fhg.iais.roberta.syntax.lang.expr.NumConst;
+import de.fhg.iais.roberta.util.dbc.Assert;
+import de.fhg.iais.roberta.visitor.hardware.actor.IDifferentialMotorVisitor;
+
+public abstract class DifferentialMotorValidatorAndCollectorVisitor extends MotorValidatorAndCollectorVisitor implements IDifferentialMotorVisitor<Void> {
+
+    public DifferentialMotorValidatorAndCollectorVisitor(
+        ConfigurationAst robotConfiguration,
+        ClassToInstanceMap<IProjectBean.IBuilder<?>> beanBuilders) {
+        super(robotConfiguration, beanBuilders);
+    }
+
+    @Override
+    public Void visitDriveAction(DriveAction<Void> driveAction) {
+        checkAndAddDifferentialDriveBlock(driveAction);
+        checkAndVisitMotionParam(driveAction, driveAction.getParam());
+        return null;
+    }
+
+    @Override
+    public Void visitCurveAction(CurveAction<Void> curveAction) {
+        checkAndAddDifferentialDriveBlock(curveAction);
+        checkForZeroSpeedInCurve(curveAction.getParamLeft().getSpeed(), curveAction.getParamRight().getSpeed(), curveAction);
+        return null;
+    }
+
+    @Override
+    public Void visitTurnAction(TurnAction<Void> turnAction) {
+        checkAndVisitMotionParam(turnAction, turnAction.getParam());
+        checkAndAddDifferentialDriveBlock(turnAction);
+        return null;
+    }
+
+    @Override
+    public Void visitMotorDriveStopAction(MotorDriveStopAction<Void> stopAction) {
+        checkAndAddDifferentialDriveBlock(stopAction);
+        return null;
+    }
+
+    private void checkAndAddDifferentialDriveBlock(Action<Void> motionAction) {
+        if ( hasDifferentialDriveCheck(motionAction) ) {
+            hasEncodersOnDifferentialDriveCheck(motionAction);
+            addDifferentialDriveToUsedHardware();
+        }
+    }
+
+    private boolean hasDifferentialDriveCheck(Action<Void> motionAction) {
+        ConfigurationComponent differentialDrive = getDifferentialDrive();
+        if ( differentialDrive == null ) {
+            addErrorToPhrase(motionAction, "CONFIGURATION_ERROR_ACTOR_MISSING");
+            return false;
+        } else if ( differentialDrive.getOptProperty("MOTOR_L").equals(differentialDrive.getOptProperty("MOTOR_R")) ) {
+            addErrorToPhrase(motionAction, "CONFIGURATION_ERROR_OVERLAPPING_PORTS");
+            return false;
+        }
+        return true;
+    }
+
+    private ConfigurationComponent getDifferentialDrive() {
+        Map<String, ConfigurationComponent> configComponents = this.robotConfiguration.getConfigurationComponents();
+        for ( ConfigurationComponent component : configComponents.values() ) {
+            if ( component.getComponentType().equals(SC.DIFFERENTIALDRIVE) ) {
+                return component;
+            }
+        }
+        return null;
+    }
+
+    private void hasEncodersOnDifferentialDriveCheck(Action<Void> motionParam) {
+        ConfigurationComponent differentialDrive = getDifferentialDrive();
+        Assert.notNull(differentialDrive, "differentialDrive block is missing in the configuration");
+        List<ConfigurationComponent> rightMotors = getEncodersOnPort(differentialDrive.getOptProperty("MOTOR_R"));
+        List<ConfigurationComponent> leftMotors = getEncodersOnPort(differentialDrive.getOptProperty("MOTOR_L"));
+
+        if ( rightMotors.size() > 1 ) {
+            addErrorToPhrase(motionParam, "CONFIGURATION_ERROR_MULTIPLE_RIGHT_MOTORS");
+        } else if ( leftMotors.size() > 1 ) {
+            addErrorToPhrase(motionParam, "CONFIGURATION_ERROR_MULTIPLE_LEFT_MOTORS");
+        } else if ( rightMotors.isEmpty() ) {
+            addErrorToPhrase(motionParam, "CONFIGURATION_ERROR_MOTOR_RIGHT_MISSING");
+        } else if ( leftMotors.isEmpty() ) {
+            addErrorToPhrase(motionParam, "CONFIGURATION_ERROR_MOTOR_LEFT_MISSING");
+        }
+    }
+
+    private void addDifferentialDriveToUsedHardware() {
+        ConfigurationComponent diffDrive = getDifferentialDrive();
+        Assert.notNull(diffDrive, "differential missing in Configuration");
+
+        usedHardwareBuilder.addUsedActor(new UsedActor(diffDrive.getUserDefinedPortName(), SC.DIFFERENTIALDRIVE));
+        List<ConfigurationComponent> motorsR = getEncodersOnPort(diffDrive.getOptProperty("MOTOR_R"));
+        List<ConfigurationComponent> motorsL = getEncodersOnPort(diffDrive.getOptProperty("MOTOR_L"));
+        if ( !motorsL.isEmpty() ) {
+            usedHardwareBuilder.addUsedActor(new UsedActor(motorsL.get(0).getUserDefinedPortName(), motorsL.get(0).getComponentType()));
+        }
+        if ( !motorsR.isEmpty() ) {
+            usedHardwareBuilder.addUsedActor(new UsedActor(motorsR.get(0).getUserDefinedPortName(), motorsR.get(0).getComponentType()));
+        }
+    }
+
+    private List<ConfigurationComponent> getEncodersOnPort(String port) {
+        Map<String, ConfigurationComponent> configComponents = this.robotConfiguration.getConfigurationComponents();
+        List<ConfigurationComponent> encoders = new ArrayList<>();
+        for ( ConfigurationComponent component : configComponents.values() ) {
+            if ( component.getComponentType().equals(SC.ENCODER) || component.getComponentType().equals(SC.MOTOR) || component.getComponentType().equals(SC.STEPMOTOR) ) {
+                if ( component.getComponentProperties().containsValue(port) ) {
+                    encoders.add(component);
+                }
+            }
+        }
+        return encoders;
+    }
+
+    private void checkForZeroSpeedInCurve(Expr<Void> speedLeft, Expr<Void> speedRight, Action<Void> action) {
+        if ( speedLeft.getKind().hasName("NUM_CONST") && speedRight.getKind().hasName("NUM_CONST") ) {
+            double speedLeftNumConst = Double.parseDouble(((NumConst<Void>) speedLeft).getValue());
+            double speedRightNumConst = Double.parseDouble(((NumConst<Void>) speedRight).getValue());
+
+            boolean bothMotorsHaveZeroSpeed = (Math.abs(speedLeftNumConst) < DOUBLE_EPS) && (Math.abs(speedRightNumConst) < DOUBLE_EPS);
+            if ( bothMotorsHaveZeroSpeed ) {
+                addWarningToPhrase(action, "MOTOR_SPEED_0");
+            }
+        }
+    }
+}

--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/validate/MotorValidatorAndCollectorVisitor.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/validate/MotorValidatorAndCollectorVisitor.java
@@ -1,4 +1,4 @@
-package de.fhg.iais.roberta.visitor.hardware.actor;
+package de.fhg.iais.roberta.visitor.validate;
 
 import com.google.common.collect.ClassToInstanceMap;
 
@@ -17,18 +17,16 @@ import de.fhg.iais.roberta.syntax.action.motor.MotorSetPowerAction;
 import de.fhg.iais.roberta.syntax.action.motor.MotorStopAction;
 import de.fhg.iais.roberta.syntax.lang.expr.Expr;
 import de.fhg.iais.roberta.syntax.lang.expr.NumConst;
-import de.fhg.iais.roberta.visitor.IVisitor;
-import de.fhg.iais.roberta.visitor.validate.AbstractValidatorAndCollectorVisitor;
+import de.fhg.iais.roberta.visitor.hardware.actor.IMotorVisitor;
 
-public class MotorValidatorAndCollectorVisitor extends AbstractValidatorAndCollectorVisitor implements IMotorVisitor<Void> {
+public abstract class MotorValidatorAndCollectorVisitor extends CommonNepoValidatorAndCollectorVisitor implements IMotorVisitor<Void> {
 
     public static final double DOUBLE_EPS = 1E-7;
 
     public MotorValidatorAndCollectorVisitor(
-        IVisitor<Void> mainVisitor,
         ConfigurationAst robotConfiguration,
         ClassToInstanceMap<IProjectBean.IBuilder<?>> beanBuilders) {
-        super(mainVisitor, robotConfiguration, beanBuilders);
+        super(robotConfiguration, beanBuilders);
     }
 
     @Override
@@ -79,7 +77,6 @@ public class MotorValidatorAndCollectorVisitor extends AbstractValidatorAndColle
             checkForZeroSpeed(action, speed);
         }
     }
-
 
     protected void checkForZeroSpeed(Action<Void> action, Expr<Void> speed) {
         if ( speed.getKind().hasName("NUM_CONST") ) {

--- a/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/validate/DifferentialMotorValidatorAndCollectorVisitorEv3.java
+++ b/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/validate/DifferentialMotorValidatorAndCollectorVisitorEv3.java
@@ -1,4 +1,4 @@
-package de.fhg.iais.roberta.visitor.hardware.actor;
+package de.fhg.iais.roberta.visitor.validate;
 
 import java.util.Optional;
 
@@ -17,15 +17,14 @@ import de.fhg.iais.roberta.syntax.action.motor.differential.MotorDriveStopAction
 import de.fhg.iais.roberta.syntax.action.motor.differential.TurnAction;
 import de.fhg.iais.roberta.syntax.lang.expr.Expr;
 import de.fhg.iais.roberta.syntax.lang.expr.NumConst;
-import de.fhg.iais.roberta.visitor.IVisitor;
+import de.fhg.iais.roberta.visitor.hardware.actor.IDifferentialMotorVisitor;
 
-public class DifferentialMotorValidatorAndCollectorVisitor extends MotorValidatorAndCollectorVisitor implements IDifferentialMotorVisitor<Void> {
+public abstract class DifferentialMotorValidatorAndCollectorVisitorEv3 extends MotorValidatorAndCollectorVisitor implements IDifferentialMotorVisitor<Void> {
 
-    public DifferentialMotorValidatorAndCollectorVisitor(
-        IVisitor<Void> mainVisitor,
+    public DifferentialMotorValidatorAndCollectorVisitorEv3(
         ConfigurationAst robotConfiguration,
         ClassToInstanceMap<IProjectBean.IBuilder<?>> beanBuilders) {
-        super(mainVisitor, robotConfiguration, beanBuilders);
+        super(robotConfiguration, beanBuilders);
     }
 
     @Override

--- a/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/validate/Ev3ValidatorAndCollectorVisitor.java
+++ b/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/validate/Ev3ValidatorAndCollectorVisitor.java
@@ -19,14 +19,6 @@ import de.fhg.iais.roberta.syntax.action.display.ShowTextAction;
 import de.fhg.iais.roberta.syntax.action.ev3.ShowPictureAction;
 import de.fhg.iais.roberta.syntax.action.light.LightAction;
 import de.fhg.iais.roberta.syntax.action.light.LightStatusAction;
-import de.fhg.iais.roberta.syntax.action.motor.MotorGetPowerAction;
-import de.fhg.iais.roberta.syntax.action.motor.MotorOnAction;
-import de.fhg.iais.roberta.syntax.action.motor.MotorSetPowerAction;
-import de.fhg.iais.roberta.syntax.action.motor.MotorStopAction;
-import de.fhg.iais.roberta.syntax.action.motor.differential.CurveAction;
-import de.fhg.iais.roberta.syntax.action.motor.differential.DriveAction;
-import de.fhg.iais.roberta.syntax.action.motor.differential.MotorDriveStopAction;
-import de.fhg.iais.roberta.syntax.action.motor.differential.TurnAction;
 import de.fhg.iais.roberta.syntax.action.sound.PlayFileAction;
 import de.fhg.iais.roberta.syntax.action.sound.PlayNoteAction;
 import de.fhg.iais.roberta.syntax.action.sound.ToneAction;
@@ -48,15 +40,11 @@ import de.fhg.iais.roberta.syntax.sensor.generic.TimerSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.TouchSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.UltrasonicSensor;
 import de.fhg.iais.roberta.visitor.IEv3Visitor;
-import de.fhg.iais.roberta.visitor.hardware.actor.DifferentialMotorValidatorAndCollectorVisitor;
 
-public class Ev3ValidatorAndCollectorVisitor extends CommonNepoValidatorAndCollectorVisitor implements IEv3Visitor<Void> {
-
-    private final DifferentialMotorValidatorAndCollectorVisitor differentialMotorValidatorAndCollectorVisitor;
+public class Ev3ValidatorAndCollectorVisitor extends DifferentialMotorValidatorAndCollectorVisitorEv3 implements IEv3Visitor<Void> {
 
     public Ev3ValidatorAndCollectorVisitor(ConfigurationAst robotConfiguration, ClassToInstanceMap<IProjectBean.IBuilder<?>> beanBuilders) {
         super(robotConfiguration, beanBuilders);
-        differentialMotorValidatorAndCollectorVisitor = new DifferentialMotorValidatorAndCollectorVisitor(this, robotConfiguration, beanBuilders);
     }
 
     @Override
@@ -110,16 +98,6 @@ public class Ev3ValidatorAndCollectorVisitor extends CommonNepoValidatorAndColle
         }
         usedHardwareBuilder.addUsedSensor(new UsedSensor(compassSensor.getUserDefinedPort(), SC.COMPASS, compassSensor.getMode()));
         return null;
-    }
-
-    @Override
-    public Void visitCurveAction(CurveAction<Void> curveAction) {
-        return differentialMotorValidatorAndCollectorVisitor.visitCurveAction(curveAction);
-    }
-
-    @Override
-    public Void visitDriveAction(DriveAction<Void> driveAction) {
-        return differentialMotorValidatorAndCollectorVisitor.visitDriveAction(driveAction);
     }
 
     @Override
@@ -185,31 +163,6 @@ public class Ev3ValidatorAndCollectorVisitor extends CommonNepoValidatorAndColle
     public Void visitLightStatusAction(LightStatusAction<Void> lightStatusAction) {
         usedHardwareBuilder.addUsedActor(new UsedActor(lightStatusAction.getUserDefinedPort(), SC.LIGHT));
         return null;
-    }
-
-    @Override
-    public Void visitMotorDriveStopAction(MotorDriveStopAction<Void> stopAction) {
-        return differentialMotorValidatorAndCollectorVisitor.visitMotorDriveStopAction(stopAction);
-    }
-
-    @Override
-    public Void visitMotorGetPowerAction(MotorGetPowerAction<Void> motorGetPowerAction) {
-        return differentialMotorValidatorAndCollectorVisitor.visitMotorGetPowerAction(motorGetPowerAction);
-    }
-
-    @Override
-    public Void visitMotorOnAction(MotorOnAction<Void> motorOnAction) {
-        return differentialMotorValidatorAndCollectorVisitor.visitMotorOnAction(motorOnAction);
-    }
-
-    @Override
-    public Void visitMotorSetPowerAction(MotorSetPowerAction<Void> motorSetPowerAction) {
-        return differentialMotorValidatorAndCollectorVisitor.visitMotorSetPowerAction(motorSetPowerAction);
-    }
-
-    @Override
-    public Void visitMotorStopAction(MotorStopAction<Void> motorStopAction) {
-        return differentialMotorValidatorAndCollectorVisitor.visitMotorStopAction(motorStopAction);
     }
 
     @Override
@@ -288,11 +241,6 @@ public class Ev3ValidatorAndCollectorVisitor extends CommonNepoValidatorAndColle
         checkSensorPort(touchSensor);
         usedHardwareBuilder.addUsedSensor(new UsedSensor(touchSensor.getUserDefinedPort(), SC.TOUCH, touchSensor.getMode()));
         return null;
-    }
-
-    @Override
-    public Void visitTurnAction(TurnAction<Void> turnAction) {
-        return differentialMotorValidatorAndCollectorVisitor.visitTurnAction(turnAction);
     }
 
     @Override


### PR DESCRIPTION
Also added DifferentialMotorValidatorAndCollectorVisitor for new configurations and moved old DifferentialMotorValidatorEV3 to the EV3 plugin.

This change is important for the validators of new robot Systems with the new configuration, which use a differential drive block  at the moment that is mBot2 and ORB.

## Type of change

Refactor

# How Has This Been Tested?

Tested EV3 validators as its the only system that should be affected, also successfully ran Integration tests.
It is also used in  the feature/mBot2 branch without any issues.

