### PR TITLE
#1195: Fix simulation not working on IE 11

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/nepostackmachine/interpreter.state.js
+++ b/OpenRobertaServer/staticResources/js/app/nepostackmachine/interpreter.state.js
@@ -1,3 +1,10 @@
+var __spreadArrays = (this && this.__spreadArrays) || function () {
+    for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+    for (var r = Array(s), k = 0, i = 0; i < il; i++)
+        for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+            r[k] = a[j];
+    return r;
+};
 define(["require", "exports", "./interpreter.constants", "./interpreter.util"], function (require, exports, C, U) {
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.State = void 0;
@@ -231,8 +238,7 @@ define(["require", "exports", "./interpreter.constants", "./interpreter.util"], 
          * @param breakPoints the array of breakpoint block id's to have their highlights added*/
         State.prototype.addHighlights = function (breakPoints) {
             var _this = this;
-            Array.from(this.currentBlocks)
-                .map(function (blockId) { return stackmachineJsHelper.getBlockById(blockId); })
+            __spreadArrays(this.currentBlocks).map(function (blockId) { return stackmachineJsHelper.getBlockById(blockId); })
                 .forEach(function (block) { return _this.highlightBlock(block); });
             breakPoints.forEach(function (id) {
                 var block = stackmachineJsHelper.getBlockById(id);
@@ -250,8 +256,7 @@ define(["require", "exports", "./interpreter.constants", "./interpreter.util"], 
          * @param breakPoints the array of breakpoint block id's to have their highlights removed*/
         State.prototype.removeHighlights = function (breakPoints) {
             var _this = this;
-            Array.from(this.currentBlocks)
-                .map(function (blockId) { return stackmachineJsHelper.getBlockById(blockId); })
+            __spreadArrays(this.currentBlocks).map(function (blockId) { return stackmachineJsHelper.getBlockById(blockId); })
                 .forEach(function (block) {
                 var object = stackmachineJsHelper.getJqueryObject(block);
                 if (object.hasClass('selectedBreakpoint')) {

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.ev3.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.ev3.js
@@ -245,11 +245,13 @@ define(["require", "exports", "simulation.simulation", "interpreter.constants", 
             timer5: false,
         };
         var SpeechSynthesis = window.speechSynthesis;
-        //cancel needed so speak works in chrome because it's created already speaking
-        SpeechSynthesis.cancel();
         if (!SpeechSynthesis) {
             context = null;
             console.log('Sorry, but the Speech Synthesis API is not supported by your browser. Please, consider upgrading to the latest version or downloading Google Chrome or Mozilla Firefox');
+        }
+        else {
+            //cancel needed so speak works in chrome because it's created already speaking
+            SpeechSynthesis.cancel();
         }
         this.sayText = {
             language: 'en-US',

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
@@ -148,7 +148,7 @@ define(["require", "exports", "simulation.scene", "simulation.constants", "util"
         var moduleName = 'simulation.robot.' + simRobotType;
         removeMouseEvents();
         resetSelection();
-        new Promise(function (resolve_1, reject_1) { require([moduleName], resolve_1, reject_1); }).then(function (ROBOT) {
+        require([moduleName], function (ROBOT) {
             createRobots(ROBOT.default, numRobots);
             for (var i = 0; i < robots.length; i++) {
                 robots[i].debug = debug;
@@ -499,7 +499,7 @@ define(["require", "exports", "simulation.scene", "simulation.constants", "util"
         if (currentBackground > 1) {
             if (isIE() || isEdge()) {
                 // TODO IE and Edge: Input event not firing for file type of input
-                $('.dropdown.sim, .simScene').show();
+                $('.dropdown.sim, .simScene, #simEditButtons').show();
                 $('#simImport').hide();
             }
             else {
@@ -523,7 +523,8 @@ define(["require", "exports", "simulation.scene", "simulation.constants", "util"
             robots = [];
             readyRobots = [];
             isDownRobots = [];
-            new Promise(function (resolve_2, reject_2) { require(['simulation.robot.' + simRobotType], resolve_2, reject_2); }).then(function (reqRobot) {
+            var moduleName = 'simulation.robot.' + simRobotType;
+            require([moduleName], function (reqRobot) {
                 createRobots(reqRobot.default, numRobots);
                 for (var i = 0; i < numRobots; i++) {
                     robots[i].reset();

--- a/OpenRobertaWeb/src/app/nepostackmachine/interpreter.state.ts
+++ b/OpenRobertaWeb/src/app/nepostackmachine/interpreter.state.ts
@@ -272,7 +272,7 @@ export class State {
     /** Will add highlights from all currently blocks being currently executed and all given Breakpoints
      * @param breakPoints the array of breakpoint block id's to have their highlights added*/
     public addHighlights(breakPoints: any[]) {
-        Array.from(this.currentBlocks)
+        [...this.currentBlocks]
             .map((blockId) => stackmachineJsHelper.getBlockById(blockId))
             .forEach((block) => this.highlightBlock(block));
 
@@ -291,7 +291,7 @@ export class State {
     /** Will remove highlights from all currently blocks being currently executed and all given Breakpoints
      * @param breakPoints the array of breakpoint block id's to have their highlights removed*/
     public removeHighlights(breakPoints: any[]) {
-        Array.from(this.currentBlocks)
+        [...this.currentBlocks]
             .map((blockId) => stackmachineJsHelper.getBlockById(blockId))
             .forEach((block) => {
                 let object = stackmachineJsHelper.getJqueryObject(block);

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/robot.ev3.js
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/robot.ev3.js
@@ -251,13 +251,14 @@ function Ev3(pose, configuration, num, robotBehaviour) {
         timer5: false,
     };
     var SpeechSynthesis = window.speechSynthesis;
-    //cancel needed so speak works in chrome because it's created already speaking
-    SpeechSynthesis.cancel();
     if (!SpeechSynthesis) {
         context = null;
         console.log(
             'Sorry, but the Speech Synthesis API is not supported by your browser. Please, consider upgrading to the latest version or downloading Google Chrome or Mozilla Firefox'
         );
+    } else {
+        //cancel needed so speak works in chrome because it's created already speaking
+        SpeechSynthesis.cancel();
     }
     this.sayText = {
         language: 'en-US',

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.js
@@ -169,7 +169,7 @@ function setBackground(num) {
 
     removeMouseEvents();
     resetSelection();
-    import(moduleName).then(function (ROBOT) {
+    require([moduleName], function (ROBOT) {
         createRobots(ROBOT.default, numRobots);
         for (var i = 0; i < robots.length; i++) {
             robots[i].debug = debug;
@@ -532,7 +532,7 @@ function init(programs, refresh, robotType) {
     if (currentBackground > 1) {
         if (isIE() || isEdge()) {
             // TODO IE and Edge: Input event not firing for file type of input
-            $('.dropdown.sim, .simScene').show();
+            $('.dropdown.sim, .simScene, #simEditButtons').show();
             $('#simImport').hide();
         } else {
             $('.dropdown.sim, .simScene, #simImport, #simResetPose, #simEditButtons').show();
@@ -556,7 +556,8 @@ function init(programs, refresh, robotType) {
         robots = [];
         readyRobots = [];
         isDownRobots = [];
-        import('simulation.robot.' + simRobotType).then(function (reqRobot) {
+        var moduleName = 'simulation.robot.' + simRobotType;
+        require([moduleName], function (reqRobot) {
             createRobots(reqRobot.default, numRobots);
             for (var i = 0; i < numRobots; i++) {
                 robots[i].reset();


### PR DESCRIPTION
# Description

This PR implements the following changes:
* Replace Array.from() with spread syntax.
* Replace dynamic imports with require() and callback.
* Add simEditButtons to list of divs to be shown in case of IE.
* Add else block for SpeechSynthesis.cancel().

Note: Array.from() and dynamic imports (which return a Promise object) are not compatible with IE. Transpiled ts code was thus erroneous for use with IE.

Fixes #1195 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Internet Explorer 11 on following (remote) Windows machines:
- Windows 7
- Windows 8.1
- Windows 10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes