### PR TITLE
Issue #1068: fix inconsistent size of help window, formatting of help…

### DIFF
--- a/OpenRobertaServer/staticResources/help/progHelp_arduino_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_arduino_de.html
@@ -1,427 +1,1612 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start_ardu" class="help beginner"><h3 id="ProgrammierBlöckeArduino-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am »Wiederhole unendlich oft«-Block.</p><p>Für Systeme, die auf einem Arduino oder einem ähnlichen Mikrocontroller basieren, ist hier immer eine »Wiederhole unendlich oft«-Schleife mit dem Start-Block verbunden, die ebenfalls nicht entfernt werden kann. Dies liegt daran, dass solche Mikrocontroller meistens für genau eine Aufgabe programmiert werden, die dann immer wieder ausgeführt werden soll. Wenn du nur einen Durchlauf des Programm möchtest, kannst du den Roboter am Ende der Schleife einfach für eine sehr lange Zeit warten lassen.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
-</ul><br><p>Wenn globale Variablen erzeugt wurden:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variablen.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
-</ul><br></div><div id="robActions_motor_on_for_ardu" class="help expert"><h3 id="ProgrammierBlöckeArduino-»ServomotorSG90...Setzean°«"><span style="color: rgb(0,0,0);">»Servomotor SG90 ... Setze an°« </span></h3><p>Mit dem Block »Servormotor SG90 ... Setze an°« programmierst du die Position eines Servomotors in Grad. Der Servomotor fährt dann in die entsprechende Position.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor Port, wähle einen Servomotor aus, den du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-left">Gradzahl, in die der Motor bewegt werden soll.</li>
-</ul><br></div><div id="robActions_motor_on_for" class="help expert"><h3 id="ProgrammierBlöckeArduino-»Motor28BYJ-48Port...anrpm...fürUmdrehungen/Grad...«"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Motor 28BYJ-48 Port ... an  rpm ... für Umdrehungen/Grad ...«</span><br></span></h3><p>Mit dem Block »Motor 28BYJ-48 Port ... an rpm ... für ... Umdrehungen/Grad« stellst du die Geschwindigkeit und Anzahl der Umdrehungen ein, die sich der Motor drehen soll. Dein Roboter startet den gewählten Motor, bis er die eingestellte Anzahl Umdrehungen bzw. Winkelgrade gemacht hat.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor Port, wähle einen Schrittmotor aus, den du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-left">Tempo, dreht sich der Motor rückwärts.</li><li class="typcn typcn-arrow-sorted-down">Umdrehungen oder Grad. 1 Umdrehung entspricht 360 Grad.</li><li class="typcn typcn-arrow-left">Zahl, Anzahl der Umdrehungen bzw. Winkelgrade. Es sind nur positive Zahlen zugelassen.</li>
-</ul><br></div><div id="robActions_set_relay" class="help expert"><h3 id="ProgrammierBlöckeArduino-»SchalteRelaisSRD-05VDC-SL-C...an/aus«"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Schalte Relais  SRD-05VDC-SL-C ... an/aus«</span><br></span></h3><p>Mit dem Block »Schalte Relais SRD-05VDC-SL-C ... an/aus« kannst du ein Relais an einem bestimmten Pin steuern.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle ein Relais aus, das du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-sorted-down">an/aus, wähle ob das Relais ein- oder ausgeschaltet werden soll.</li>
-</ul><br></div><div id="robActions_serial_print" class="help beginner"><h3 id="ProgrammierBlöckeArduino-»ZeigeaufSerialMonitor...«">»Zeige auf Serial Monitor ...«</h3><p>Mit dem Block »Zeige auf Serial Monitor ...« kannst du Text und Zahlen über die serielle Schnittstelle deines Roboters versenden. Du kannst dir die Ausgaben der seriellen Schnittstelle im USB-Programm anschauen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, der über die serielle Schnittstelle ausgegeben werden soll.</li>
-</ul></div><div id="robActions_display_text" class="help expert"><h3 id="ProgrammierBlöckeArduino-»LCD1602...«"><span style="color: rgb(85,85,85);">»LCD 1602 ...«</span></h3><p>Mit dem Block »LCD 1602 ...« kannst du Text und Zahlen auf einem LCD 1602 anzeigen lassen. Dabei kannst du zusätzlich noch bestimmen, in welcher Spalte und in welcher Zeile der Text auf dem LCD erscheinen soll.</p><p>Das Display ist für Texte in mehreren Zeilen (von links nach rechts) und Spalten (von oben nach unten) eingeteilt. Die Zählung beginnt jeweils bei 0.</p><p>Wenn zuvor schon etwas auf dem Display angezeigt war, werden nur die Stellen überschrieben, in die der Text geschrieben wird.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 aus, das du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li><li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li><li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
-</ul></div><div id="robActions_display_clear" class="help expert"><h3 style="letter-spacing: normal;" id="ProgrammierBlöckeArduino-»LöscheBildschirmLCD1602«">»Lösche Bildschirm LCD 1602«</h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »Lösche Bildschirm« kannst du Text und Zahlen auf dem LCD 1602 löschen. Das Display ist anschließend leer.
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 aus, das du in der Roboterkonfiguration angelegt hast.</li>
-</ul></div><div id="robActions_display_text_i2c" class="help beginner"><h3 style="letter-spacing: normal;" id="ProgrammierBlöckeArduino-»LCD1602I²C...«">»LCD 1602 I²C ...«</h3><p>Mit dem Block »LCD 1602 I²C« kannst du Text und Zahlen auf einem über den I²C-Bus angeschlossenen LCD 1602 anzeigen lassen. Dabei kannst du zusätzlich noch bestimmen, in welcher Spalte und in welcher Zeile der Text auf dem LCD erscheinen soll.</p><p>Das Display ist für Texte in mehreren Zeilen (von links nach rechts) und Spalten (von oben nach unten) eingeteilt. Die Zählung beginnt jeweils bei 0.</p><p>Wenn zuvor schon etwas auf dem Display angezeigt war, werden nur die Stellen überschrieben, in die der Text geschrieben wird.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 I²C aus, das du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li><li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li><li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
-</ul></div><div id="robActions_display_clear_i2c" class="help beginner"><h3 id="ProgrammierBlöckeArduino-»LöscheBildschirmLCD1602I²C«">»Lösche Bildschirm LCD 1602 I²C«</h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »Lösche Bildschirm LCD 1602 I²C« kannst du Text und Zahlen auf dem LCD 1602 löschen, der über den I²C Bus angeschlossen ist. Das Display ist anschließend leer.
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 I²C aus, das du in der Roboterkonfiguration angelegt hast.</li>
-</ul></div><div id="robActions_play_tone" class="help beginner"><h3 id="ProgrammierBlöckeArduino-»Spiele...FrequenzHz...Dauerms«">»Spiele ... Frequenz Hz ... Dauer ms«</h3><p>Mit dem Block »Spiele Frequenz Hz... Dauer ms« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie lange der Ton gespielt wird) programmieren. Der Ton wird über einen an den Arduino angeschlossenen Lautsprecher abgespielt, bis die eingestellte Dauer erreicht ist.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Bitte beachte, dass das menschliche Gehör Frequenzen zwischen ca. 30 Hz bis ca. 15.000 Hz (15 kHz) wahrnehmen kann - je nach Mensch und Alter kann dies unterschiedlich sein.</p></div></div><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Summer aus, den du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-left">Zahl, gewünschte Frequenz in Hz (Hertz) eingeben.</li><li class="typcn typcn-arrow-left"> Zahl, gewünschte Dauer des Tons in Millisekunden (ms) eingeben.</li>
-</ul></div><div id="robActions_brickLight_on" class="help beginner"><h3 style="letter-spacing: normal;" id="ProgrammierBlöckeArduino-»LED...an/aus«">»LED ... an/aus«</h3><p><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »LED ... an/aus« kannst du die eine an deinen Arduino angeschlossene LED ein- oder ausschalten.</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle eine LED aus, die du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-sorted-down">Option, An/aus, wähle aus, ob du die LED ein- oder ausschalten möchtest.</li>
-</ul><br></div><div id="robActions_led_on" class="help expert"><h3 style="letter-spacing: normal;" id="ProgrammierBlöckeArduino-»SetzeLEDan...Farbe«">»Setze LED an ... Farbe« </h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block "Setze LED an ... Farbe" kannst du eine an deinen Arduino angeschlossene Farb-LED mit einer bestimmten Farbe einschalten.</p><p style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle eine RGB LED aus, die du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-left">Farbe, wähle dir Farbe  aus, in der die LED leuchten soll.</li>
-</ul></div><div id="robActions_led_off" class="help expert"><h3 style="letter-spacing: normal;" id="ProgrammierBlöckeArduino-»SchalteLEDaus...«">»Schalte LED aus ...«</h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »Schalte LED aus ...« kannst du die eine an deinen Arduino angeschlossene Farb-LED ausschalten.
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle eine RGB LED aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul></div><div id="robActions_write_pin" class="help beginner"><h3 id="ProgrammierBlöckeArduino-»Schreibedigitalen/analogenWertAktor...«">»Schreibe digitalen/analogen Wert Aktor ...«</h3><p>Mit dem Block »Schreibe analogen/digitalen Wert Aktor ...« kannst du einen analogen oder digitalen Wert auf einen Pin deines Arduino schreiben. </p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">analog/digital, wähle aus ob du einen digitalen oder analogen Wert schreiben willst.</li><li class="typcn typcn-arrow-sorted-down">Pin, wähle den Pin aus auf den du schreiben möchtest.</li><li class="typcn typcn-arrow-left">Zahl, Wert der geschrieben werden soll.</li>
-</ul><br></div><div id="robSensors_out_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeArduino-»gibanalogen/digitalenWertSensor...«">»gib analogen/digitalen Wert Sensor...«</h3><p>Mit dem Block »gib analogen/digitalen Wert Sensor...« kannst du einem anderen Block »mitteilen«, welcher analoge oder digitale Wert an einem Sensor deines Arduino anliegt.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»analog« oder »digital«. Stelle ein, wie der welche Art der zu messende Wert hat.</li><li class="typcn typcn-arrow-sorted-down">Pin, wähle einen Pin aus.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Wert der an dem Pin anliegt.</li>
-</ul><br> </div><div id="robSensors_timer_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeArduino-»GibWertmsZeitgeber«">»Gib Wert ms Zeitgeber«</h3><p>Mit dem Block »Gib Wert Zeitgeber« kannst du einem anderen Block den aktuellen Stand des internen Zeitgebers in Millisekunden »mitteilen«. Der Zeitgeber wird automatisch mit dem Beginn eines Programms gestartet.</p><p>Einstellöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zeitgeber-Nummer, wähle den Zeitgeber aus, dessen Wert du ermitteln möchtest.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl Millisekunden, die seit dem Programmstart oder dem letzten Zurücksetzen des Zeitgebers vergangen sind.</li>
-</ul><br></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="ProgrammierBlöckeArduino-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück«</h3><p>Mit dem Block »Setze Zeitgeber ... zurück« können die internen Zeitgeber auf den Wert 0 zurückgesetzt werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zeitgeber-Nummer, wähle den Zeitgeber aus, den du zurücksetzen möchtest.</li>
-</ul><br></div><div id="robSensors_key_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeArduino-»Taste...gedrückt?«">»Taste ... gedrückt?«</h3><p>Mit dem Block »Taste ... gedrückt?« kannst du einem anderen Block »mitteilen« , ob die ausgewählte Taste gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>true = gedrückt</em> oder <em>false = nicht gedrückt</em> zurück.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle eine Taste aus, die du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><br>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »true«, wenn die gewählte Taste gedrückt ist, sonst »false«.</li>
-</ul> </div><div id="robSensors_motion_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeArduino-»gibAnwesenheitBewegungssensorHC-SR501...«">»gib Anwesenheit Bewegungssensor HC-SR501...«</h3><p>Mit dem Block »gib Anwesenheit Bewegungssensor ...« kannst du einem anderen Block »mitteilen« , ob der Bewegungssensor eine Bewegung wahrnimmt oder nicht.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, wähle einen Bewegungssensor aus, den du in der Roboterkonfiguration angelegt hast.<br></span></li>
-</ul><br><p><br>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »true«, wenn eine Bewegung wahrgenommen wird, sonst »false«.</li>
-</ul> </div><div id="robSensors_light_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeArduino-»gibLicht%Lichtsensor...«">»gib Licht % Lichtsensor ...«</h3><p>Mit dem Block »gib Licht % Lichtsensor ...« kannst du einem anderen Block »mitteilen«, welchen Helligkeitswert zwischen 0 und 100 der Lichtsensor misst.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Lichtsensor aus, den du in der Roboterkonfiguration erstellt hast.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Helligkeitswert in %<span>.</span></li>
-</ul><br> </div><div id="robSensors_infrared_getSample" class="help expert">  <h3 id="ProgrammierBlöckeArduino-»GibAbstand/AnwesenheitInfrarotsensor...«">»Gib Abstand/Anwesenheit Infrarotsensor ...«</h3><p>Mit dem Block »Gib Abstand/Anwesenheit Infrarotsensor ...« kannst du einem anderen Block »mitteilen«, welchen Abstand der Infrarotsensor misst.</p><p>Im Modus »Abstand« wird der Abstand als Zahl übermittelt.</p><p>Im Modus »Anwesenheit« gibt der Sensor an, ob Infrarot empfangen wird oder nicht.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Ein exakte Messung der Abstände in cm ist mit dem Infrarotsensor nicht möglich. Die gemessenen Abstände sind also ungefähre Werte.</p></div></div><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»Abstand« oder »Anwesenheit«. Stelle ein, wie der Infrarotsensor messen soll.</li><li class="typcn typcn-arrow-sorted-down">Port, wähle einen Infrarotsensor aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, bei »Abstand«, maximaler Abstand 70 cm.</p><p>Logischer Wert, bei »Anwesenheit«;<span> »Wahr« wenn Infrarot empfangen wird und <span> »Falsch« wenn nicht</span></span> .</p></li>
-</ul><br> </div><div id="robSensors_temperature_getSample" class="help expert">  <h3 id="ProgrammierBlöckeArduino-»gibWert°TemperatursensorTMP36...«">»gib Wert ° Temperatursensor TMP36...«</h3><p>Mit dem Block »gib Wert ° Temperatursensor ...« kannst du einem anderen Block »mitteilen« , welche Temperatur durch den Temperatursensor gemessen wird.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Temperatursensor aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><br>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die vom Sensor gemessene Temperatur in Grad Celsius.</li>
-</ul><br> </div><div id="robSensors_humidity_getSample" class="help expert"> <h3 id="ProgrammierBlöckeArduino-»gibWert%LuftfeuchtigkeitsensorDHT11...«">»gib Wert % Luftfeuchtigkeitsensor DHT11...«</h3><p>Mit dem Block »gib Wert % Luftfeuchtigkeitsensor ...« kannst du einem anderen Block »mitteilen«, wie hoch die Luftfeuchtigkeit zwischen 0% und 100% ist, die der Luftfeuchtigkeitssensor misst.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Luftfeuchtigkeitsensor aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Luftfeuchtigkeit in %.</li>
-</ul><br> </div><div id="robSensors_drop_getSample" class="help expert"> <h3 id="ProgrammierBlöckeArduino-»gibWert%Tropfsensor...«">»gib Wert % Tropfsensor...«</h3><p>Mit dem Block »gib Wert % Tropfsensor ...« kannst du einem anderen Block »mitteilen«, wie hoch die nass der Tropfsensor zwischen 0% und 100% ist.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Tropfensensor aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Nässe in %.</li>
-</ul><br> </div><div id="robSensors_pulse_getSample" class="help expert"> <h3 id="ProgrammierBlöckeArduino-»gibWertPulssensor...«">»gib Wert Pulssensor...«</h3><p>Mit dem Block »gib Wert Pulssensor ...« kannst du einem anderen Block »mitteilen«, wie hoch der Puls der Person ist, bei der der Sensor verwendet wird.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Pulssensor aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gemessener Puls.</li>
-</ul><br> </div><div id="robSensors_potentiometer_getSample" class="help expert"><h3 id="ProgrammierBlöckeArduino-»GibWertVPotentiometer...«">»Gib Wert V Potentiometer ...«</h3><p>Mit dem Block »Gib Wert V Potentiometer ...« kannst du einem anderen Block »mitteilen«, auf welchen Wert in Volt das an deinen Arduino angeschlossene Potentiometer eingestellt ist.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle ein Potentiometer aus, das du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Spannung in Volt, auf die das Potentiometer eingestellt ist.</li>
-</ul><br></div><div id="robSensors_moisture_getSample" class="help expert"> <h3 id="ProgrammierBlöckeArduino-»gibWert%Feuchtigkeitssensor...«">»gib Wert % Feuchtigkeitssensor ...«</h3><p>Mit dem Block »gib Wert % Feuchtigkeitssensor ...« kannst du einem anderen Block »mitteilen«, wie hoch die Feuchtigkeit zwischen 0 und 100 ist, die der Feuchtigkeitssensor misst.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Feuchtigkeitsensor aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Feuchtigkeit in %<span>.</span></li>
-</ul><br> </div><div id="robSensors_ultrasonic_getSample" class="help expert"> <h3 id="ProgrammierBlöckeArduino-»gibAbstandcmUltraschallHC-SR04...«">»gib Abstand cm Ultraschall HC-SR04 ...«</h3><p>Mit dem Block »gib Abstand cm Ultraschall HC-SR04 ...« kannst du einem anderen Block »mitteilen«,  welcher Abstand in cm von dem Ultraschallsensor gemessen wird.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Ultraschallsensor HS-SR04 aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Abstand in cm</li>
-</ul><br> </div><div id="robSensors_rfid_getSample" class="help expert"> <h3 id="ProgrammierBlöckeArduino-»gibID/AnwesenheitRFID-RC522Reader...«">»gib ID/Anwesenheit RFID-RC522 Reader...«</h3><p>Mit dem Block »gib ID/Anwesenheit RFID-RC522 Reader ...« kannst du einem anderen Block »mitteilen«, welche UID (Unique Identification Number) ein RFID-Tag hat, dass du an den Sensor hälst oder ob ein RFID-Tag erkannt wurde.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»ID« oder »Anwesenheit«. Stelle ein, wie der Infrarotsensor messen soll.</li><li class="typcn typcn-arrow-sorted-down">Port, wähle einen RFID Reader aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Text,<span> bei »Kartenserie«;</span> UID des RFID-Tags.</p><p><span>Logischer Wert, bei »Anwesenheit«;</span><span> »Wahr« wenn ein RFID-Tag erkannt wird und »Falsch« wenn nicht</span><span> .</span></p></li>
-</ul><br> </div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammierBlöckeArduino-»Wartebis...«">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wartems...«">»Warte ms ... «</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wartebis...«.1">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Zufallszahl«">»Zufallszahl« </h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeArduino-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeArduino-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt werden soll. Zahl zwischen 0 und 255.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeArduino-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von der verwendeten Programmiersprache des Roboters abhängt. </span><span style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt, sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der Zeichenkette »52abcd« die Zahl 52.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeArduino-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li><li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte das die Nummerierung bei 0 anfängt.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeArduino-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeArduino-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeArduino-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeArduino-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeArduino-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeArduino-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeArduino-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="ProgrammierBlöckeArduino-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammierBlöckeArduino-»Farbwahl«">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammierBlöckeArduino-»Farbwahl«.1">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammierBlöckeArduino-»Farbwahl«.2">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierBlöckeArduino-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, die  Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierBlöckeArduino-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 class="auto-cursor-target" id="ProgrammierBlöckeArduino-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammierBlöckeArduino-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="ProgrammierBlöckeArduino-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammierBlöckeArduino-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammierBlöckeArduino-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammierBlöckeArduino-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="ProgrammierBlöckeArduino-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="ProgrammierBlöckeArduino-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammierBlöckeArduino-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen Wert zurück.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierBlöckeArduino-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit Rückgabewert «</h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start_ardu" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den
+                man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am »Wiederhole unendlich
+                oft«-Block.</p>
+            <p>Für Systeme, die auf einem Arduino oder einem ähnlichen Mikrocontroller basieren, ist hier immer eine
+                »Wiederhole unendlich oft«-Schleife mit dem Start-Block verbunden, die ebenfalls nicht entfernt werden
+                kann. Dies liegt daran, dass solche Mikrocontroller meistens für genau eine Aufgabe programmiert werden,
+                die dann immer wieder ausgeführt werden soll. Wenn du nur einen Durchlauf des Programm möchtest, kannst
+                du den Roboter am Ende der Schleife einfach für eine sehr lange Zeit warten lassen.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
+            </ul><br>
+            <p>Wenn globale Variablen erzeugt wurden:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variablen.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on_for_ardu" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»ServomotorSG90...Setzean°«"><span style="color: rgb(0,0,0);">»Servomotor
+                    SG90 ... Setze an°« </span></h3>
+            <p>Mit dem Block »Servormotor SG90 ... Setze an°« programmierst du die Position eines Servomotors in Grad.
+                Der Servomotor fährt dann in die entsprechende Position.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor Port, wähle einen Servomotor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+                <li class="typcn typcn-arrow-left">Gradzahl, in die der Motor bewegt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on_for" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»Motor28BYJ-48Port...anrpm...fürUmdrehungen/Grad...«"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Motor 28BYJ-48 Port ... an rpm ...
+                        für Umdrehungen/Grad ...«</span><br></span></h3>
+            <p>Mit dem Block »Motor 28BYJ-48 Port ... an rpm ... für ... Umdrehungen/Grad« stellst du die
+                Geschwindigkeit und Anzahl der Umdrehungen ein, die sich der Motor drehen soll. Dein Roboter startet den
+                gewählten Motor, bis er die eingestellte Anzahl Umdrehungen bzw. Winkelgrade gemacht hat.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor Port, wähle einen Schrittmotor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+                <li class="typcn typcn-arrow-left">Tempo, dreht sich der Motor rückwärts.</li>
+                <li class="typcn typcn-arrow-sorted-down">Umdrehungen oder Grad. 1 Umdrehung entspricht 360 Grad.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anzahl der Umdrehungen bzw. Winkelgrade. Es sind nur positive
+                    Zahlen zugelassen.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_set_relay" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»SchalteRelaisSRD-05VDC-SL-C...an/aus«"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Schalte Relais SRD-05VDC-SL-C ...
+                        an/aus«</span><br></span></h3>
+            <p>Mit dem Block »Schalte Relais SRD-05VDC-SL-C ... an/aus« kannst du ein Relais an einem bestimmten Pin
+                steuern.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle ein Relais aus, das du in der Roboterkonfiguration
+                    angelegt hast.</li>
+                <li class="typcn typcn-arrow-sorted-down">an/aus, wähle ob das Relais ein- oder ausgeschaltet werden
+                    soll.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_serial_print" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»ZeigeaufSerialMonitor...«">»Zeige auf Serial Monitor ...«</h3>
+            <p>Mit dem Block »Zeige auf Serial Monitor ...« kannst du Text und Zahlen über die serielle Schnittstelle
+                deines Roboters versenden. Du kannst dir die Ausgaben der seriellen Schnittstelle im USB-Programm
+                anschauen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, der über die serielle Schnittstelle ausgegeben werden soll.
+                </li>
+            </ul>
+        </div>
+        <div id="robActions_display_text" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»LCD1602...«"><span style="color: rgb(85,85,85);">»LCD 1602 ...«</span>
+            </h3>
+            <p>Mit dem Block »LCD 1602 ...« kannst du Text und Zahlen auf einem LCD 1602 anzeigen lassen. Dabei kannst
+                du zusätzlich noch bestimmen, in welcher Spalte und in welcher Zeile der Text auf dem LCD erscheinen
+                soll.</p>
+            <p>Das Display ist für Texte in mehreren Zeilen (von links nach rechts) und Spalten (von oben nach unten)
+                eingeteilt. Die Zählung beginnt jeweils bei 0.</p>
+            <p>Wenn zuvor schon etwas auf dem Display angezeigt war, werden nur die Stellen überschrieben, in die der
+                Text geschrieben wird.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 aus, das du in der
+                    Roboterkonfiguration angelegt hast.</li>
+                <li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear" class="help expert">
+            <h3 style="letter-spacing: normal;" id="ProgrammierBlöckeArduino-»LöscheBildschirmLCD1602«">»Lösche
+                Bildschirm LCD 1602«</h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »Lösche
+                Bildschirm« kannst du Text und Zahlen auf dem LCD 1602 löschen. Das Display ist anschließend leer.
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 aus, das du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_text_i2c" class="help beginner">
+            <h3 style="letter-spacing: normal;" id="ProgrammierBlöckeArduino-»LCD1602I²C...«">»LCD 1602 I²C ...«</h3>
+            <p>Mit dem Block »LCD 1602 I²C« kannst du Text und Zahlen auf einem über den I²C-Bus angeschlossenen LCD
+                1602 anzeigen lassen. Dabei kannst du zusätzlich noch bestimmen, in welcher Spalte und in welcher Zeile
+                der Text auf dem LCD erscheinen soll.</p>
+            <p>Das Display ist für Texte in mehreren Zeilen (von links nach rechts) und Spalten (von oben nach unten)
+                eingeteilt. Die Zählung beginnt jeweils bei 0.</p>
+            <p>Wenn zuvor schon etwas auf dem Display angezeigt war, werden nur die Stellen überschrieben, in die der
+                Text geschrieben wird.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 I²C aus, das du in der
+                    Roboterkonfiguration angelegt hast.</li>
+                <li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear_i2c" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»LöscheBildschirmLCD1602I²C«">»Lösche Bildschirm LCD 1602 I²C«</h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »Lösche
+                Bildschirm LCD 1602 I²C« kannst du Text und Zahlen auf dem LCD 1602 löschen, der über den I²C Bus
+                angeschlossen ist. Das Display ist anschließend leer.
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 I²C aus, das du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul>
+        </div>
+        <div id="robActions_play_tone" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»Spiele...FrequenzHz...Dauerms«">»Spiele ... Frequenz Hz ... Dauer ms«</h3>
+            <p>Mit dem Block »Spiele Frequenz Hz... Dauer ms« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie
+                lange der Ton gespielt wird) programmieren. Der Ton wird über einen an den Arduino angeschlossenen
+                Lautsprecher abgespielt, bis die eingestellte Dauer erreicht ist.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Bitte beachte, dass das menschliche Gehör Frequenzen zwischen ca. 30 Hz bis ca. 15.000 Hz (15
+                        kHz) wahrnehmen kann - je nach Mensch und Alter kann dies unterschiedlich sein.</p>
+                </div>
+            </div>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Summer aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+                <li class="typcn typcn-arrow-left">Zahl, gewünschte Frequenz in Hz (Hertz) eingeben.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, gewünschte Dauer des Tons in Millisekunden (ms) eingeben.</li>
+            </ul>
+        </div>
+        <div id="robActions_brickLight_on" class="help beginner">
+            <h3 style="letter-spacing: normal;" id="ProgrammierBlöckeArduino-»LED...an/aus«">»LED ... an/aus«</h3>
+            <p><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »LED ... an/aus«
+                    kannst du die eine an deinen Arduino angeschlossene LED ein- oder ausschalten.</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle eine LED aus, die du in der Roboterkonfiguration
+                    angelegt hast.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, An/aus, wähle aus, ob du die LED ein- oder ausschalten
+                    möchtest.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_led_on" class="help expert">
+            <h3 style="letter-spacing: normal;" id="ProgrammierBlöckeArduino-»SetzeLEDan...Farbe«">»Setze LED an ...
+                Farbe« </h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block "Setze
+                LED an ... Farbe" kannst du eine an deinen Arduino angeschlossene Farb-LED mit einer bestimmten Farbe
+                einschalten.</p>
+            <p style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle eine RGB LED aus, die du in der
+                    Roboterkonfiguration angelegt hast.</li>
+                <li class="typcn typcn-arrow-left">Farbe, wähle dir Farbe aus, in der die LED leuchten soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_off" class="help expert">
+            <h3 style="letter-spacing: normal;" id="ProgrammierBlöckeArduino-»SchalteLEDaus...«">»Schalte LED aus ...«
+            </h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block
+                »Schalte LED aus ...« kannst du die eine an deinen Arduino angeschlossene Farb-LED ausschalten.
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle eine RGB LED aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul>
+        </div>
+        <div id="robActions_write_pin" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»Schreibedigitalen/analogenWertAktor...«">»Schreibe digitalen/analogen Wert
+                Aktor ...«</h3>
+            <p>Mit dem Block »Schreibe analogen/digitalen Wert Aktor ...« kannst du einen analogen oder digitalen Wert
+                auf einen Pin deines Arduino schreiben. </p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">analog/digital, wähle aus ob du einen digitalen oder analogen
+                    Wert schreiben willst.</li>
+                <li class="typcn typcn-arrow-sorted-down">Pin, wähle den Pin aus auf den du schreiben möchtest.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert der geschrieben werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_out_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»gibanalogen/digitalenWertSensor...«">»gib analogen/digitalen Wert
+                Sensor...«</h3>
+            <p>Mit dem Block »gib analogen/digitalen Wert Sensor...« kannst du einem anderen Block »mitteilen«, welcher
+                analoge oder digitale Wert an einem Sensor deines Arduino anliegt.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»analog« oder »digital«. Stelle ein, wie der welche Art der zu
+                    messende Wert hat.</li>
+                <li class="typcn typcn-arrow-sorted-down">Pin, wähle einen Pin aus.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Wert der an dem Pin anliegt.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»GibWertmsZeitgeber«">»Gib Wert ms Zeitgeber«</h3>
+            <p>Mit dem Block »Gib Wert Zeitgeber« kannst du einem anderen Block den aktuellen Stand des internen
+                Zeitgebers in Millisekunden »mitteilen«. Der Zeitgeber wird automatisch mit dem Beginn eines Programms
+                gestartet.</p>
+            <p>Einstellöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zeitgeber-Nummer, wähle den Zeitgeber aus, dessen Wert du
+                    ermitteln möchtest.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl Millisekunden, die seit dem Programmstart oder dem
+                    letzten Zurücksetzen des Zeitgebers vergangen sind.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück«</h3>
+            <p>Mit dem Block »Setze Zeitgeber ... zurück« können die internen Zeitgeber auf den Wert 0 zurückgesetzt
+                werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zeitgeber-Nummer, wähle den Zeitgeber aus, den du zurücksetzen
+                    möchtest.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»Taste...gedrückt?«">»Taste ... gedrückt?«</h3>
+            <p>Mit dem Block »Taste ... gedrückt?« kannst du einem anderen Block »mitteilen« , ob die ausgewählte Taste
+                gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>true = gedrückt</em> oder <em>false
+                    = nicht gedrückt</em> zurück.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle eine Taste aus, die du in der Roboterkonfiguration
+                    angelegt hast.</li>
+            </ul><br>
+            <p><br>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »true«, wenn die gewählte Taste gedrückt ist, sonst
+                    »false«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_motion_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»gibAnwesenheitBewegungssensorHC-SR501...«">»gib Anwesenheit
+                Bewegungssensor HC-SR501...«</h3>
+            <p>Mit dem Block »gib Anwesenheit Bewegungssensor ...« kannst du einem anderen Block »mitteilen« , ob der
+                Bewegungssensor eine Bewegung wahrnimmt oder nicht.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, wähle einen Bewegungssensor aus, den du in der
+                        Roboterkonfiguration angelegt hast.<br></span></li>
+            </ul><br>
+            <p><br>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »true«, wenn eine Bewegung wahrgenommen wird, sonst
+                    »false«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»gibLicht%Lichtsensor...«">»gib Licht % Lichtsensor ...«</h3>
+            <p>Mit dem Block »gib Licht % Lichtsensor ...« kannst du einem anderen Block »mitteilen«, welchen
+                Helligkeitswert zwischen 0 und 100 der Lichtsensor misst.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Lichtsensor aus, den du in der
+                    Roboterkonfiguration erstellt hast.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Helligkeitswert in %<span>.</span></li>
+            </ul><br>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»GibAbstand/AnwesenheitInfrarotsensor...«">»Gib Abstand/Anwesenheit
+                Infrarotsensor ...«</h3>
+            <p>Mit dem Block »Gib Abstand/Anwesenheit Infrarotsensor ...« kannst du einem anderen Block »mitteilen«,
+                welchen Abstand der Infrarotsensor misst.</p>
+            <p>Im Modus »Abstand« wird der Abstand als Zahl übermittelt.</p>
+            <p>Im Modus »Anwesenheit« gibt der Sensor an, ob Infrarot empfangen wird oder nicht.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Ein exakte Messung der Abstände in cm ist mit dem Infrarotsensor nicht möglich. Die gemessenen
+                        Abstände sind also ungefähre Werte.</p>
+                </div>
+            </div>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»Abstand« oder »Anwesenheit«. Stelle ein, wie der
+                    Infrarotsensor messen soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Infrarotsensor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, bei »Abstand«, maximaler Abstand 70 cm.</p>
+                    <p>Logischer Wert, bei »Anwesenheit«;<span> »Wahr« wenn Infrarot empfangen wird und <span> »Falsch«
+                                wenn nicht</span></span> .</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_temperature_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»gibWert°TemperatursensorTMP36...«">»gib Wert ° Temperatursensor TMP36...«
+            </h3>
+            <p>Mit dem Block »gib Wert ° Temperatursensor ...« kannst du einem anderen Block »mitteilen« , welche
+                Temperatur durch den Temperatursensor gemessen wird.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Temperatursensor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><br>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die vom Sensor gemessene Temperatur in Grad Celsius.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_humidity_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»gibWert%LuftfeuchtigkeitsensorDHT11...«">»gib Wert %
+                Luftfeuchtigkeitsensor DHT11...«</h3>
+            <p>Mit dem Block »gib Wert % Luftfeuchtigkeitsensor ...« kannst du einem anderen Block »mitteilen«, wie hoch
+                die Luftfeuchtigkeit zwischen 0% und 100% ist, die der Luftfeuchtigkeitssensor misst.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Luftfeuchtigkeitsensor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Luftfeuchtigkeit in %.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_drop_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»gibWert%Tropfsensor...«">»gib Wert % Tropfsensor...«</h3>
+            <p>Mit dem Block »gib Wert % Tropfsensor ...« kannst du einem anderen Block »mitteilen«, wie hoch die nass
+                der Tropfsensor zwischen 0% und 100% ist.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Tropfensensor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Nässe in %.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_pulse_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»gibWertPulssensor...«">»gib Wert Pulssensor...«</h3>
+            <p>Mit dem Block »gib Wert Pulssensor ...« kannst du einem anderen Block »mitteilen«, wie hoch der Puls der
+                Person ist, bei der der Sensor verwendet wird.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Pulssensor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gemessener Puls.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_potentiometer_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»GibWertVPotentiometer...«">»Gib Wert V Potentiometer ...«</h3>
+            <p>Mit dem Block »Gib Wert V Potentiometer ...« kannst du einem anderen Block »mitteilen«, auf welchen Wert
+                in Volt das an deinen Arduino angeschlossene Potentiometer eingestellt ist.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle ein Potentiometer aus, das du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Spannung in Volt, auf die das Potentiometer eingestellt ist.
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_moisture_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»gibWert%Feuchtigkeitssensor...«">»gib Wert % Feuchtigkeitssensor ...«</h3>
+            <p>Mit dem Block »gib Wert % Feuchtigkeitssensor ...« kannst du einem anderen Block »mitteilen«, wie hoch
+                die Feuchtigkeit zwischen 0 und 100 ist, die der Feuchtigkeitssensor misst.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Feuchtigkeitsensor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Feuchtigkeit in %<span>.</span></li>
+            </ul><br>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»gibAbstandcmUltraschallHC-SR04...«">»gib Abstand cm Ultraschall HC-SR04
+                ...«</h3>
+            <p>Mit dem Block »gib Abstand cm Ultraschall HC-SR04 ...« kannst du einem anderen Block »mitteilen«, welcher
+                Abstand in cm von dem Ultraschallsensor gemessen wird.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Ultraschallsensor HS-SR04 aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Abstand in cm</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_rfid_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»gibID/AnwesenheitRFID-RC522Reader...«">»gib ID/Anwesenheit RFID-RC522
+                Reader...«</h3>
+            <p>Mit dem Block »gib ID/Anwesenheit RFID-RC522 Reader ...« kannst du einem anderen Block »mitteilen«,
+                welche UID (Unique Identification Number) ein RFID-Tag hat, dass du an den Sensor hälst oder ob ein
+                RFID-Tag erkannt wurde.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»ID« oder »Anwesenheit«. Stelle ein, wie der Infrarotsensor
+                    messen soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen RFID Reader aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Text,<span> bei »Kartenserie«;</span> UID des RFID-Tags.</p>
+                    <p><span>Logischer Wert, bei »Anwesenheit«;</span><span> »Wahr« wenn ein RFID-Tag erkannt wird und
+                            »Falsch« wenn nicht</span><span> .</span></p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wennmachesonst«">»Wenn mache sonst«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wiederholeunendlichoft«">»Wiederhole unendlich
+                oft«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wiederholenmal«">»Wiederhole n mal«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wiederholesolange/bis«[Experten-Block]">
+                »Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»FürWertausderListe«[Experten-Block]">»Für Wert
+                aus der Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Zählevonbis«[Experten-Block]">»Zähle von bis«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="ProgrammierBlöckeArduino-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeArduino-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wartems...«">»Warte ms ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wartebis...«.1">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»MathematischeFunktionen«[Experten-Block]">
+                »Mathematische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»TrigonometrischeFunktionen«[Experten-Block]">
+                »Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Konstanten«[Experten-Block]">»Konstanten« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Zahleneigenschaft«[Experten-Block]">
+                »Zahleneigenschaft« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»runden«[Experten-Block]">»runden« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Listeauswerten«[Experten-Block]">»Liste
+                auswerten« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Restvon«[Experten-Block]">»Rest von« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Begrenze«[Experten-Block]">»Begrenze« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»GanzzahligeZufallswerte«[Experten-Block]">
+                »Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Zufallszahl«">»Zufallszahl« </h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeArduino-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in
+                Zeichenkette« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeArduino-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»ErstelleText«[Experten-Block]">»Erstelle Text«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeArduino-»Textanhängen«[Experten-Block]">»Text anhängen«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeArduino-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeArduino-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ...
+                an Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeArduino-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeArduino-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste«
+                <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeArduino-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeArduino-»istleer?«[Experten-Block]">»ist leer?« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeArduino-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeArduino-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeArduino-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammierBlöckeArduino-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammierBlöckeArduino-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammierBlöckeArduino-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammierBlöckeArduino-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeArduino-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ...
+                Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeArduino-»FarbemitRot...Grün...Blau...«[Experten-Block]">
+                »Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeArduino-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün
+                ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammierBlöckeArduino-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb
+                einer Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="ProgrammierBlöckeArduino-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="ProgrammierBlöckeArduino-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeArduino-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne
+                Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeArduino-»FunktionsaufrufmitRückgabewert«">
+                »Funktionsaufruf mit Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_arduino_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_arduino_en.html
@@ -1,421 +1,1538 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start_ardu" class="help beginner"><h3 id="ProgrammingBlocksArduino-»Programstart«"><span style="color: rgb(0,0,0);">»Program start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Each program starts with the »Start« block, which cannot be deleted. The first block you want to use is connected directly to the »Sequence connection« on the »Repeat indefinitely« block.</p><p>For systems based on an Arduino or similar microcontroller, there is always a »repeat indefinitely« loop connected to the start block, which also cannot be removed. This is due to the fact that such microcontrollers are usually programmed for exactly one task, which then has to be executed again and again. If you only want one run of the program, you can simply make the robot wait at the end of the loop for a very long time.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">create a new global variable</li><li class="typcn typcn-minus">delete the global variable</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable</li><li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«, »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li><li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial value of the variable.</li>
-</ul></div><div id="robActions_motor_on_for_ardu" class="help expert"><h3 id="ProgrammingBlocksArduino-»servomotorSG90...setto°«"><span style="color: rgb(0,0,0);">»servo motor SG90 ... set to°« </span></h3><p>With the block »servo motor SG90 ... set to°« you can set the position of your servo motor in degree. The servo motor is going to move into the position.</p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected </span>the motor to.</span></li><li class="typcn typcn-arrow-left">Ammount of degree, the motor shall be moved.</li>
-</ul><br></div><div id="robActions_motor_on_for" class="help expert"><h3 id="ProgrammingBlocksArduino-»motor28BYJ-48port...onrpm...forrotation/degree...«"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»motor 28BYJ-48 port ... on  rpm ... for rotation/degree ...«</span><br></span></h3><p>With the »motor 28BYJ-48 port ... on rpm... for rotation/degree« block you can program the speed (velocity) of the selected motor. Your robot starts the selected motor and rotates the motor until the specified number of rotations or degrees is done. </p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the motor to.</span></li><li class="typcn typcn-arrow-left">number, speed in rounds per minute, in which the motor shall rotate. Negative values lets the motor rotate into the other direction.</li><li class="typcn typcn-arrow-sorted-down">rotation or degree. Choose the one which fits best. 1 rotation is the same than 360 degrees.</li><li class="typcn typcn-arrow-left">number, rotations or degrees, only positive numbers are allowed.</li>
-</ul></div><div id="robActions_set_relay" class="help expert"><h3 id="ProgrammingBlocksArduino-»turnrelaySRD-05VDC-SL-C...on/off«"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»turn relay  SRD-05VDC-SL-C ... on/off«</span><br></span></h3><p>With the  »turn relay SRD-05VDC-SL-C ... on/of« block you can control the relay connected to the chosen pin.</p><p>Options and Arguments
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the relay to.</span></li><li class="typcn typcn-arrow-sorted-down">on/off, choose wether the relay is turned on or off.</li>
-</ul><br></div><div id="robActions_serial_print" class="help beginner"><h3 id="ProgrammingBlocksArduino-»showonSerialMonitor...«">»show on Serial Monitor ...«</h3><p>With the  »show on Serial Monitor ...« block you can send texts or numbers using the serial interface of your Arduino. Using the serial display of the usb-programm you can read these messages.</p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, you want to send.</li>
-</ul></div><div id="robActions_display_text" class="help expert"><h3 id="ProgrammingBlocksArduino-»LCD1602...«"><span style="color: rgb(85,85,85);">»LCD 1602 ...«</span></h3><p>With the »LCD 1602 ...« block you can display texts or numbers on your LCD 1602. You can although set the column and row the text is .</p><p>The display is seperatet into several rows (from left to right) an rows (from top to bottom). Counting starts at 0.</p><p>If there was a text displayed before, only the characters are going to be overwritten, where the new text is going to be displayed.</p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the display to.</span></li><li class="typcn typcn-arrow-left">Text, to be shown on the display.</li><li class="typcn typcn-arrow-left">number, column-id the text is going to be shown.</li><li class="typcn typcn-arrow-left">number, row-id, the text should start at.</li>
-</ul></div><div id="robActions_display_clear" class="help expert"><h3 style="letter-spacing: normal;" id="ProgrammingBlocksArduino-»cleardisplayLCD1602«">»clear display LCD 1602«</h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »clear displys LCD 1602« you can clear the text, displayed on your LCD. After using this block the display will show nothing.
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the display to.</span></li>
-</ul></div><div id="robActions_display_text_i2c" class="help beginner"><h3 style="letter-spacing: normal;" id="ProgrammingBlocksArduino-»LCD1602I²C...«">»LCD 1602 I²C ...«</h3><p>With the »LCD 1602 I²C...« block you can display texts or numbers on your LCD 1602, connected to the I²C-Bus. You can although set the column and row the text is .</p><p>The display is seperatet into several rows (from left to right) an rows (from top to bottom). Counting starts at 0.</p><p>If there was a text displayed before, only the characters are going to be overwritten, where the new text is going to be displayed.</p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected</span> the display to.</li><li class="typcn typcn-arrow-left">Text, to be shown on the display.</li><li class="typcn typcn-arrow-left">number, column-id the text is going to be shown.</li><li class="typcn typcn-arrow-left">number, row-id, the text should start at.</li>
-</ul></div><div id="robActions_display_clear_i2c" class="help beginner"><h3 id="ProgrammingBlocksArduino-»deletedisplayLCD1602I²C«">»delete display LCD 1602 I²C«</h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »clear displys LCD 1602 I²C« you can clear the text, displayed on your LCD, connect to the I²C-Bus. After using this block the display will show nothing.</p><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected</span> the display to.</li>
-</ul></div><div id="robActions_play_tone" class="help beginner"><h3 id="ProgrammingBlocksArduino-»play...frequencyHz..durationms«">»play ... frequency Hz .. duration ms«</h3><p>With the »play ... frequency Hz ... duration ms« block you can program the frequency (pitch level) and the time (how long the sound should be played) that a sound is played. The sound is played by a buzzer connected to your Arduino. The frequency setting corresponds directly to the frequency in Hertz, for example, setting the frequency to 400 corresponds to 400 Hertz. Example: 261 = C.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Note that the human ear can perceive frequencies from about 30Hz to about 15,000Hz (15kHz). This can vary depending on the person and their age.</p></div></div><p>Options and Arguments::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected</span> the buzzer to.</li><li class="typcn typcn-arrow-left">Number, desired frequency in Hz (Hertz) .</li><li class="typcn typcn-arrow-left">Number, desired duration in milliseconds (ms).</li>
-</ul></div><div id="robActions_brickLight_on" class="help beginner"><h3 style="letter-spacing: normal;" id="ProgrammingBlocksArduino-»LED...on/off«">»LED ... on/off«</h3><p><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »LED ... on/off«block you can switch on or off a LED connected to your Arduino.</span></p><p><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the LED to.</span></li><li class="typcn typcn-arrow-sorted-down">on/off, choose wether the LED is turned on or off.</li>
-</ul><br></div><div id="robActions_led_on" class="help expert"><h3 style="letter-spacing: normal;" id="ProgrammingBlocksArduino-»turnLEDon...colour«">»turn LED on ... colour« </h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the "tunr LED on ... colour" block you can turn on a RGB-LED, connected to your Arduino in the colour you want to.</p><p style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options and Arguments::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the RGB-LED to.</span></li><li class="typcn typcn-arrow-left">colour, you want the LED to have.</li>
-</ul></div><div id="robActions_led_off" class="help expert"><h3 style="letter-spacing: normal;" id="ProgrammingBlocksArduino-»turnLEDoff...«">»turn LED off ...«</h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »turn LED off« block you can turn off the LED.</p><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the RGB-LED to.</span></li>
-</ul></div><div id="robActions_write_pin" class="help beginner"><h3 id="ProgrammingBlocksArduino-»writedigital/analogvalueactuator...«">»write digital/analog value actuator...«</h3><p>With the »write digital/analog value actuator ...« block you can write a digital or an analog value to an actuator connected to your Arduino. </p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">digital/analog, choose wether you want to write a digital or an analog value to an actuator. (By changing this option the pickable actuators change)</li><li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the actuator to.</span></li><li class="typcn typcn-arrow-left">Number, value to be written.</li>
-</ul><br></div><div id="robSensors_out_getSample" class="help beginner"> <h3 id="ProgrammingBlocksArduino-»getanalog/digitalvaluesensor...«">»get analog/digital value sensor...«</h3><p>With the »get analog/digital value sensor...« block you can »tell« another block, wich analog or digital value is read from a sensor, connected to your Arduino.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»analog« or »digital«. pick in which format the data are read.</li><li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, value read from the sensor.</li>
-</ul> </div><div id="robSensors_timer_getSample" class="help beginner"> <h3 id="ProgrammingBlocksArduino-»getvaluemstimer«">»get value ms timer«</h3><p>With the  »get value ms timer« block you can read the current state of one of the internal timers of your Arduino in millseconds. The timer is started automatically when the program starts .</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">timer-id, choose the timer, from which you want to read.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, time in milliseconds since programstart or last reset of the timer.</li>
-</ul><br></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="ProgrammingBlocksArduino-»resettimer...«">»reset timer ...«</h3><p>With the »reset timer ...« block you can set the count of an internal timer to 0.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>timer-id, choose the timer, from which you want to reset.</span></li>
-</ul><br></div><div id="robSensors_key_getSample" class="help beginner"> <h3 id="ProgrammingBlocksArduino-»button...pressed?«">»button... pressed?«</h3><p>With the »button ... pressed?« block you can query wether a button is pressed or not. </p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean value, »true«, if the button is pressed, else »false«.</li>
-</ul> </div><div id="robSensors_motion_getSample" class="help beginner"> <h3 id="ProgrammingBlocksArduino-»getpresencemotionsensorHC-SR501...«">»get presence motion sensor HC-SR501...«</h3><p>With the »get presence motion sensor HC-SR501...« block you can query if the motion sensor is recognizing a motion.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean value, »true«, if the button is pressed, else »false«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><span>boolean value, »true«, if a motion is recognized, else »false«.</span></li>
-</ul> </div><div id="robSensors_light_getSample" class="help beginner"> <h3 id="ProgrammingBlocksArduino-»getlight%lightsensor...«">»get light % light sensor ...«</h3><p>With the »get light % light sensor ...« block you can read the measured brighness in % from your light sensor</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, brightness from 0% to 100%.</li>
-</ul> </div><div id="robSensors_infrared_getSample" class="help expert">  <h3 id="ProgrammingBlocksArduino-»getvalue/presenceinfraredsensor...«">»get value/presence infrared sensor ...«</h3><p>With the  »get value/presence infrared sensor ...« you can read the measured distance from your infrared sensor or if it detects infrared light.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>In <span>»presence«</span>-mode infrared light is detected. This can be emmited by annother infrared sensor.</p></div></div><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>An exact measurement of the distances in cm is not possible with the infrared sensor. The measured distances are therefore approximate values.</p></div></div><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»value« or »presence«, choose wich measuringmode should be used.</li><li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>number, from 0 cm to 70 cm.</p><p><span>boolean value, »true«, if infrared light is detected, else »false«.</span></p></li>
-</ul><br> </div><div id="robSensors_temperature_getSample" class="help expert">  <h3 id="ProgrammingBlocksArduino-»getvalue°temperaturesensorTMP36...«">»get value ° temperature sensor TMP36...«</h3><p>With the  »get value ° temperature sensor TMP36...« you can read the temperature your sensor is measuring.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, measured temperature in degree Celsius.</li>
-</ul><br> </div><div id="robSensors_humidity_getSample" class="help expert"> <h3 id="ProgrammingBlocksArduino-»gethumidity%/temperature°humiditysensorDHT11...«">»get humidity %/temperature ° humidity sensor DHT11...«</h3><p>With the  »gib humidity %/temperature ° humidity sensor DHT11...« block you can measure humidity in % or temperature in  ° Celsius.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">humidity %/temperature °, choose which value you want to read.</li><li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, humidity in % or temperature in °.</li>
-</ul> </div><div id="robSensors_drop_getSample" class="help expert"> <h3 id="ProgrammingBlocksArduino-»getvalue%dropsensor...«">»get value % drop sensor...«</h3><p>With the  »get value % drop sensor ...« block you can read how wet the sensor is.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><p class="auto-cursor-target"><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, wetness between 0% and 100%.</li>
-</ul> </div><div id="robSensors_pulse_getSample" class="help expert"> <h3 id="ProgrammingBlocksArduino-»getvaluepulssensor...«">»get value puls sensor...«</h3><p>With the  »get value puls sensor ...« block you can read how high the heartrate of a person, the sensor is attached to, is.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, measured pulse.</li>
-</ul> </div><div id="robSensors_potentiometer_getSample" class="help expert"><h3 id="ProgrammingBlocksArduino-»getvalueVpotentiometer...«">»get value V potentiometer ...«</h3><p>With the  »get value V potentiometer ...« block you can read to which value the potentiometer is set to.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, voltage the potentiometer is set so.</li>
-</ul><br></div><div id="robSensors_moisture_getSample" class="help expert"> <h3 id="ProgrammingBlocksArduino-»getvalue%moisturesensor...«">»get value % moisture sensor ...«</h3><p>With the  »get value % moisture sensor ...« block you can read the moisture between 0% and 100%.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><p class="auto-cursor-target"><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, moisture in %.</li>
-</ul> </div><div id="robSensors_ultrasonic_getSample" class="help expert"> <h3 id="ProgrammingBlocksArduino-»getdistancecmultrasonicsensorHC-SR04...«">»get distance cm ultrasonic sensor HC-SR04 ...«</h3><p>With the  »get distance ultrasonic sensor HC-SR04 ...« block you can measure the distance between your ultrasonic sensor and an obstacle.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, distance in cm</li>
-</ul><br> </div><div id="robSensors_rfid_getSample" class="help expert"> <h3 id="ProgrammingBlocksArduino-»getID/presenceRFID-RC522Reader...«">»get ID/presence RFID-RC522 Reader...«</h3><p>With the  »get ID/presence RFID-RC522 Reader ...« block you can read which  UID (Unique Identification Number) an RFID-Tag got or if a RFID-Tag was recognized.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»ID« or »presence«. choose the value to be measured.</li><li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the RFID-reader to.</span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Text,<span> when »ID«;</span> UID of the RFID-Tags.</p><p><span>boolean, when »presence«;</span><span> »true« if a RFID-Tag was detected, else »false«</span><span> .</span></p></li>
-</ul><br> </div><div id="robControls_if" class="help beginner"><h3 id="ProgrammingBlocksArduino-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="ProgrammingBlocksArduino-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="ProgrammingBlocksArduino-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="ProgrammingBlocksArduino-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="ProgrammingBlocksArduino-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="ProgrammingBlocksArduino-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="ProgrammingBlocksArduino-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="ProgrammingBlocksArduino-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="ProgrammingBlocksArduino-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="ProgrammingBlocksArduino-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="ProgrammingBlocksArduino-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="ProgrammingBlocksArduino-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="ProgrammingBlocksArduino-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="ProgrammingBlocksArduino-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="ProgrammingBlocksArduino-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="ProgrammingBlocksArduino-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="ProgrammingBlocksArduino-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="ProgrammingBlocksArduino-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="ProgrammingBlocksArduino-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="ProgrammingBlocksArduino-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="ProgrammingBlocksArduino-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="ProgrammingBlocksArduino-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="ProgrammingBlocksArduino-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="ProgrammingBlocksArduino-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="ProgrammingBlocksArduino-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksArduino-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="ProgrammingBlocksArduino-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="ProgrammingBlocksArduino-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="ProgrammingBlocksArduino-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="ProgrammingBlocksArduino-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksArduino-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksArduino-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="ProgrammingBlocksArduino-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammingBlocksArduino-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="ProgrammingBlocksArduino-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksArduino-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksArduino-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksArduino-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksArduino-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksArduino-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksArduino-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksArduino-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksArduino-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksArduino-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksArduino-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksArduino-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingBlocksArduino-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammingBlocksArduino-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammingBlocksArduino-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingBlocksArduino-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="ProgrammingBlocksArduino-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="ProgrammingBlocksArduino-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammingBlocksArduino-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="ProgrammingBlocksArduino-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammingBlocksArduino-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammingBlocksArduino-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammingBlocksArduino-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="ProgrammingBlocksArduino-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="ProgrammingBlocksArduino-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammingBlocksArduino-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingBlocksArduino-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start_ardu" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»Programstart«"><span style="color: rgb(0,0,0);">»Program
+                    start«</span><span style="color: rgb(0,0,0);"> </span></h3>
+            <p>Each program starts with the »Start« block, which cannot be deleted. The first block you want to use is
+                connected directly to the »Sequence connection« on the »Repeat indefinitely« block.</p>
+            <p>For systems based on an Arduino or similar microcontroller, there is always a »repeat indefinitely« loop
+                connected to the start block, which also cannot be removed. This is due to the fact that such
+                microcontrollers are usually programmed for exactly one task, which then has to be executed again and
+                again. If you only want one run of the program, you can simply make the robot wait at the end of the
+                loop for a very long time.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">create a new global variable</li>
+                <li class="typcn typcn-minus">delete the global variable</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«,
+                    »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li>
+                <li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial
+                    value of the variable.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on_for_ardu" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»servomotorSG90...setto°«"><span style="color: rgb(0,0,0);">»servo motor
+                    SG90 ... set to°« </span></h3>
+            <p>With the block »servo motor SG90 ... set to°« you can set the position of your servo motor in degree. The
+                servo motor is going to move into the position.</p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected </span>the motor to.</span></li>
+                <li class="typcn typcn-arrow-left">Ammount of degree, the motor shall be moved.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on_for" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»motor28BYJ-48port...onrpm...forrotation/degree...«"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»motor 28BYJ-48 port ... on rpm ...
+                        for rotation/degree ...«</span><br></span></h3>
+            <p>With the »motor 28BYJ-48 port ... on rpm... for rotation/degree« block you can program the speed
+                (velocity) of the selected motor. Your robot starts the selected motor and rotates the motor until the
+                specified number of rotations or degrees is done. </p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the motor to.</span></li>
+                <li class="typcn typcn-arrow-left">number, speed in rounds per minute, in which the motor shall rotate.
+                    Negative values lets the motor rotate into the other direction.</li>
+                <li class="typcn typcn-arrow-sorted-down">rotation or degree. Choose the one which fits best. 1 rotation
+                    is the same than 360 degrees.</li>
+                <li class="typcn typcn-arrow-left">number, rotations or degrees, only positive numbers are allowed.</li>
+            </ul>
+        </div>
+        <div id="robActions_set_relay" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»turnrelaySRD-05VDC-SL-C...on/off«"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»turn relay SRD-05VDC-SL-C ...
+                        on/off«</span><br></span></h3>
+            <p>With the »turn relay SRD-05VDC-SL-C ... on/of« block you can control the relay connected to the chosen
+                pin.</p>
+            <p>Options and Arguments
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the relay to.</span></li>
+                <li class="typcn typcn-arrow-sorted-down">on/off, choose wether the relay is turned on or off.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_serial_print" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»showonSerialMonitor...«">»show on Serial Monitor ...«</h3>
+            <p>With the »show on Serial Monitor ...« block you can send texts or numbers using the serial interface of
+                your Arduino. Using the serial display of the usb-programm you can read these messages.</p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, you want to send.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_text" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»LCD1602...«"><span style="color: rgb(85,85,85);">»LCD 1602 ...«</span>
+            </h3>
+            <p>With the »LCD 1602 ...« block you can display texts or numbers on your LCD 1602. You can although set the
+                column and row the text is .</p>
+            <p>The display is seperatet into several rows (from left to right) an rows (from top to bottom). Counting
+                starts at 0.</p>
+            <p>If there was a text displayed before, only the characters are going to be overwritten, where the new text
+                is going to be displayed.</p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the display to.</span></li>
+                <li class="typcn typcn-arrow-left">Text, to be shown on the display.</li>
+                <li class="typcn typcn-arrow-left">number, column-id the text is going to be shown.</li>
+                <li class="typcn typcn-arrow-left">number, row-id, the text should start at.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear" class="help expert">
+            <h3 style="letter-spacing: normal;" id="ProgrammingBlocksArduino-»cleardisplayLCD1602«">»clear display LCD
+                1602«</h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »clear
+                displys LCD 1602« you can clear the text, displayed on your LCD. After using this block the display will
+                show nothing.
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the display to.</span></li>
+            </ul>
+        </div>
+        <div id="robActions_display_text_i2c" class="help beginner">
+            <h3 style="letter-spacing: normal;" id="ProgrammingBlocksArduino-»LCD1602I²C...«">»LCD 1602 I²C ...«</h3>
+            <p>With the »LCD 1602 I²C...« block you can display texts or numbers on your LCD 1602, connected to the
+                I²C-Bus. You can although set the column and row the text is .</p>
+            <p>The display is seperatet into several rows (from left to right) an rows (from top to bottom). Counting
+                starts at 0.</p>
+            <p>If there was a text displayed before, only the characters are going to be overwritten, where the new text
+                is going to be displayed.</p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected</span> the display to.</li>
+                <li class="typcn typcn-arrow-left">Text, to be shown on the display.</li>
+                <li class="typcn typcn-arrow-left">number, column-id the text is going to be shown.</li>
+                <li class="typcn typcn-arrow-left">number, row-id, the text should start at.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear_i2c" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»deletedisplayLCD1602I²C«">»delete display LCD 1602 I²C«</h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »clear
+                displys LCD 1602 I²C« you can clear the text, displayed on your LCD, connect to the I²C-Bus. After using
+                this block the display will show nothing.</p>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected</span> the display to.</li>
+            </ul>
+        </div>
+        <div id="robActions_play_tone" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»play...frequencyHz..durationms«">»play ... frequency Hz .. duration ms«
+            </h3>
+            <p>With the »play ... frequency Hz ... duration ms« block you can program the frequency (pitch level) and
+                the time (how long the sound should be played) that a sound is played. The sound is played by a buzzer
+                connected to your Arduino. The frequency setting corresponds directly to the frequency in Hertz, for
+                example, setting the frequency to 400 corresponds to 400 Hertz. Example: 261 = C.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Note that the human ear can perceive frequencies from about 30Hz to about 15,000Hz (15kHz). This
+                        can vary depending on the person and their age.</p>
+                </div>
+            </div>
+            <p>Options and Arguments::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected</span> the buzzer to.</li>
+                <li class="typcn typcn-arrow-left">Number, desired frequency in Hz (Hertz) .</li>
+                <li class="typcn typcn-arrow-left">Number, desired duration in milliseconds (ms).</li>
+            </ul>
+        </div>
+        <div id="robActions_brickLight_on" class="help beginner">
+            <h3 style="letter-spacing: normal;" id="ProgrammingBlocksArduino-»LED...on/off«">»LED ... on/off«</h3>
+            <p><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »LED ... on/off«block you
+                    can switch on or off a LED connected to your Arduino.</span></p>
+            <p><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the LED to.</span></li>
+                <li class="typcn typcn-arrow-sorted-down">on/off, choose wether the LED is turned on or off.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_led_on" class="help expert">
+            <h3 style="letter-spacing: normal;" id="ProgrammingBlocksArduino-»turnLEDon...colour«">»turn LED on ...
+                colour« </h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the "tunr LED on
+                ... colour" block you can turn on a RGB-LED, connected to your Arduino in the colour you want to.</p>
+            <p style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options and Arguments::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the RGB-LED to.</span></li>
+                <li class="typcn typcn-arrow-left">colour, you want the LED to have.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_off" class="help expert">
+            <h3 style="letter-spacing: normal;" id="ProgrammingBlocksArduino-»turnLEDoff...«">»turn LED off ...«</h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »turn LED
+                off« block you can turn off the LED.</p>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the RGB-LED to.</span></li>
+            </ul>
+        </div>
+        <div id="robActions_write_pin" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»writedigital/analogvalueactuator...«">»write digital/analog value
+                actuator...«</h3>
+            <p>With the »write digital/analog value actuator ...« block you can write a digital or an analog value to an
+                actuator connected to your Arduino. </p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">digital/analog, choose wether you want to write a digital or
+                    an analog value to an actuator. (By changing this option the pickable actuators change)</li>
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the actuator to.</span></li>
+                <li class="typcn typcn-arrow-left">Number, value to be written.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_out_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»getanalog/digitalvaluesensor...«">»get analog/digital value sensor...«
+            </h3>
+            <p>With the »get analog/digital value sensor...« block you can »tell« another block, wich analog or digital
+                value is read from a sensor, connected to your Arduino.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»analog« or »digital«. pick in which format the data are read.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, value read from the sensor.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»getvaluemstimer«">»get value ms timer«</h3>
+            <p>With the »get value ms timer« block you can read the current state of one of the internal timers of your
+                Arduino in millseconds. The timer is started automatically when the program starts .</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">timer-id, choose the timer, from which you want to read.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, time in milliseconds since programstart or last reset of the
+                    timer.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»resettimer...«">»reset timer ...«</h3>
+            <p>With the »reset timer ...« block you can set the count of an internal timer to 0.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>timer-id, choose the timer, from which you want to
+                        reset.</span></li>
+            </ul><br>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»button...pressed?«">»button... pressed?«</h3>
+            <p>With the »button ... pressed?« block you can query wether a button is pressed or not. </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean value, »true«, if the button is pressed, else »false«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_motion_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»getpresencemotionsensorHC-SR501...«">»get presence motion sensor
+                HC-SR501...«</h3>
+            <p>With the »get presence motion sensor HC-SR501...« block you can query if the motion sensor is recognizing
+                a motion.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean value, »true«, if the button is pressed, else »false«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"><span>boolean value, »true«, if a motion is recognized, else
+                        »false«.</span></li>
+            </ul>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»getlight%lightsensor...«">»get light % light sensor ...«</h3>
+            <p>With the »get light % light sensor ...« block you can read the measured brighness in % from your light
+                sensor</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, brightness from 0% to 100%.</li>
+            </ul>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»getvalue/presenceinfraredsensor...«">»get value/presence infrared sensor
+                ...«</h3>
+            <p>With the »get value/presence infrared sensor ...« you can read the measured distance from your infrared
+                sensor or if it detects infrared light.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>In <span>»presence«</span>-mode infrared light is detected. This can be emmited by annother
+                        infrared sensor.</p>
+                </div>
+            </div>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>An exact measurement of the distances in cm is not possible with the infrared sensor. The
+                        measured distances are therefore approximate values.</p>
+                </div>
+            </div>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»value« or »presence«, choose wich measuringmode should be
+                    used.</li>
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>number, from 0 cm to 70 cm.</p>
+                    <p><span>boolean value, »true«, if infrared light is detected, else »false«.</span></p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_temperature_getSample" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»getvalue°temperaturesensorTMP36...«">»get value ° temperature sensor
+                TMP36...«</h3>
+            <p>With the »get value ° temperature sensor TMP36...« you can read the temperature your sensor is measuring.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, measured temperature in degree Celsius.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_humidity_getSample" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»gethumidity%/temperature°humiditysensorDHT11...«">»get humidity
+                %/temperature ° humidity sensor DHT11...«</h3>
+            <p>With the »gib humidity %/temperature ° humidity sensor DHT11...« block you can measure humidity in % or
+                temperature in ° Celsius.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">humidity %/temperature °, choose which value you want to read.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, humidity in % or temperature in °.</li>
+            </ul>
+        </div>
+        <div id="robSensors_drop_getSample" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»getvalue%dropsensor...«">»get value % drop sensor...«</h3>
+            <p>With the »get value % drop sensor ...« block you can read how wet the sensor is.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul>
+            <p class="auto-cursor-target"><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, wetness between 0% and 100%.</li>
+            </ul>
+        </div>
+        <div id="robSensors_pulse_getSample" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»getvaluepulssensor...«">»get value puls sensor...«</h3>
+            <p>With the »get value puls sensor ...« block you can read how high the heartrate of a person, the sensor is
+                attached to, is.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, measured pulse.</li>
+            </ul>
+        </div>
+        <div id="robSensors_potentiometer_getSample" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»getvalueVpotentiometer...«">»get value V potentiometer ...«</h3>
+            <p>With the »get value V potentiometer ...« block you can read to which value the potentiometer is set to.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, voltage the potentiometer is set so.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_moisture_getSample" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»getvalue%moisturesensor...«">»get value % moisture sensor ...«</h3>
+            <p>With the »get value % moisture sensor ...« block you can read the moisture between 0% and 100%.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul>
+            <p class="auto-cursor-target"><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, moisture in %.</li>
+            </ul>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»getdistancecmultrasonicsensorHC-SR04...«">»get distance cm ultrasonic
+                sensor HC-SR04 ...«</h3>
+            <p>With the »get distance ultrasonic sensor HC-SR04 ...« block you can measure the distance between your
+                ultrasonic sensor and an obstacle.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, distance in cm</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_rfid_getSample" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»getID/presenceRFID-RC522Reader...«">»get ID/presence RFID-RC522 Reader...«
+            </h3>
+            <p>With the »get ID/presence RFID-RC522 Reader ...« block you can read which UID (Unique Identification
+                Number) an RFID-Tag got or if a RFID-Tag was recognized.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»ID« or »presence«. choose the value to be measured.</li>
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the RFID-reader to.</span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Text,<span> when »ID«;</span> UID of the RFID-Tags.</p>
+                    <p><span>boolean, when »presence«;</span><span> »true« if a RFID-Tag was detected, else
+                            »false«</span><span> .</span></p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="ProgrammingBlocksArduino-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»breakout/continuewithnextiterationofloop«[Expert-block]">»break
+                out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammingBlocksArduino-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="ProgrammingBlocksArduino-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»mathematicalfunction«[Expert-block]">»mathematical function« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksArduino-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»constrain«[Expert-block]">»constrain« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksArduino-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksArduino-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="ProgrammingBlocksArduino-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksArduino-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="ProgrammingBlocksArduino-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksArduino-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksArduino-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksArduino-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to
+                Number« <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksArduino-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksArduino-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksArduino-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksArduino-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksArduino-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksArduino-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksArduino-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksArduino-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingBlocksArduino-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingBlocksArduino-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammingBlocksArduino-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingBlocksArduino-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red
+                ... green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="ProgrammingBlocksArduino-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green
+                ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingBlocksArduino-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ...
+                green ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammingBlocksArduino-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function
+                blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function
+                blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»ifblocktobeusedwithinafunction«">»if block to be used within a function«
+            </h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="ProgrammingBlocksArduino-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function
+                with return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="ProgrammingBlocksArduino-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a
+                function with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammingBlocksArduino-»functioncallwithoutreturnvalue«">»function call without return value «
+            </h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksArduino-»functioncallwithreturnvalue«">»function call
+                with return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_bob3_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_bob3_de.html
@@ -1,271 +1,1061 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="BlockbeschreibungBOB3-»Programmstart«"><span style="color: rgb(0,0,0);">»Programmstart«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Jedes Programm beginnt mit dem »Programmstart-Block«, welcher nicht gelöscht werden kann. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am Programmstart-Block. </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
-</ul><br><p>Wenn globale Variablen erzeugt wurden:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variablen.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
-</ul></div><div id="makeblockActions_leds_on" class="help beginner"><h3 id="BlockbeschreibungBOB3-»SchalteLEDAuge...Farbe...«">»Schalte LED Auge ... Farbe ... «</h3><p>Mit diesem Block kannst eine der LEDs des BOB3 einschalten, die sich in den Augen des BOB3 befinden. Bei diesen LEDs handelt sich um RGB-LEDs, sie können also verschiedene Farben aus Rot, Grün und Blau darstellen.</p><p>Option und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du steuern möchtest. Du kannst entweder das rechte oder das linke Auge ansteuern.</li><li class="typcn typcn-arrow-left">Farbe, die Farbe in der das Auge leuchten soll.</li>
-</ul></div><div id="makeblockActions_leds_off" class="help beginner"><h3 id="BlockbeschreibungBOB3-»SchalteLEDAuge...aus«">»Schalte LED Auge ... aus«</h3><p>Mit diesem Block kannst du eine LED, die die Augen des BOB3 darstellen, ausschalten.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du ausschalten möchtest.</li>
-</ul><br></div><div id="bob3Actions_set_led" class="help beginner"><h3 id="BlockbeschreibungBOB3-»SchalteLEDKörper...an/aus«">»Schalte LED Körper ... an/aus «</h3><p>Mit diesem Knopf kannst du eine LED am Körper des BOB3 steuern. Diese LEDs leuchten weiß und du kannst sie entweder aus- oder einschalten.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle hier die LED aus, die du steuern möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle ob du die LED an- oder ausschalten möchtest.</li>
-</ul><br></div><div id="bob3Actions_remember" class="help expert"><h3 id="BlockbeschreibungBOB3-»SpeichereZahl...«[Experten-Block]">»Speichere Zahl ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine Zahl im Zwischenspeicher des BOB3 speichern. Der Zwischenspeicher ist allerdings sehr klein und du kannst immer nur eine Zahl speichern, Wenn du eine neue Zahl speicherst, wird die alte gespeicherte Zahl überschrieben.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zahl, die Zahl, die du speichern möchtest.</li>
-</ul><br></div><div id="bob3Actions_recall" class="help expert"><h3 id="BlockbeschreibungBOB3-»LeseZahlausSpeicher«[Experten-Block]">»Lese Zahl aus Speicher « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du die Zahl im Zwischenspeicher des BOB3 auslesen.</p><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die Zahl die momentan im Zwischenspeicher gespeichert ist.</li>
-</ul><br></div><div id="bob3Sensors_ambientlight" class="help beginner"><h3 id="BlockbeschreibungBOB3-»Gib...%Infrarotsensor«">»Gib ... % Infrarotsensor«</h3><p>Mit diesem  Block  kannst du den  Infrarotsensor deines  Roboters abfragen und entweder  das Umgebungslicht oder das von deinem Roboter reflektierte  Licht messen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Art des Lichts  die du messen möchtest, entweder das Umgebungslicht oder das  reflektierte Licht.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zahl,  Stärke des gemessenen Lichts zwischen 0 und 100.</li>
-</ul></div><div id="robSensors_pintouch_getSample" class="help beginner"><h3 id="BlockbeschreibungBOB3-»Arm...gedrückt?«">»Arm ... gedrückt?«</h3><p>Mit diesem Block kannst du die Berührungssensoren deines Roboters abfragen, ob diese gerade gedrückt werden.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Seite des Roboters, die du abfragen möchtest. Entweder links oder rechts.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle den Sensor, den du abfragen möchtest. Entweder einen einzelnen Sensor auf der ausgewählten Seite oder alle Sensoren der Seite gleichzeitig.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wahrheitswert, entweder wahr oder falsch,  je nachdem ob der  Sensor  gedrückt wird oder nicht.</li>
-</ul></div><div id="bob3Sensors_temperature_getSample" class="help beginner"><h3 id="BlockbeschreibungBOB3-»GibWert°Temperatursensor«">»Gib  Wert  °  Temperatursensor«</h3><p>Mit diesem  Block kannst du  den eingebauten Temperatursensor deines Roboters abfragen und die Umgebungstemperatur messen.</p><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Umgebungstemperatur in ° Celsius.</li>
-</ul></div><div id="bob3Sensors_getCode" class="help beginner"><h3 id="BlockbeschreibungBOB3-»GibWertBinär-Code«">»Gib Wert Binär-Code«</h3><p>Mit diesem Block kannst du den Binär-Code auf der Rückseite deines Roboters abfragen.</p><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Wert des Binär-Codes auf der Rückseite.</li>
-</ul></div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="BlockbeschreibungBOB3-»GibWertZeitgeber1«">»Gib Wert Zeitgeber  1«</h3><p>Mit diesem Block kannst du den internen Zeitgeber deines Roboters abfragen. Dieser gibt dir die Zeit seit Start des Programms oder dem letzten Zurücksetzen an.</p><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, vergangene Zeit seit Start des Programm oder dem letzten Zurücksetzen in Millisekunden.</li>
-</ul></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="BlockbeschreibungBOB3-»SetzeZeitgeber1zurück«">»Setze Zeitgeber 1  zurück«</h3><p>Mit diesem Block kannst du den Wert des eingebauten Zeitgebers deines Roboters auf 0 zurücksetzen.</p></div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Warte«">»Warte«</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wartebis«">»Warte bis«</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Zufallszahl«[Experten-Block]">»Zufallszahl« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="variables_set" class="help beginner"><h3 id="BlockbeschreibungBOB3-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="BlockbeschreibungBOB3-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul> </div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBOB3-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBOB3-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBOB3-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBOB3-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBOB3-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBOB3-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBOB3-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="BlockbeschreibungBOB3-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="BlockbeschreibungBOB3-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="BlockbeschreibungBOB3-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="BlockbeschreibungBOB3-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="BlockbeschreibungBOB3-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="BlockbeschreibungBOB3-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="bob3Communication_sendBlock" class="help expert">9<h3 id="BlockbeschreibungBOB3-»SendeNachricht...«">»Sende Nachricht ... «</h3><p>Mit diesem Block kannst du eine Nachricht an alle anderen Robotern in deiner Umgebung senden. Du kannst allerdings nur Zahlen als Nachricht an andere Roboter versenden.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Nachricht die du an andere Roboter versenden möchtest.</li>
-</ul></div><div id="bob3Communication_receiveBlock" class="help expert"><h3 id="BlockbeschreibungBOB3-»EmpfangeNachricht«">»Empfange Nachricht «</h3><p>Mit diesem Block kannst du die Nachrichten von anderen Robotern empfangen.</p><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, empfangene Nachricht von anderen Robotern.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»Programmstart«"><span style="color: rgb(0,0,0);">»Programmstart«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Programmstart-Block«, welcher nicht gelöscht werden kann. Den ersten
+                Block, den man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am
+                Programmstart-Block. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
+            </ul><br>
+            <p>Wenn globale Variablen erzeugt wurden:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variablen.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
+            </ul>
+        </div>
+        <div id="makeblockActions_leds_on" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»SchalteLEDAuge...Farbe...«">»Schalte LED Auge ... Farbe ... «</h3>
+            <p>Mit diesem Block kannst eine der LEDs des BOB3 einschalten, die sich in den Augen des BOB3 befinden. Bei
+                diesen LEDs handelt sich um RGB-LEDs, sie können also verschiedene Farben aus Rot, Grün und Blau
+                darstellen.</p>
+            <p>Option und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du steuern möchtest. Du kannst
+                    entweder das rechte oder das linke Auge ansteuern.</li>
+                <li class="typcn typcn-arrow-left">Farbe, die Farbe in der das Auge leuchten soll.</li>
+            </ul>
+        </div>
+        <div id="makeblockActions_leds_off" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»SchalteLEDAuge...aus«">»Schalte LED Auge ... aus«</h3>
+            <p>Mit diesem Block kannst du eine LED, die die Augen des BOB3 darstellen, ausschalten.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du ausschalten möchtest.</li>
+            </ul><br>
+        </div>
+        <div id="bob3Actions_set_led" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»SchalteLEDKörper...an/aus«">»Schalte LED Körper ... an/aus «</h3>
+            <p>Mit diesem Knopf kannst du eine LED am Körper des BOB3 steuern. Diese LEDs leuchten weiß und du kannst
+                sie entweder aus- oder einschalten.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle hier die LED aus, die du steuern möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob du die LED an- oder ausschalten möchtest.
+                </li>
+            </ul><br>
+        </div>
+        <div id="bob3Actions_remember" class="help expert">
+            <h3 id="BlockbeschreibungBOB3-»SpeichereZahl...«[Experten-Block]">»Speichere Zahl ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine Zahl im Zwischenspeicher des BOB3 speichern. Der Zwischenspeicher ist
+                allerdings sehr klein und du kannst immer nur eine Zahl speichern, Wenn du eine neue Zahl speicherst,
+                wird die alte gespeicherte Zahl überschrieben.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zahl, die Zahl, die du speichern möchtest.</li>
+            </ul><br>
+        </div>
+        <div id="bob3Actions_recall" class="help expert">
+            <h3 id="BlockbeschreibungBOB3-»LeseZahlausSpeicher«[Experten-Block]">»Lese Zahl aus Speicher « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du die Zahl im Zwischenspeicher des BOB3 auslesen.</p>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die Zahl die momentan im Zwischenspeicher gespeichert ist.
+                </li>
+            </ul><br>
+        </div>
+        <div id="bob3Sensors_ambientlight" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»Gib...%Infrarotsensor«">»Gib ... % Infrarotsensor«</h3>
+            <p>Mit diesem Block kannst du den Infrarotsensor deines Roboters abfragen und entweder das Umgebungslicht
+                oder das von deinem Roboter reflektierte Licht messen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Art des Lichts die du messen möchtest,
+                    entweder das Umgebungslicht oder das reflektierte Licht.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zahl, Stärke des gemessenen Lichts zwischen 0 und 100.</li>
+            </ul>
+        </div>
+        <div id="robSensors_pintouch_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»Arm...gedrückt?«">»Arm ... gedrückt?«</h3>
+            <p>Mit diesem Block kannst du die Berührungssensoren deines Roboters abfragen, ob diese gerade gedrückt
+                werden.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Seite des Roboters, die du abfragen
+                    möchtest. Entweder links oder rechts.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Sensor, den du abfragen möchtest. Entweder
+                    einen einzelnen Sensor auf der ausgewählten Seite oder alle Sensoren der Seite gleichzeitig.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wahrheitswert, entweder wahr oder falsch, je nachdem ob der Sensor
+                    gedrückt wird oder nicht.</li>
+            </ul>
+        </div>
+        <div id="bob3Sensors_temperature_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»GibWert°Temperatursensor«">»Gib Wert ° Temperatursensor«</h3>
+            <p>Mit diesem Block kannst du den eingebauten Temperatursensor deines Roboters abfragen und die
+                Umgebungstemperatur messen.</p>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Umgebungstemperatur in ° Celsius.</li>
+            </ul>
+        </div>
+        <div id="bob3Sensors_getCode" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»GibWertBinär-Code«">»Gib Wert Binär-Code«</h3>
+            <p>Mit diesem Block kannst du den Binär-Code auf der Rückseite deines Roboters abfragen.</p>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Wert des Binär-Codes auf der Rückseite.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»GibWertZeitgeber1«">»Gib Wert Zeitgeber 1«</h3>
+            <p>Mit diesem Block kannst du den internen Zeitgeber deines Roboters abfragen. Dieser gibt dir die Zeit seit
+                Start des Programms oder dem letzten Zurücksetzen an.</p>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, vergangene Zeit seit Start des Programm oder dem letzten
+                    Zurücksetzen in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»SetzeZeitgeber1zurück«">»Setze Zeitgeber 1 zurück«</h3>
+            <p>Mit diesem Block kannst du den Wert des eingebauten Zeitgebers deines Roboters auf 0 zurücksetzen.</p>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wennmachesonst«">»Wenn mache sonst«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«
+            </h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wiederholenmal«">»Wiederhole n mal«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole
+                solange/bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»FürWertausderListe«[Experten-Block]">»Für Wert aus
+                der Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungBOB3-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Warte«">»Warte«</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wartebis«">»Warte bis«</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»MathematischeFunktionen«[Experten-Block]">
+                »Mathematische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»TrigonometrischeFunktionen«[Experten-Block]">
+                »Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Konstanten«[Experten-Block]">»Konstanten« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Zahleneigenschaft«[Experten-Block]">
+                »Zahleneigenschaft« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»runden«[Experten-Block]">»runden« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Listeauswerten«[Experten-Block]">»Liste auswerten«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Restvon«[Experten-Block]">»Rest von« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Begrenze«[Experten-Block]">»Begrenze« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»GanzzahligeZufallswerte«[Experten-Block]">
+                »Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Zufallszahl«[Experten-Block]">»Zufallszahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»ErstelleText«[Experten-Block]">»Erstelle Text«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Textanhängen«[Experten-Block]">»Text anhängen«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBOB3-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBOB3-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste«
+                <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBOB3-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBOB3-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBOB3-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBOB3-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBOB3-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="BlockbeschreibungBOB3-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="BlockbeschreibungBOB3-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="BlockbeschreibungBOB3-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="BlockbeschreibungBOB3-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb
+                einer Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="BlockbeschreibungBOB3-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="BlockbeschreibungBOB3-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="bob3Communication_sendBlock" class="help expert"><h3 id="BlockbeschreibungBOB3-»SendeNachricht...«">
+                »Sende Nachricht ... «</h3>
+            <p>Mit diesem Block kannst du eine Nachricht an alle anderen Robotern in deiner Umgebung senden. Du kannst
+                allerdings nur Zahlen als Nachricht an andere Roboter versenden.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Nachricht die du an andere Roboter versenden möchtest.</li>
+            </ul>
+        </div>
+        <div id="bob3Communication_receiveBlock" class="help expert">
+            <h3 id="BlockbeschreibungBOB3-»EmpfangeNachricht«">»Empfange Nachricht «</h3>
+            <p>Mit diesem Block kannst du die Nachrichten von anderen Robotern empfangen.</p>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, empfangene Nachricht von anderen Robotern.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_bob3_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_bob3_en.html
@@ -1,337 +1,1224 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start_ardu" class="help beginner"><h3 id="BlockdescriptionBOB3-»Programstart«"><span style="color: rgb(0,0,0);">»Program start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Each program starts with the »Start« block, which cannot be deleted. The first block you want to use is connected directly to the »Sequence connection« on the »Repeat indefinitely« block.</p><p>For systems based on an Arduino or similar microcontroller, there is always a »repeat indefinitely« loop connected to the start block, which also cannot be removed. This is due to the fact that such microcontrollers are usually programmed for exactly one task, which then has to be executed again and again. If you only want one run of the program, you can simply make the robot wait at the end of the loop for a very long time.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">create a new global variable</li><li class="typcn typcn-minus">delete the global variable</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable</li><li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«, »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li><li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial value of the variable.</li>
-</ul></div><div id="makeblockActions_leds_on" class="help beginner"><h3 id="BlockdescriptionBOB3-»turnLEDeye...oncolour...«">»turn LED eye ... on colour ... «</h3><p>With this block you can switch on one of the LEDs of the BOB3, which are in the eyes of the BOB3. These LEDs are RGB LEDs, so they can display different colors of red, green and blue.</p><p>Option and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose which LED you want to control</li><li class="typcn typcn-arrow-left">colour, the colour you want the  eye to display.</li>
-</ul></div><div id="makeblockActions_leds_off" class="help beginner"><h3 id="BlockdescriptionBOB3-»turnLEDeye...off«">»turn LED eye ... off«</h3><p>With this block you can turn off one of the LEDs in the eyes of your BOB3.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose which LED you want to turn off.</li>
-</ul></div><div id="bob3Actions_set_led" class="help beginner"><h3 id="BlockdescriptionBOB3-»turnLEDbody...«">»turn LED  body ... «</h3><p>With this button you can control an LED on the body of the BOB3. These LEDs glow white and you can either switch them off or on.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, select here the LED you want to control.</li><li class="typcn typcn-arrow-sorted-down">Option, select whether you want to turn the LED on or off.</li>
-</ul></div><div id="bob3Actions_remember" class="help expert"><h3 id="BlockdescriptionBOB3-»remembernumber...«[Expert-block]">»remember number ... « <span class="typcn typcn-star"></span></h3><p>With this block you can store a number in the cache of the BOB3. The cache is very small and you can only store one number at a time. If you store a new number, the old number will be overwritten.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number you want to save.</li>
-</ul></div><div id="bob3Actions_recall" class="help expert"><h3 id="BlockdescriptionBOB3-»recallnumber«[Expert-block]">»recall number « <span class="typcn typcn-star"></span></h3><p>With this block you can read the number in the cache of the BOB3.</p><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the number currently stored in the cache.</li>
-</ul></div><div id="robSensors_infrared_getSample" class="help beginner"><h3 id="BlockdescriptionBOB3-»get...light%infraredsensor«">»get ... light % infrared sensor «</h3><p>With this block you can scan your robot's infrared sensor and measure either the ambient light or the light reflected by your robot.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, select the type of light you want to measure, either ambient or reflected light.</li>
-</ul><p class="auto-cursor-target"><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number,  value of the measured light between 0 and 100.</li>
-</ul></div><div id="robSensors_pintouch_getSample" class="help beginner"><h3 id="BlockdescriptionBOB3-»arm...pressed?«">»arm ... pressed? «</h3><p>With this block you can query your robot's touch sensors to see if they are currently being pressed.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, select the side of the robot you want to query. Either left or right.</li><li class="typcn typcn-arrow-sorted-down">option, select the sensor you want to query. Either a single sensor on the selected site or all sensors on the site at once.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, either true or false, depending on whether the sensor is pressed or not</li>
-</ul></div><div id="robSensors_temperature_getSample" class="help beginner"><h3 id="BlockdescriptionBOB3-»getvalue°temperaturesensor«">»get value ° temperature sensor «</h3><p>With this block you can query the built-in temperature sensor of your robot and measure the ambient temperature.</p><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, temperature of the robot's surroundings in °C.</li>
-</ul></div><div id="robSensors_code_getSample" class="help beginner"><h3 id="BlockdescriptionBOB3-»getvaluecodepad«">»get value code pad «</h3><p>With this block you can request the binary code on the back of your robot.</p><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, value of the binary code on the back.</li>
-</ul></div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="BlockdescriptionBOB3-»getvaluemstimer1«">»get value ms timer 1 «</h3><p>With this block you can query the internal timer of your robot. It tells you the time since the start of the program or the last reset.</p><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">number, elapsed time since program start or last reset in milliseconds.</li>
-</ul></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="BlockdescriptionBOB3-»resettimer1«">»reset timer 1 «</h3><p>With this block you can reset the value of your robot's built-in timer to 0.</p></div><div id="robControls_if" class="help beginner"><h3 id="BlockdescriptionBOB3-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="BlockdescriptionBOB3-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="BlockdescriptionBOB3-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="BlockdescriptionBOB3-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="BlockdescriptionBOB3-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="BlockdescriptionBOB3-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="BlockdescriptionBOB3-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="BlockdescriptionBOB3-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="BlockdescriptionBOB3-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="BlockdescriptionBOB3-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="BlockdescriptionBOB3-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="BlockdescriptionBOB3-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="BlockdescriptionBOB3-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="BlockdescriptionBOB3-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="BlockdescriptionBOB3-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="BlockdescriptionBOB3-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="BlockdescriptionBOB3-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="BlockdescriptionBOB3-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="BlockdescriptionBOB3-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="BlockdescriptionBOB3-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="BlockdescriptionBOB3-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="BlockdescriptionBOB3-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="BlockdescriptionBOB3-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="BlockdescriptionBOB3-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="BlockdescriptionBOB3-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBOB3-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="BlockdescriptionBOB3-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="BlockdescriptionBOB3-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="BlockdescriptionBOB3-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="BlockdescriptionBOB3-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionBOB3-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionBOB3-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="BlockdescriptionBOB3-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="BlockdescriptionBOB3-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="BlockdescriptionBOB3-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBOB3-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionBOB3-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionBOB3-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBOB3-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBOB3-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBOB3-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBOB3-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBOB3-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBOB3-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBOB3-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBOB3-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockdescriptionBOB3-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="BlockdescriptionBOB3-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="BlockdescriptionBOB3-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockdescriptionBOB3-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="BlockdescriptionBOB3-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="BlockdescriptionBOB3-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="BlockdescriptionBOB3-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="BlockdescriptionBOB3-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="BlockdescriptionBOB3-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="BlockdescriptionBOB3-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="BlockdescriptionBOB3-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="BlockdescriptionBOB3-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="BlockdescriptionBOB3-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="BlockdescriptionBOB3-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="BlockdescriptionBOB3-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div><div id="bob3Communication_sendBlock" class="help expert"><h3 id="BlockdescriptionBOB3-»sendmessage...«[Expert-block]">»send message ... « <span class="typcn typcn-star"></span></h3><p>With this block you can send a message to all other robots in your environment. However, you can only send numbers as a message to other robots.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, message you want to send to other robots.</li>
-</ul><br></div><div id="bob3Communication_receiveBlock" class="help expert"><h3 id="BlockdescriptionBOB3-»receivemessage«[Expert-block]">»receive message « <span class="typcn typcn-star"></span></h3><p>With this block you can receive messages from other robots.</p><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, the received message.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start_ardu" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»Programstart«"><span style="color: rgb(0,0,0);">»Program start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Each program starts with the »Start« block, which cannot be deleted. The first block you want to use is
+                connected directly to the »Sequence connection« on the »Repeat indefinitely« block.</p>
+            <p>For systems based on an Arduino or similar microcontroller, there is always a »repeat indefinitely« loop
+                connected to the start block, which also cannot be removed. This is due to the fact that such
+                microcontrollers are usually programmed for exactly one task, which then has to be executed again and
+                again. If you only want one run of the program, you can simply make the robot wait at the end of the
+                loop for a very long time.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">create a new global variable</li>
+                <li class="typcn typcn-minus">delete the global variable</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«,
+                    »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li>
+                <li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial
+                    value of the variable.</li>
+            </ul>
+        </div>
+        <div id="makeblockActions_leds_on" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»turnLEDeye...oncolour...«">»turn LED eye ... on colour ... «</h3>
+            <p>With this block you can switch on one of the LEDs of the BOB3, which are in the eyes of the BOB3. These
+                LEDs are RGB LEDs, so they can display different colors of red, green and blue.</p>
+            <p>Option and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose which LED you want to control</li>
+                <li class="typcn typcn-arrow-left">colour, the colour you want the eye to display.</li>
+            </ul>
+        </div>
+        <div id="makeblockActions_leds_off" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»turnLEDeye...off«">»turn LED eye ... off«</h3>
+            <p>With this block you can turn off one of the LEDs in the eyes of your BOB3.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose which LED you want to turn off.</li>
+            </ul>
+        </div>
+        <div id="bob3Actions_set_led" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»turnLEDbody...«">»turn LED body ... «</h3>
+            <p>With this button you can control an LED on the body of the BOB3. These LEDs glow white and you can either
+                switch them off or on.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, select here the LED you want to control.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, select whether you want to turn the LED on or off.
+                </li>
+            </ul>
+        </div>
+        <div id="bob3Actions_remember" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»remembernumber...«[Expert-block]">»remember number ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can store a number in the cache of the BOB3. The cache is very small and you can only
+                store one number at a time. If you store a new number, the old number will be overwritten.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number you want to save.</li>
+            </ul>
+        </div>
+        <div id="bob3Actions_recall" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»recallnumber«[Expert-block]">»recall number « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can read the number in the cache of the BOB3.</p>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the number currently stored in the cache.</li>
+            </ul>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»get...light%infraredsensor«">»get ... light % infrared sensor «</h3>
+            <p>With this block you can scan your robot's infrared sensor and measure either the ambient light or the
+                light reflected by your robot.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, select the type of light you want to measure, either
+                    ambient or reflected light.</li>
+            </ul>
+            <p class="auto-cursor-target"><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, value of the measured light between 0 and 100.</li>
+            </ul>
+        </div>
+        <div id="robSensors_pintouch_getSample" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»arm...pressed?«">»arm ... pressed? «</h3>
+            <p>With this block you can query your robot's touch sensors to see if they are currently being pressed.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, select the side of the robot you want to query. Either
+                    left or right.</li>
+                <li class="typcn typcn-arrow-sorted-down">option, select the sensor you want to query. Either a single
+                    sensor on the selected site or all sensors on the site at once.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, either true or false, depending on whether the sensor is
+                    pressed or not</li>
+            </ul>
+        </div>
+        <div id="robSensors_temperature_getSample" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»getvalue°temperaturesensor«">»get value ° temperature sensor «</h3>
+            <p>With this block you can query the built-in temperature sensor of your robot and measure the ambient
+                temperature.</p>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, temperature of the robot's surroundings in °C.</li>
+            </ul>
+        </div>
+        <div id="robSensors_code_getSample" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»getvaluecodepad«">»get value code pad «</h3>
+            <p>With this block you can request the binary code on the back of your robot.</p>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, value of the binary code on the back.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»getvaluemstimer1«">»get value ms timer 1 «</h3>
+            <p>With this block you can query the internal timer of your robot. It tells you the time since the start of
+                the program or the last reset.</p>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">number, elapsed time since program start or last reset in
+                    milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»resettimer1«">»reset timer 1 «</h3>
+            <p>With this block you can reset the value of your robot's built-in timer to 0.</p>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="BlockdescriptionBOB3-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue
+                with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="BlockdescriptionBOB3-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="BlockdescriptionBOB3-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»mathematicalfunction«[Expert-block]">»mathematical function« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBOB3-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionBOB3-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionBOB3-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="BlockdescriptionBOB3-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockdescriptionBOB3-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="BlockdescriptionBOB3-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBOB3-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionBOB3-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionBOB3-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number«
+                <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBOB3-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBOB3-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBOB3-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBOB3-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBOB3-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBOB3-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBOB3-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBOB3-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockdescriptionBOB3-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="BlockdescriptionBOB3-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="BlockdescriptionBOB3-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockdescriptionBOB3-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ...
+                green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="BlockdescriptionBOB3-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ...
+                blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="BlockdescriptionBOB3-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green
+                ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="BlockdescriptionBOB3-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function
+                blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function
+                blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="BlockdescriptionBOB3-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with
+                return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="BlockdescriptionBOB3-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function
+                with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»functioncallwithoutreturnvalue«">»function call without return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockdescriptionBOB3-»functioncallwithreturnvalue«">»function call with
+                return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul>
+        </div>
+        <div id="bob3Communication_sendBlock" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»sendmessage...«[Expert-block]">»send message ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can send a message to all other robots in your environment. However, you can only
+                send numbers as a message to other robots.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, message you want to send to other robots.</li>
+            </ul><br>
+        </div>
+        <div id="bob3Communication_receiveBlock" class="help expert">
+            <h3 id="BlockdescriptionBOB3-»receivemessage«[Expert-block]">»receive message « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can receive messages from other robots.</p>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, the received message.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_calliope_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_calliope_de.html
@@ -1,484 +1,1911 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><br><h3 id="ProgrammierBlöckeCalliope-»Programmstart«"><span style="color: rgb(0,0,0);">»Programmstart«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Jedes Programm beginnt mit dem »Programmstart-Block«, welcher nicht gelöscht werden kann. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am Programmstart-Block. </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Wenn globale Variablen erzeugt wurden:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variablen.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
-</ul></div><div id="mbedActions_display_text" class="help beginner"><h3 id="ProgrammierBlöckeCalliope-»ZeigeText...«"><span style="color: rgb(0,0,0);">»Zeige Text ...«</span></h3><p>Mit dem Block »Zeige ...« kannst du deinen Calliope mini Text darstellen lassen.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »Text« zeigt die Zeichenkette als Laufschrift über den Bildschirm an,  »Zeichen« blendet die Buchstaben nacheinander ein.</li><li class="typcn typcn-arrow-left">Zeichenkette, anzuzeigender Text.</li>
-</ul></div><div id="mbedActions_display_image" class="help beginner"><h3 id="ProgrammierBlöckeCalliope-»ZeigeBild...«"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Zeige Bild ...«</span><br></span></h3><p>Mit dem Block »Zeige Bild/Animation« können selbst erstellte oder vordefinierte Bilder auf dem Bildschirm deines Calliope mini angezeigt werden.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Bild oder Animation, Bilder werden nacheinander angezeigt.</li><li class="typcn typcn-arrow-left">Bild oder Liste von Bildern als Animation.</li>
-</ul></div><div id="mbedActions_display_clear" class="help beginner"><h3 id="ProgrammierBlöckeCalliope-»LöscheBildschirm«"><span style="color: rgb(0,0,255);"> <span style="color: rgb(0,0,0);">»Lösche Bildschirm«</span><br></span></h3><p>Mit dem Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Lösche Bildschirm</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« kann der Bildschirminhalt deines Calliope mini gelöscht werden</span></span>.</p></div><div id="mbedActions_display_setBrightness" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»SetzeHelligkeit...«[Experten-Block]">»Setze Helligkeit ...« <span class="typcn typcn-star"></span></h3><p>Die Helligkeit aller LEDs auf dem Bildschirm deines Calliope mini wird auf einen einheitlichen Wert gesetzt. 0 schaltet die LEDs ganz aus, 9 ist der maximale Helligkeitswert.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 9 für die Helligkeit der LEDs. Dabei bedeutet 0, dass die LEDs aus sind und 9, dass die LEDs am hellsten leuchten.</li>
-</ul></div><div id="mbedActions_display_getBrightness" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»gibHelligkeit«[Experten-Block]">»gib Helligkeit« <span class="typcn typcn-star"></span></h3><p>Die Helligkeit aller LEDs auf dem Bildschirm deines Calliope mini wird gelesen. 0 bedeutet, dass alle LEDs ausgeschaltet sind, 9 ist der Helligkeitswert.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Wert zwischen 0 und 9 für die Helligkeit der LEDs. Dabei bedeutet 0, dass die LEDs aus sind und 9, dass die LEDs am hellsten leuchten.</li>
-</ul></div><div id="mbedActions_display_setPixel" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»SetzeLEDHelligkeitx...«[Experten-Block]">»Setze LED Helligkeit x ...« <span class="typcn typcn-star"></span></h3><p>Die Helligkeit einer einzelnen LED auf dem Bildschirm deines Calliope mini wird auf einen Wert festgelegt. Die Position der LED wird mittels x-Achse und y-Achse ermittelt. x ist die horizontale  und  y ist die vertikale Achse. 0 schaltet die LEDs aus, 9 ist der maximale Helligkeitswert.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 4 für die x-Position der LED. Dabei steht 0 für die erste LED in der Reihe und 4 für die fünfte und die letzte LED in der Reihe.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 4 für die y-Position der LED. Dabei steht 0 für die erste LED in der Spalte und 4 für die fünfte und die letzte LED in der Spalte.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 9 für die Helligkeit der LED. Dabei bedeutet 0, dass die LED aus ist und 9, dass die LED am hellsten leuchtet.</li>
-</ul></div><div id="mbedActions_display_getPixel" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»gibLEDHelligkeitx...«[Experten-Block]">»gib LED Helligkeit x ...« <span class="typcn typcn-star"></span></h3><p>Die Helligkeit einer LED auf dem Bildschirm deines Calliope mini wird gelesen. Die Position der LED wird mittels x-Achse und y-Achse ermittelt. x ist die horizontale und y ist die vertikale Achse. 0 bedeutet, dass die LED ausgeschaltet ist und 9, dass die LED am hellsten leuchtet.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 4 für die x-Position der LED. Dabei steht 0 für die erste LED in der Reihe und 4 für die fünfte und die letzte LED in der Reihe.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 4 für die y-Position der LED. Dabei steht 0 für die erste LED in der Spalte und 4 für die fünfte und die letzte LED in der Spalte.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Wert zwischen 0 und 9. Dabei bedeutet 0, dass die LED aus ist und 9, dass die LED am hellsten leuchtet.</li>
-</ul><br></div><div id="robActions_serial_print" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»ZeigeaufSerialMonitor...«[Experten-Block]">»Zeige auf Serial Monitor ...« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »Zeige auf Serial Monitor...« kannst du die Ausgabe in einem Serialen Monitor deiner Wahl (z.B. Arduino Serial Monitor / (Chrome) Browser Serial Monitor) anzeigen lassen.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Bestimme, was auf deinem Serialen Monitor angezeigt werden soll. Mögliche Varianten sind: Zahl, logischer Wert, Zeichenkette oder Farbe.</li>
-</ul></div><div id="mbedActions_fourDigitDisplay_show" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»Zeige4-ZiffernDisplayZahl...«[Experten-Block]">»Zeige 4-Ziffern Display Zahl...« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine Zahl von 0 bis  9999 auf dem Grove 4-Ziffern Display von Seeed anzeigen lassen. Das Display muss am rechten Grove-Anschluss (A1) angeschlossen werden. Die Position von 0 bis 3 gibt die Startposition der Zahl an.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"><p align="left">Zahl, Wert zwischen 0 und 9999. Diese Zahl wird auf dem Display abgebildet.</p></li><li class="typcn typcn-arrow-left"><p align="left">Zahl, Wert von 0 bis 3. Dies ist die Startposition der eingegeben Zahl.</p></li><li class="typcn typcn-arrow-left"><p align="left">Logischer Wert, wahr oder falsch. Bestimmt, ob ein Doppelpunkt in der Mitte angezeigt werden soll.</p></li>
-</ul></div><div id="mbedActions_fourDigitDisplay_clear" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»LöscheBildschirm4-ZiffernDisplay«[Experten-Block]">»Lösche Bildschirm 4-Ziffern Display« <span class="typcn typcn-star"></span></h3><p>Dieser Block löscht die Ausgabe auf dem Grove-Display von Seeed, wenn dieses am rechtem Grove-Anschluss (A1) angeschlossen ist.</p><br></div><div id="mbedActions_leds_on" class="help beginner"><h3 id="ProgrammierBlöckeCalliope-»SchalteLED...anFarbe...«">»Schalte LED ... an Farbe ...«</h3><p>Mit dem Block »Schalte LED ... an Farbe ...« kannst du die RGB-LED deines Calliope mini oder Calli:bot in einer bestimmten Farbe einschalten.</p><p>Auswahlmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, RGB-LED, die du einschalten möchtest.</li><li class="typcn typcn-arrow-left">Farbe, in der die RGB-LED leuchten soll.</li>
-</ul></div><div id="mbedActions_leds_off" class="help beginner"><h3 id="ProgrammierBlöckeCalliope-»SchalteLEDaus...«">»Schalte LED aus ...«</h3><p>Mit dem Block »Schalte LED aus ...« kannst du eine RGB-LED deines Calliope mini oder Calli:bot ausschalten.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, RGB-LED, die du ausschalten möchtest.</li>
-</ul></div><div id="mbedActions_ledBar_set" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»SetzeLEDLeiste...Helligkeit...«[Experten-Block]">»Setze LED Leiste ... Helligkeit ...« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block setzt du die ausgewählte LED auf der Grove LED-Bar v2.0 von Seeed auf die ausgewählte Helligkeit. Die LED-Leiste muss mit dem rechten Grove-Anschluss (A1) verbunden werden. Dabei leuchtet die erste LED, also LED 0, rot, LED 1 orange und alle anderen grün.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wert von 0 bis 9. Die Zahl zeigt die LED, die gesteuert werden soll. Die Nummerierung der LEDs beginnt unten am Schriftzug »LED Bar v2.0«.</li><li class="typcn typcn-arrow-left">Zahl, Wert von 0 bis 8. Dabei bedeutet 0, dass die LED aus ist und 8, dass die LED am hellsten leuchtet.</li>
-</ul></div><div id="robActions_brickLight_on" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»SchalteLEDanCalli:bot...«[Experten-Block]">»Schalte LED an Calli:bot ...« <span class="typcn typcn-star"></span></h3><p class="western">Mit diesem Block wird die rote LED am Calli:bot ein- oder ausgeschaltet.</p><p class="western auto-cursor-target">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die LED, welche du an deinem Calli:bot steuern möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle, ob die LED ein- oder ausgeschaltet werden soll.</li>
-</ul></div><div id="mbedActions_motors_on" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»Motor...anTempo%...«[Experten-Block]">»Motor ... an Tempo % ... « <span class="typcn typcn-star"></span></h3><p>Der Block »<span style="color: rgb(0,0,255);"><span><span style="color: rgb(0,0,0);">Motor ... an Tempo</span><span style="color: rgb(0,0,0);"> % ... </span></span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« setzt </span></span>das Tempo (Geschwindigkeit) des jeweiligen Motors auf einen neuen Wert.</p><p>Falls einer von zwei angeschlossenen Motoren sich nicht drehen soll, so muss dessen Tempo-Wert explizit auf 0 gestellt werden.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Motoren aus, für die das Tempo (Geschwindigkeit) eingestellt werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 100. Geschwindigkeit des ersten Motors in Prozent.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 100. Geschwindigkeit des zweiten Motors in Prozent.</li>
-</ul></div><div id="mbedActions_motors_stop" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»StoppeMotorPortA+B«[Experten-Block]">»Stoppe Motor Port A + B« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Stoppe Motor Port A + B</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« schaltest du den Motor A und den Motor B gleichzeitig aus.</span></span></p></div><div id="mbedActions_motor_on" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»MotorPort...anTempo...«[Experten-Block]">»Motor Port ... an Tempo ...« <span class="typcn typcn-star"></span></h3><p>Der Block »<span style="color: rgb(0,0,255);"><span><span style="color: rgb(0,0,0);">Motor Port </span><span style="color: rgb(0,0,0);">... an Tempo ...</span></span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« setzt </span></span>das Tempo (Geschwindigkeit) eines Motors auf einen neuen Wert.</p><p>Wenn zwei Motoren angeschlossen sind, laufen beide nur mit halber Leistung. Falls einer von zwei angeschlossenen Motoren sich nicht drehen soll, so muss dessen Tempo-Wert explizit auf 0 gestellt werden. Es wird empfohlen, beim Einsatz von zwei Motoren stets zwei Motor-Blöcke - für jeden einen - als Paare zu verwenden.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, für den das Tempo eingestellt werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 100.</li>
-</ul></div><div id="mbedActions_motor_stop" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»StoppeMotor...«[Experten-Block]">»Stoppe Motor ...« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Stoppe Motor ...</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« schaltest du den </span></span>Motor, der an deinem Calliope mini oder Calli:bot angeschlossen ist, aus.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den Motor aus, der ausgeschaltet werden soll.</li>
-</ul></div><div id="mbedActions_single_motor_on" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»MotoranTempo%...«[Experten-Block]">»Motor an Tempo % ...« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block setzt du das Tempo (Geschwindigkeit) des Motors auf einen neuen Wert. Achtung: Dieser Block kann nur den Motor steuern, den du an die Motor-Pins über der RGB-LED anschließt.</p><br><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Geschwindigkeit des Motors. Wenn die Zahl negativ ist, wird die Drehrichtung umgekehrt.</li>
-</ul></div><div id="mbedActions_single_motor_stop" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»StoppeMotor...«[Experten-Block].1">»Stoppe Motor ...« <span class="typcn typcn-star"></span></h3><p>Du kannst einstellen, ob der Motor langsam ausläuft oder gebremst wird.
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Stoppmöglichkeiten; »auslaufen<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">«</span></span> sorgt dafür, dass der Motor langsam ausläuft; »bremsen<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">«</span></span> sorgt dafür, dass der Motor abrupt abgebremst wird.</li>
-</ul></div><div id="mbedActions_servo_set" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»SetzeServomotor...auf°...«[Experten-Block]">»Setze Servomotor ... auf ° ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du einen angeschlossenen Servomotor steuern und dessen Arm drehen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Winkel bzw. Position in die sich der Arm des Servomotors drehen soll. Zahl zwischen -180 und 180.</li>
-</ul><br></div><div id="mbedActions_motionkit_single_set" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»MotionKit......«[Experten-Block]">»MotionKit ... ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du einen einzelnen Motor des MotionKits ansteuern und ihn entweder vor- oder rückwärts laufen lassen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, der Motor, den du ansteuern möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, vor- oder rückwärts, die Richtung in die sich der Motor dreehen soll.</li>
-</ul><br></div><div id="mbedActions_motionkit_dual_set" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»MotionKitlinks...rechts...«[Experten-Block]">»MotionKit links ... rechts ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du die beiden Motoren des MotionKits gleichzeitig ansteuern. Dabei müssen sich die beiden Motoren allerdings nicht in die gleiche Richtung drehen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, vor- oder rückwärts, die Richtung in die sich der linke Motor drehen soll.</li><li class="typcn typcn-arrow-sorted-down">Option, vor- oder rückwärts, die Richtung, in die sich der rechte Motor drehen soll.</li>
-</ul><br></div><div id="mbedActions_play_note" class="help beginner"><h3 id="ProgrammierBlöckeCalliope-»Spiele...«">»Spiele ...«</h3><p>Mit dem Block »Spiele ...« bringst du deinen Roboter dazu, einen ganze, halbe, viertel, achtel oder sechzehntel Note abzuspielen.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Länge der Note.</li><li class="typcn typcn-arrow-sorted-down">Option, Note die gespielt werden soll.</li>
-</ul></div><div id="mbedActions_play_tone" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»SpieleFrequenz...Dauer«[Experten-Block]">»Spiele Frequenz ... Dauer« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »Spiele Frequenz ... Dauer« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie lange der Ton gespielt wird) programmieren. Der Ton wird über den eingebauten Lautsprecher deines Calliope mini abgespielt, bis die eingestellte Dauer erreicht ist.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Bitte beachte, dass das menschliche Gehör Frequenzen zwischen ca. 30 Hz bis ca. 15.000 Hz (15 kHz) wahrnehmen kann - je nach Mensch und Alter kann dies unterschiedlich sein.</p></div></div><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, gewünschte Frequenz in Hz (Hertz) eingeben. Je höher die Frequenz, desto höher ist der Ton.</li><li class="typcn typcn-arrow-left"> Zahl, gewünschte Dauer des Tons in Millisekunden (ms) eingeben.</li>
-</ul></div><div id="mbedActions_write_to_pin" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»Schreibe...WertaufPin...«[Experten-Block]">»Schreibe ... Wert auf Pin ...« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »Schreibe ... Wert auf Pin ...« kannst du einen analogen oder digitalen Wert auf einen der Pins schreiben.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, analog oder digital. »Analog« sind die Werte zwischen 0 und 1023. 0 bedeutet, dass es keine keine Spannung am Pin anliegt, und 1023 bedeutet, dass die vollen 3.3V anliegen. »Digital« sind entweder 0 oder 1. 0 bedeutet, dass keine Spannung anliegt und 1 bedeutet, dass volle Spannung anliegt.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle den Ausgabepin aus.</li><li class="typcn typcn-arrow-left">Zahl, zu schreibender Wer. »Analog« sind die Werte zwischen 0 und 1023. 0 bedeutet, dass es keine keine Spannung am Pin anliegt, und 1023 bedeutet, dass die vollen 3.3V anliegen. »Digital« sind entweder 0 oder 1. 0 bedeutet, dass keine Spannung anliegt und 1 bedeutet, dass volle Spannung anliegt.</li>
-</ul></div><div id="mbedActions_switch_led_matrix" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»SchalteLEDMatrix...«[Experten-Block]">»Schalte LED Matrix ...« <span class="typcn typcn-star"></span></h3><p class="western">Mit diesem Block wird die LED Matrix  ein- oder ausgeschaltet.</p><p class="western auto-cursor-target">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">An / Aus - steuert, ob die LED Matrix ein- oder ausgeschaltet wird.</li>
-</ul></div><div id="robSensors_key_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeCalliope-»Taste...gedrückt?«">»Taste ... gedrückt?«</h3><p>Mit dem Block »Taste ... gedrückt?« kannst du einem anderen Block »mitteilen«,  ob eine der eingebauten Tasten gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>wahr = gedrückt</em> oder <em>falsch = nicht gedrückt</em> zurück.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Taste aus, die du abfragen möchtest.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn die Taste gedrückt ist, sonst »falsch«.</li>
-</ul> </div><div id="robSensors_pintouch_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeCalliope-»Pin...gedrückt?«">»Pin ... gedrückt?«</h3><p>Mit dem Block »Pin ... gedrückt?« kannst du einem anderen Block »mitteilen«,  ob der ausgewählte Pin berührt wird oder nicht. Dieser Block gibt die logischen Werte <em>wahr = gedrückt</em> oder <em>falsch = nicht gedrückt</em> zurück.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den Pin aus, den du abfragen willst.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn der Pin berührt wird, sonst »falsch«.</li>
-</ul> </div><div id="robSensors_gesture_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeCalliope-»Gib...Lage«">»Gib ... Lage«</h3><p>Mit dem Block »Gib ... Lage« kannst du einem anderen Block »mitteilen«, ob sich der Calliope mini in einer bestimmten Lage befindet. Dieser Block fragt den eingebauten Gyrosensor des Calliope mini ab.</p><p>Befindet sich der Calliope mini in der abgefragten Lage liefert der »Gib ... Lage« Block  »wahr«, sonst »falsch«.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><p>Option, wähle die Lage, die abgefragt werden soll. Mögliche Lagen:</p><ul><li>aufrecht: USB-Anschluss des Calliope mini zeigt nach oben</li><li>kopfüber: USB-Anschluss des Calliope mini zeigt nach unten</li><li>auf der Vorderseite: Calliope-Beschriftung zeigt nach unten</li><li>auf der Rückseite: Calliope-Beschriftung zeigt nach oben</li><li>geschüttelt: Calliope mini wird geschüttelt</li><li>frei fallend: Calliope mini wird nach unten beschleunigt</li></ul></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn er sich in der ausgewählten Lage befindet, sonst »falsch«.</li>
-</ul> </div><div id="robSensors_compass_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeCalliope-»gibWinkel°Kompasssensor«">»gib Winkel ° Kompasssensor«</h3><p>Mit dem Block »gib Winkel Kompasssensor« kannst du die Orientierung deines Calliope minis im Bezug auf die Himmelsrichtungen auslesen, genau wie auf einem Kompass.</p><p>Dazu musst du vorher den Calliope mini kalibrieren, indem du den Calliope mini in alle Richtungen neigst, bis alle LEDS auf dem Display des Calliope mini leuchten.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Orientierung in Grad von 0° bis 360°. Dabei bedeutet 0°, dass dein Calliope mini in Richtung Norden zeigt.</li>
-</ul> </div><div id="robSensors_sound_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeCalliope-»gibGeräusch%Mikrofon«">»gib Geräusch % Mikrofon«</h3><p>Mit dem Block »gib Wert Mikrofon« kannst du die Lautstärke von Geräuschen in der näheren Umgebung messen. Das Mikrofon ist nicht sehr empfindlich und die Geräusche sollten nicht zu weit weg sein.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Lautstärke von 0 (leise) bis 100 (laut). Bei älteren Versionen des Calliope mini kann es sein, dass nur Werte zwischen 0 und ca. 10 ausgegeben werden.</li>
-</ul> </div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="ProgrammierBlöckeCalliope-»gibWertmsZeitgeber«">»gib Wert ms Zeitgeber«</h3><p>Mit dem Block »Gib Wert Zeitgeber« kannst du einem anderen Block den aktuellen Stand des internen Zeitgebers in Millisekunden »mitteilen«. Der Zeitgeber 1 wird automatisch mit dem Beginn eines Programms gestartet.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, aktueller Wert des Zeitgebers in Millisekunden.</li>
-</ul></div><div id="mbedSensors_timer_reset" class="help beginner"><h3 id="ProgrammierBlöckeCalliope-»SetzeZeitgeberzurück«">»Setze Zeitgeber zurück«</h3><p>Mit dem Block »Setze Zeitgeber zurück« kannst du den internen Zeitgeber auf den Wert 0 zurücksetzen.</p><br></div><div id="robSensors_temperature_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeCalliope-»gibWert°Temperatursensor«">»gib Wert ° Temperatursensor«</h3><p>Mit dem Block »gib Wert Temperatursensor« kannst du die aktuell gemessene Temperatur als Zahl auslesen. Dieser Block fragt den eingebauten Temperatursensor des Calliope mini ab.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl; Temperatur in Grad Celsius.</li>
-</ul> </div><div id="robSensors_rssi_getSample" class="help expert"> <h3 id="ProgrammierBlöckeCalliope-»gibWertEmpfangsstärke«[Experten-Block]">»gib Wert Empfangsstärke« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block gibst du die Signalstärke der letzten Nachricht zurück.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Signalstärke der letzten Nachricht.</li>
-</ul> </div><div id="robSensors_light_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeCalliope-»gibWert%Lichtsensor«">»gib Wert % Lichtsensor«</h3><p>Mit dem Block »gib Wert % Lichtsensor« kannst du Helligkeit deiner Umgebung messen. Dieser Block fragt den eingebauten Lichtsensor des Calliope mini ab.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl; Helligkeit von 0 bis 100. 0 bedeutet, dass es dunkel ist und 100, dass es hell ist.</li>
-</ul> </div><div id="robSensors_pin_getSample" class="help expert"> <h3 id="ProgrammierBlöckeCalliope-»gib...WertPin...«[Experten-Block]">»gib ... Wert Pin ...« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »gib ... Wert Pin ...« kannst du den Eingabewert an dem ausgewählten Pin auslesen, wenn du dort ein anderes Gerät oder Zusatzmodul angeschlossen hast. </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle, welche Art von Signal du einlesen möchtest. »Analog« sind die Werte zwischen 0 und 1023. 0 bedeutet, dass es keine keine Spannung am Pin anliegt, und 1023 bedeutet, dass die vollen 3.3V anliegen. »Digital« sind entweder 0 oder 1. 0 bedeutet, dass keine Spannung anliegt und 1 bedeutet, dass volle Spannung anliegt.</li><li class="typcn typcn-arrow-sorted-down">Pin, wähle den Pin aus, den du abfragen willst.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl; aktueller Wert des Eingangssignals. Entweder zwischen 0 und 1023  bei einem analogen Signal, bei einem digitalen Signal entweder 0 oder 1.</li>
-</ul> </div><div id="robSensors_gyro_getSample" class="help expert"> <h3 id="ProgrammierBlöckeCalliope-»gibWinkel°Kreiselsensor...«">»gib Winkel ° Kreiselsensor ...«</h3><p>Dieser Block gibt den aktuellen Wert des Kreiselsensors zurück. Der Wert ist der Winkel, um den der Calliope mini in die ausgewählte Richtung geneigt ist.</p><p class="auto-cursor-target">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Achse, um die der Calliope mini gedreht wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Winkel um die der Calliope mini gedreht worden ist. Die x-Achse ist diejenige, die den Pin 0 und 3 gedanklich verbindet (im Bild grün). Sie kann die Werte von 0° bis 90° zurückgeben. Die y-Achse (im Bild rot) gibt die Werte von -180° bis +180° und verbidet gedanklich den USB-Connector mit der Auskerbung.</li>
-</ul> </div><div id="robSensors_accelerometer_getSample" class="help expert"> <h3 id="ProgrammierBlöckeCalliope-»gibWertmilli-gBeschleunigungssensor...«[Experten-Block]">»gib Wert milli-g Beschleunigungssensor ...« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »gib Wert milli-g Beschleunigung ...« kannst du die Beschleunigung des Calliope mini auslesen. Es gibt drei Richtungen, in denen die Beschleunigung gemessen werden kann. Die Beschleunigung kann in die drei verschiedenen Raumrichtungen (links-rechts, vorne-hinten und oben-unten) gemessen werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Optionen; wähle, für welche Richtung der Wert ausgegeben werden soll. »x« ist die links-rechts-Achse, »y« die vorne-hinten-Achse, »z« ist die oben-unten Achse.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl; aktueller Wert der Beschleunigung in milli-g. 1g oder 1000 milli-g wirken auf den Calliope mini aufgrund der Erdbeschleunigung, ohne das er bewegt wird.</li>
-</ul> </div><div id="robSensors_humidity_getSample" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»gib...LuftfeuchtigkeitssensorA1«[Experten-Block]">»gib ... Luftfeuchtigkeitssensor A1« <span class="typcn typcn-star"></span></h3><p class="western">Dieser Block zeigt den Wert des Feuchtigkeitssensors. Dieser Sensor misst sowohl die relative Luftfeuchtigkeit als auch die Temperatur der Umgebung und muss an den Pin A1 angeschlossen werden.</p><p class="western">Der verwendete Sensor ist ein SHT31 und kommuniziert per I²C mit dem Calliope mini.</p><p class="western">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wert der Luftfeuchtigkeit in Prozent oder der Temperatur in Grad Celsius.</li>
-</ul><p class="western auto-cursor-target">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option; wähle, ob du die Werte für die Luftfeuchtigkeit oder die Temperatur zurückbekommen möchtest.</li>
-</ul></div><div id="robSensors_ultrasonic_getSample" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»gibAbstandcmUltraschallsensor...«[Experten-Block]">»gib Abstand cm Ultraschallsensor ...« <span class="typcn typcn-star"></span></h3><p class="western">Dieser Sensor misst den Abstand zum nächsten Objekt durch das Aussenden von Ultraschallwellen. Dieser Senosor muss entweder am Calliope mini an den Pin A1 oder an den vorgesehenen Platz am Calli:bot angeschlossen werden. Der verwendete Sensor ist ein Grove Ultraschall-Sensor auf Basis eines HC-SR04, allerdings mit einem verbauten Mikrocontroller, der die Kommunikation übernimmt.</p><p class="western">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, der Eingang kann entweder für Calliope mini oder den Calli:bot konfiguriert werden.</li>
-</ul><br><p class="western">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wert des Ultraschallsensors - Abstand zum nächsten Objekt in Zentimetern.</li>
-</ul><br></div><div id="robSensors_infrared_getSample" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»gibLinieInfrarotsensorCalli:bot...«[Experten-Block]">»gib Linie Infrarotsensor Calli:bot ...« <span class="typcn typcn-star"></span></h3><p class="western">Dieser Sensor misst die Schattierung des Untergrunds und gibt zurück, ob es sich um einen hellen oder dunklen Untergrund handelt.</p><p class="western">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn der Untergrund dunkel ist, sonst »falsch«.</li>
-</ul><p class="western auto-cursor-target">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den linken oder rechten Calli:bot Sensor aus.</li>
-</ul></div><div id="robSensors_colourtcs3472_getSample" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»Gib...FarbsensorTCS3472...«[Experten-Block]"><br>»Gib ... Farbsensor TCS3472 ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du den Farbsensor TCS3472 abfragen. Dieser Sensor kann die Farbe, die Helligkeit und die Farbzusammensetzung seiner Umgebung messen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Eigenschaft aus, die du messen möchtest. Es steht Farbe, Licht und RGB zur Auswahl.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle den Sensor aus, den du abfragen möchtest.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die Farbe der Umgebung.</li><li class="typcn typcn-arrow-right">Zahl, die Helligkeit der Umgebung in Prozent.</li><li class="typcn typcn-arrow-right">Liste von Zahlen, die Aufteilung der Farbe in Werte von Rot, Grün und Blau.</li>
-</ul><br></div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»Wartebis...«">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wartems...«">»Warte ms ... «</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wartebis...«.1">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Zufallszahl«">»Zufallszahl« </h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeCalliope-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeCalliope-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt werden soll. Zahl zwischen 0 und 255.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeCalliope-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von der verwendeten Programmiersprache des Roboters abhängt. </span><span style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt, sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der Zeichenkette »52abcd« die Zahl 52.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeCalliope-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li><li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte das die Nummerierung bei 0 anfängt.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeCalliope-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeCalliope-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeCalliope-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeCalliope-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeCalliope-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeCalliope-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeCalliope-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="ProgrammierBlöckeCalliope-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammierBlöckeCalliope-»Farbwahl«">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammierBlöckeCalliope-»Farbwahl«.1">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammierBlöckeCalliope-»Farbwahl«.2">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, die  Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammierBlöckeCalliope-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="ProgrammierBlöckeCalliope-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammierBlöckeCalliope-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammierBlöckeCalliope-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammierBlöckeCalliope-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="ProgrammierBlöckeCalliope-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="ProgrammierBlöckeCalliope-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen Wert zurück.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit Rückgabewert «</h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
-</ul><br></div><div id="mbedImage_image" class="help beginner"><h3 id="ProgrammierBlöckeCalliope-»ErstelleBild«">»Erstelle Bild«<span style="color: rgb(0,0,0);"> </span></h3><p>Mit dem Block <span style="color: rgb(0,0,0);">»Erstelle Bild« kannst du eigene Bilder für die Anzeige des Calliope erstellen. Jede einzelne Leuchte ist durch einen Punkt im Raster dargestellt.</span></p><p><span style="color: rgb(0,0,0);">Du kannst für jede Leuchte eine Helligkeit zwischen 0 und 9 angeben, in der die jeweilige Lampe leuchten soll oder eine <span style="color: rgb(0,0,0);">»#« um die Lampe einfach einzuschalten</span>.</span></p><p><span style="color: rgb(0,0,0);">Ist das Feld leer, wird die Lampe nicht eingeschaltet.</span></p><p>Eingabewerte:<span style="color: rgb(0,0,0);"> </span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl; Helligkeit der Lampe im Raster, Zahl zwischen 0 und 9.</li>
-</ul></div><div id="mbedImage_get_image" class="help beginner"><h3 id="ProgrammierBlöckeCalliope-»Bild«"><span style="color: rgb(0,0,0);">»Bild«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Mit dem Block <span style="color: rgb(0,0,0);">»Bild« kannst du ein vordefiniertes Bild auswählen</span><span style="color: rgb(0,0,0);"><span>.</span></span></p><p>Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Bild, vordefiniertes Bild.</li>
-</ul></div><div id="mbedImage_invert" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»invertiere«[Experten-Block]">»invertiere« <span class="typcn typcn-star"></span></h3><p>Ein Bild wird umgekehrt. Ursprünglich leuchtende LEDs im Calliope-Display werden ausgeschaltet, ausgeschaltete LEDs werden eingeschaltet.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Bild, das invertiert werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Bild, das invertiert wurde.</li>
-</ul></div><div id="mbedImage_shift" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»verschiebe«[Experten-Block]">»verschiebe« <span class="typcn typcn-star"></span></h3><p>Ein Bild wird um einzelne Positionen verschoben. Die Verschieberichtung und die Anzahl Positionen auf dem Display werden eingegeben.</p><p>Eingabewerte und Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Bild, das verschoben werden soll.</li><li class="typcn typcn-arrow-sorted-down">Richtung, in die das Bild verschoben werden soll; Auswahlmöglichkeiten: oben, unten, links oder rechts.</li><li class="typcn typcn-arrow-left">Zahl, um wie viele Positionen das Bild verschoben werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Bild, verschoben um die eingestellten Werte.</li>
-</ul></div><div id="mbedCommunication_sendBlock" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»SendeNachrichtZeichenkette«[Experten-Block]">»Sende Nachricht Zeichenkette« <span class="typcn typcn-star"></span></h3><p>Der Calliope sendet eine Nachricht. Alle Calliope in der nähren Umgebung können diese Nachricht empfangen.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text; Nachricht, die gesendet werden soll</li>
-</ul></div><div id="mbedCommunication_receiveBlock" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»EmpfangeNachrichtZeichenkette«[Experten-Block]">»Empfange Nachricht Zeichenkette« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block <span style="color: rgb(0,0,0);">kannst du nachschauen, ob von anderen Calliopes Nachrichten emfpangen wurden und die letzte dann in deinem Programm verwenden.<br>Wenn noch keine neue Nachricht angekommen ist wartet der Calliope dabei aber nicht, bis eine neue Nachricht ankommt. Es kann also sein, dass du keine Nachricht erhälst.<br></span></p><p><span style="color: rgb(0,0,0);"> Je nach ausgewähltem Nachrichtentyp erhälst du dann eine "0", eine unbekannte Zeichenkette oder "false" als Wert zurück.</span></p><p><span style="color: rgb(0,0,0);">Wenn du eine Zeichenkette empfangen möchtest musst du den unbekannten Wert erst einmal in deinem Programm in einer Variable speichern, damit du überprüfen kannst, ob überhaupt eine Nachricht angekommen ist. Dafür kannst du am Anfang deines Programms eine Variable anlegen und in ihr mit diesem Block eine Nachricht speichern. Da du am Anfang noch keine Nachricht empfangen hast, wird dadurch der unbekannte Wert in deiner Variable gespeichert. Später kannst du empfangene Nachrichten mit deiner Variable (dem unbekannten Wert darin) vergleichen, um herauszufinden, ob wirklich eine Nachricht angekommen ist.</span></p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Nachrichtentyp, »Zeichenkette«, »Zahl« oder »logischer Wert«.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Die letzte Nachricht, die dein Calliope emfpangen hat.</p><p>Wenn noch keine neue Nachricht angekommen ist erhälst du eine leere Nachricht. Je nach ausgewähltem Nachrichtentyp ist dies:</p><ul><li>Zeichenkette: Leere Zeichenkette</li><li>Zahl: 0</li><li>Logischer Wert: Falsch</li></ul></li>
-</ul></div><div id="mbedCommunication_setChannel" class="help expert"><h3 id="ProgrammierBlöckeCalliope-»SetzeKanalauf...«[Experten-Block]">»Setze Kanal auf ...« <span class="typcn typcn-star"></span></h3><p>Dieser Block steuert den Kanal, auf dem der Calliope mini Nachrichten empfängt. Der Calliope mini kann nur Nachrichten empfangen, die auf seinem Kanal gesendet worden sind.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl; Der Kanal, auf dem der Calliope mini Nachrichten senden und empfangen soll.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner"><br>
+            <h3 id="ProgrammierBlöckeCalliope-»Programmstart«"><span
+                    style="color: rgb(0,0,0);">»Programmstart«</span><span style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Programmstart-Block«, welcher nicht gelöscht werden kann. Den ersten
+                Block, den man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am
+                Programmstart-Block. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Wenn globale Variablen erzeugt wurden:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variablen.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_text" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»ZeigeText...«"><span style="color: rgb(0,0,0);">»Zeige Text ...«</span>
+            </h3>
+            <p>Mit dem Block »Zeige ...« kannst du deinen Calliope mini Text darstellen lassen.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »Text« zeigt die Zeichenkette als Laufschrift über den
+                    Bildschirm an, »Zeichen« blendet die Buchstaben nacheinander ein.</li>
+                <li class="typcn typcn-arrow-left">Zeichenkette, anzuzeigender Text.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_image" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»ZeigeBild...«"><span style="color: rgb(0,0,255);"><span
+                        style="color: rgb(0,0,0);">»Zeige Bild ...«</span><br></span></h3>
+            <p>Mit dem Block »Zeige Bild/Animation« können selbst erstellte oder vordefinierte Bilder auf dem Bildschirm
+                deines Calliope mini angezeigt werden.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Bild oder Animation, Bilder werden nacheinander angezeigt.
+                </li>
+                <li class="typcn typcn-arrow-left">Bild oder Liste von Bildern als Animation.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_clear" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»LöscheBildschirm«"><span style="color: rgb(0,0,255);"> <span
+                        style="color: rgb(0,0,0);">»Lösche Bildschirm«</span><br></span></h3>
+            <p>Mit dem Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Lösche
+                        Bildschirm</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">«
+                        kann der Bildschirminhalt deines Calliope mini gelöscht werden</span></span>.</p>
+        </div>
+        <div id="mbedActions_display_setBrightness" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»SetzeHelligkeit...«[Experten-Block]">»Setze Helligkeit ...« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Die Helligkeit aller LEDs auf dem Bildschirm deines Calliope mini wird auf einen einheitlichen Wert
+                gesetzt. 0 schaltet die LEDs ganz aus, 9 ist der maximale Helligkeitswert.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 9 für die Helligkeit der LEDs. Dabei
+                    bedeutet 0, dass die LEDs aus sind und 9, dass die LEDs am hellsten leuchten.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_getBrightness" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»gibHelligkeit«[Experten-Block]">»gib Helligkeit« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Die Helligkeit aller LEDs auf dem Bildschirm deines Calliope mini wird gelesen. 0 bedeutet, dass alle
+                LEDs ausgeschaltet sind, 9 ist der Helligkeitswert.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Wert zwischen 0 und 9 für die Helligkeit der LEDs. Dabei
+                    bedeutet 0, dass die LEDs aus sind und 9, dass die LEDs am hellsten leuchten.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_setPixel" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»SetzeLEDHelligkeitx...«[Experten-Block]">»Setze LED Helligkeit x ...«
+                <span class="typcn typcn-star"></span></h3>
+            <p>Die Helligkeit einer einzelnen LED auf dem Bildschirm deines Calliope mini wird auf einen Wert
+                festgelegt. Die Position der LED wird mittels x-Achse und y-Achse ermittelt. x ist die horizontale und y
+                ist die vertikale Achse. 0 schaltet die LEDs aus, 9 ist der maximale Helligkeitswert.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 4 für die x-Position der LED. Dabei steht 0
+                    für die erste LED in der Reihe und 4 für die fünfte und die letzte LED in der Reihe.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 4 für die y-Position der LED. Dabei steht 0
+                    für die erste LED in der Spalte und 4 für die fünfte und die letzte LED in der Spalte.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 9 für die Helligkeit der LED. Dabei
+                    bedeutet 0, dass die LED aus ist und 9, dass die LED am hellsten leuchtet.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_getPixel" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»gibLEDHelligkeitx...«[Experten-Block]">»gib LED Helligkeit x ...« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Die Helligkeit einer LED auf dem Bildschirm deines Calliope mini wird gelesen. Die Position der LED wird
+                mittels x-Achse und y-Achse ermittelt. x ist die horizontale und y ist die vertikale Achse. 0 bedeutet,
+                dass die LED ausgeschaltet ist und 9, dass die LED am hellsten leuchtet.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 4 für die x-Position der LED. Dabei steht 0
+                    für die erste LED in der Reihe und 4 für die fünfte und die letzte LED in der Reihe.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 4 für die y-Position der LED. Dabei steht 0
+                    für die erste LED in der Spalte und 4 für die fünfte und die letzte LED in der Spalte.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Wert zwischen 0 und 9. Dabei bedeutet 0, dass die LED aus ist
+                    und 9, dass die LED am hellsten leuchtet.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_serial_print" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»ZeigeaufSerialMonitor...«[Experten-Block]">»Zeige auf Serial Monitor ...«
+                <span class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »Zeige auf Serial Monitor...« kannst du die Ausgabe in einem Serialen Monitor deiner Wahl
+                (z.B. Arduino Serial Monitor / (Chrome) Browser Serial Monitor) anzeigen lassen.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Bestimme, was auf deinem Serialen Monitor angezeigt werden soll.
+                    Mögliche Varianten sind: Zahl, logischer Wert, Zeichenkette oder Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_fourDigitDisplay_show" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»Zeige4-ZiffernDisplayZahl...«[Experten-Block]">»Zeige 4-Ziffern Display
+                Zahl...« <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine Zahl von 0 bis 9999 auf dem Grove 4-Ziffern Display von Seeed
+                anzeigen lassen. Das Display muss am rechten Grove-Anschluss (A1) angeschlossen werden. Die Position von
+                0 bis 3 gibt die Startposition der Zahl an.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">
+                    <p align="left">Zahl, Wert zwischen 0 und 9999. Diese Zahl wird auf dem Display abgebildet.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p align="left">Zahl, Wert von 0 bis 3. Dies ist die Startposition der eingegeben Zahl.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p align="left">Logischer Wert, wahr oder falsch. Bestimmt, ob ein Doppelpunkt in der Mitte
+                        angezeigt werden soll.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="mbedActions_fourDigitDisplay_clear" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»LöscheBildschirm4-ZiffernDisplay«[Experten-Block]">»Lösche Bildschirm
+                4-Ziffern Display« <span class="typcn typcn-star"></span></h3>
+            <p>Dieser Block löscht die Ausgabe auf dem Grove-Display von Seeed, wenn dieses am rechtem Grove-Anschluss
+                (A1) angeschlossen ist.</p><br>
+        </div>
+        <div id="mbedActions_leds_on" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»SchalteLED...anFarbe...«">»Schalte LED ... an Farbe ...«</h3>
+            <p>Mit dem Block »Schalte LED ... an Farbe ...« kannst du die RGB-LED deines Calliope mini oder Calli:bot in
+                einer bestimmten Farbe einschalten.</p>
+            <p>Auswahlmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, RGB-LED, die du einschalten möchtest.</li>
+                <li class="typcn typcn-arrow-left">Farbe, in der die RGB-LED leuchten soll.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_leds_off" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»SchalteLEDaus...«">»Schalte LED aus ...«</h3>
+            <p>Mit dem Block »Schalte LED aus ...« kannst du eine RGB-LED deines Calliope mini oder Calli:bot
+                ausschalten.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, RGB-LED, die du ausschalten möchtest.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_ledBar_set" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»SetzeLEDLeiste...Helligkeit...«[Experten-Block]">»Setze LED Leiste ...
+                Helligkeit ...« <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block setzt du die ausgewählte LED auf der Grove LED-Bar v2.0 von Seeed auf die ausgewählte
+                Helligkeit. Die LED-Leiste muss mit dem rechten Grove-Anschluss (A1) verbunden werden. Dabei leuchtet
+                die erste LED, also LED 0, rot, LED 1 orange und alle anderen grün.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wert von 0 bis 9. Die Zahl zeigt die LED, die gesteuert werden
+                    soll. Die Nummerierung der LEDs beginnt unten am Schriftzug »LED Bar v2.0«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert von 0 bis 8. Dabei bedeutet 0, dass die LED aus ist und 8,
+                    dass die LED am hellsten leuchtet.</li>
+            </ul>
+        </div>
+        <div id="robActions_brickLight_on" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»SchalteLEDanCalli:bot...«[Experten-Block]">»Schalte LED an Calli:bot ...«
+                <span class="typcn typcn-star"></span></h3>
+            <p class="western">Mit diesem Block wird die rote LED am Calli:bot ein- oder ausgeschaltet.</p>
+            <p class="western auto-cursor-target">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die LED, welche du an deinem Calli:bot steuern
+                    möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle, ob die LED ein- oder ausgeschaltet werden soll.
+                </li>
+            </ul>
+        </div>
+        <div id="mbedActions_motors_on" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»Motor...anTempo%...«[Experten-Block]">»Motor ... an Tempo % ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »<span style="color: rgb(0,0,255);"><span><span style="color: rgb(0,0,0);">Motor ... an
+                            Tempo</span><span style="color: rgb(0,0,0);"> % ... </span></span></span><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« setzt </span></span>das Tempo
+                (Geschwindigkeit) des jeweiligen Motors auf einen neuen Wert.</p>
+            <p>Falls einer von zwei angeschlossenen Motoren sich nicht drehen soll, so muss dessen Tempo-Wert explizit
+                auf 0 gestellt werden.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Motoren aus, für die das Tempo
+                    (Geschwindigkeit) eingestellt werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 100. Geschwindigkeit des ersten Motors in
+                    Prozent.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 100. Geschwindigkeit des zweiten Motors in
+                    Prozent.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_motors_stop" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»StoppeMotorPortA+B«[Experten-Block]">»Stoppe Motor Port A + B« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Stoppe Motor Port A +
+                        B</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« schaltest
+                        du den Motor A und den Motor B gleichzeitig aus.</span></span></p>
+        </div>
+        <div id="mbedActions_motor_on" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»MotorPort...anTempo...«[Experten-Block]">»Motor Port ... an Tempo ...«
+                <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »<span style="color: rgb(0,0,255);"><span><span style="color: rgb(0,0,0);">Motor Port
+                        </span><span style="color: rgb(0,0,0);">... an Tempo ...</span></span></span><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« setzt </span></span>das Tempo
+                (Geschwindigkeit) eines Motors auf einen neuen Wert.</p>
+            <p>Wenn zwei Motoren angeschlossen sind, laufen beide nur mit halber Leistung. Falls einer von zwei
+                angeschlossenen Motoren sich nicht drehen soll, so muss dessen Tempo-Wert explizit auf 0 gestellt
+                werden. Es wird empfohlen, beim Einsatz von zwei Motoren stets zwei Motor-Blöcke - für jeden einen - als
+                Paare zu verwenden.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, für den das Tempo eingestellt
+                    werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 100.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_motor_stop" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»StoppeMotor...«[Experten-Block]">»Stoppe Motor ...« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Stoppe Motor
+                        ...</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« schaltest
+                        du den </span></span>Motor, der an deinem Calliope mini oder Calli:bot angeschlossen ist, aus.
+            </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Motor aus, der ausgeschaltet werden soll.
+                </li>
+            </ul>
+        </div>
+        <div id="mbedActions_single_motor_on" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»MotoranTempo%...«[Experten-Block]">»Motor an Tempo % ...« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block setzt du das Tempo (Geschwindigkeit) des Motors auf einen neuen Wert. Achtung: Dieser
+                Block kann nur den Motor steuern, den du an die Motor-Pins über der RGB-LED anschließt.</p><br>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Geschwindigkeit des Motors. Wenn
+                    die Zahl negativ ist, wird die Drehrichtung umgekehrt.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_single_motor_stop" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»StoppeMotor...«[Experten-Block].1">»Stoppe Motor ...« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Du kannst einstellen, ob der Motor langsam ausläuft oder gebremst wird.
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Stoppmöglichkeiten; »auslaufen<span
+                        style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">«</span></span> sorgt dafür, dass
+                    der Motor langsam ausläuft; »bremsen<span style="color: rgb(0,0,255);"><span
+                            style="color: rgb(0,0,0);">«</span></span> sorgt dafür, dass der Motor abrupt abgebremst
+                    wird.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_servo_set" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»SetzeServomotor...auf°...«[Experten-Block]">
+                »Setze Servomotor ... auf ° ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du einen angeschlossenen Servomotor steuern und dessen Arm drehen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Winkel bzw. Position in die sich der Arm des Servomotors drehen
+                    soll. Zahl zwischen -180 und 180.</li>
+            </ul><br>
+        </div>
+        <div id="mbedActions_motionkit_single_set" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»MotionKit......«[Experten-Block]">»MotionKit
+                ... ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du einen einzelnen Motor des MotionKits ansteuern und ihn entweder vor- oder
+                rückwärts laufen lassen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, der Motor, den du ansteuern
+                    möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, vor- oder rückwärts, die Richtung in die sich der
+                    Motor dreehen soll.</li>
+            </ul><br>
+        </div>
+        <div id="mbedActions_motionkit_dual_set" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»MotionKitlinks...rechts...«[Experten-Block]">
+                »MotionKit links ... rechts ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du die beiden Motoren des MotionKits gleichzeitig ansteuern. Dabei müssen sich
+                die beiden Motoren allerdings nicht in die gleiche Richtung drehen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, vor- oder rückwärts, die Richtung in die sich der
+                    linke Motor drehen soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, vor- oder rückwärts, die Richtung, in die sich der
+                    rechte Motor drehen soll.</li>
+            </ul><br>
+        </div>
+        <div id="mbedActions_play_note" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»Spiele...«">»Spiele ...«</h3>
+            <p>Mit dem Block »Spiele ...« bringst du deinen Roboter dazu, einen ganze, halbe, viertel, achtel oder
+                sechzehntel Note abzuspielen.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Länge der Note.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, Note die gespielt werden soll.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_play_tone" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»SpieleFrequenz...Dauer«[Experten-Block]">»Spiele Frequenz ... Dauer«
+                <span class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »Spiele Frequenz ... Dauer« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie
+                lange der Ton gespielt wird) programmieren. Der Ton wird über den eingebauten Lautsprecher deines
+                Calliope mini abgespielt, bis die eingestellte Dauer erreicht ist.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Bitte beachte, dass das menschliche Gehör Frequenzen zwischen ca. 30 Hz bis ca. 15.000 Hz (15
+                        kHz) wahrnehmen kann - je nach Mensch und Alter kann dies unterschiedlich sein.</p>
+                </div>
+            </div>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, gewünschte Frequenz in Hz (Hertz) eingeben. Je höher die
+                    Frequenz, desto höher ist der Ton.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, gewünschte Dauer des Tons in Millisekunden (ms) eingeben.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_write_to_pin" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»Schreibe...WertaufPin...«[Experten-Block]">»Schreibe ... Wert auf Pin
+                ...« <span class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »Schreibe ... Wert auf Pin ...« kannst du einen analogen oder digitalen Wert auf einen der
+                Pins schreiben.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, analog oder digital. »Analog« sind die Werte zwischen
+                    0 und 1023. 0 bedeutet, dass es keine keine Spannung am Pin anliegt, und 1023 bedeutet, dass die
+                    vollen 3.3V anliegen. »Digital« sind entweder 0 oder 1. 0 bedeutet, dass keine Spannung anliegt und
+                    1 bedeutet, dass volle Spannung anliegt.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Ausgabepin aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, zu schreibender Wer. »Analog« sind die Werte zwischen 0 und
+                    1023. 0 bedeutet, dass es keine keine Spannung am Pin anliegt, und 1023 bedeutet, dass die vollen
+                    3.3V anliegen. »Digital« sind entweder 0 oder 1. 0 bedeutet, dass keine Spannung anliegt und 1
+                    bedeutet, dass volle Spannung anliegt.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_switch_led_matrix" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»SchalteLEDMatrix...«[Experten-Block]">»Schalte LED Matrix ...« <span
+                    class="typcn typcn-star"></span></h3>
+            <p class="western">Mit diesem Block wird die LED Matrix ein- oder ausgeschaltet.</p>
+            <p class="western auto-cursor-target">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">An / Aus - steuert, ob die LED Matrix ein- oder ausgeschaltet
+                    wird.</li>
+            </ul>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»Taste...gedrückt?«">»Taste ... gedrückt?«</h3>
+            <p>Mit dem Block »Taste ... gedrückt?« kannst du einem anderen Block »mitteilen«, ob eine der eingebauten
+                Tasten gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>wahr = gedrückt</em> oder
+                <em>falsch = nicht gedrückt</em> zurück.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Taste aus, die du abfragen möchtest.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn die Taste gedrückt ist, sonst »falsch«.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_pintouch_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»Pin...gedrückt?«">»Pin ... gedrückt?«</h3>
+            <p>Mit dem Block »Pin ... gedrückt?« kannst du einem anderen Block »mitteilen«, ob der ausgewählte Pin
+                berührt wird oder nicht. Dieser Block gibt die logischen Werte <em>wahr = gedrückt</em> oder <em>falsch
+                    = nicht gedrückt</em> zurück.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Pin aus, den du abfragen willst.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn der Pin berührt wird, sonst »falsch«.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_gesture_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»Gib...Lage«">»Gib ... Lage«</h3>
+            <p>Mit dem Block »Gib ... Lage« kannst du einem anderen Block »mitteilen«, ob sich der Calliope mini in
+                einer bestimmten Lage befindet. Dieser Block fragt den eingebauten Gyrosensor des Calliope mini ab.</p>
+            <p>Befindet sich der Calliope mini in der abgefragten Lage liefert der »Gib ... Lage« Block »wahr«, sonst
+                »falsch«.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">
+                    <p>Option, wähle die Lage, die abgefragt werden soll. Mögliche Lagen:</p>
+                    <ul>
+                        <li>aufrecht: USB-Anschluss des Calliope mini zeigt nach oben</li>
+                        <li>kopfüber: USB-Anschluss des Calliope mini zeigt nach unten</li>
+                        <li>auf der Vorderseite: Calliope-Beschriftung zeigt nach unten</li>
+                        <li>auf der Rückseite: Calliope-Beschriftung zeigt nach oben</li>
+                        <li>geschüttelt: Calliope mini wird geschüttelt</li>
+                        <li>frei fallend: Calliope mini wird nach unten beschleunigt</li>
+                    </ul>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn er sich in der ausgewählten Lage
+                    befindet, sonst »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_compass_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»gibWinkel°Kompasssensor«">»gib Winkel ° Kompasssensor«</h3>
+            <p>Mit dem Block »gib Winkel Kompasssensor« kannst du die Orientierung deines Calliope minis im Bezug auf
+                die Himmelsrichtungen auslesen, genau wie auf einem Kompass.</p>
+            <p>Dazu musst du vorher den Calliope mini kalibrieren, indem du den Calliope mini in alle Richtungen neigst,
+                bis alle LEDS auf dem Display des Calliope mini leuchten.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Orientierung in Grad von 0° bis 360°. Dabei bedeutet 0°, dass
+                    dein Calliope mini in Richtung Norden zeigt.</li>
+            </ul>
+        </div>
+        <div id="robSensors_sound_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»gibGeräusch%Mikrofon«">»gib Geräusch % Mikrofon«</h3>
+            <p>Mit dem Block »gib Wert Mikrofon« kannst du die Lautstärke von Geräuschen in der näheren Umgebung messen.
+                Das Mikrofon ist nicht sehr empfindlich und die Geräusche sollten nicht zu weit weg sein.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Lautstärke von 0 (leise) bis 100 (laut). Bei älteren Versionen
+                    des Calliope mini kann es sein, dass nur Werte zwischen 0 und ca. 10 ausgegeben werden.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»gibWertmsZeitgeber«">»gib Wert ms Zeitgeber«</h3>
+            <p>Mit dem Block »Gib Wert Zeitgeber« kannst du einem anderen Block den aktuellen Stand des internen
+                Zeitgebers in Millisekunden »mitteilen«. Der Zeitgeber 1 wird automatisch mit dem Beginn eines Programms
+                gestartet.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, aktueller Wert des Zeitgebers in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="mbedSensors_timer_reset" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»SetzeZeitgeberzurück«">»Setze Zeitgeber zurück«</h3>
+            <p>Mit dem Block »Setze Zeitgeber zurück« kannst du den internen Zeitgeber auf den Wert 0 zurücksetzen.</p>
+            <br>
+        </div>
+        <div id="robSensors_temperature_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»gibWert°Temperatursensor«">»gib Wert ° Temperatursensor«</h3>
+            <p>Mit dem Block »gib Wert Temperatursensor« kannst du die aktuell gemessene Temperatur als Zahl auslesen.
+                Dieser Block fragt den eingebauten Temperatursensor des Calliope mini ab.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl; Temperatur in Grad Celsius.</li>
+            </ul>
+        </div>
+        <div id="robSensors_rssi_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»gibWertEmpfangsstärke«[Experten-Block]">»gib Wert Empfangsstärke« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block gibst du die Signalstärke der letzten Nachricht zurück.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Signalstärke der letzten Nachricht.</li>
+            </ul>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»gibWert%Lichtsensor«">»gib Wert % Lichtsensor«</h3>
+            <p>Mit dem Block »gib Wert % Lichtsensor« kannst du Helligkeit deiner Umgebung messen. Dieser Block fragt
+                den eingebauten Lichtsensor des Calliope mini ab.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl; Helligkeit von 0 bis 100. 0 bedeutet, dass es dunkel ist und
+                    100, dass es hell ist.</li>
+            </ul>
+        </div>
+        <div id="robSensors_pin_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»gib...WertPin...«[Experten-Block]">»gib ... Wert Pin ...« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »gib ... Wert Pin ...« kannst du den Eingabewert an dem ausgewählten Pin auslesen, wenn du
+                dort ein anderes Gerät oder Zusatzmodul angeschlossen hast. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle, welche Art von Signal du einlesen möchtest.
+                    »Analog« sind die Werte zwischen 0 und 1023. 0 bedeutet, dass es keine keine Spannung am Pin
+                    anliegt, und 1023 bedeutet, dass die vollen 3.3V anliegen. »Digital« sind entweder 0 oder 1. 0
+                    bedeutet, dass keine Spannung anliegt und 1 bedeutet, dass volle Spannung anliegt.</li>
+                <li class="typcn typcn-arrow-sorted-down">Pin, wähle den Pin aus, den du abfragen willst.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl; aktueller Wert des Eingangssignals. Entweder zwischen 0 und
+                    1023 bei einem analogen Signal, bei einem digitalen Signal entweder 0 oder 1.</li>
+            </ul>
+        </div>
+        <div id="robSensors_gyro_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»gibWinkel°Kreiselsensor...«">»gib Winkel ° Kreiselsensor ...«</h3>
+            <p>Dieser Block gibt den aktuellen Wert des Kreiselsensors zurück. Der Wert ist der Winkel, um den der
+                Calliope mini in die ausgewählte Richtung geneigt ist.</p>
+            <p class="auto-cursor-target">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Achse, um die der Calliope mini gedreht
+                    wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Winkel um die der Calliope mini gedreht worden ist. Die
+                    x-Achse ist diejenige, die den Pin 0 und 3 gedanklich verbindet (im Bild grün). Sie kann die Werte
+                    von 0° bis 90° zurückgeben. Die y-Achse (im Bild rot) gibt die Werte von -180° bis +180° und
+                    verbidet gedanklich den USB-Connector mit der Auskerbung.</li>
+            </ul>
+        </div>
+        <div id="robSensors_accelerometer_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»gibWertmilli-gBeschleunigungssensor...«[Experten-Block]">»gib Wert
+                milli-g Beschleunigungssensor ...« <span class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »gib Wert milli-g Beschleunigung ...« kannst du die Beschleunigung des Calliope mini
+                auslesen. Es gibt drei Richtungen, in denen die Beschleunigung gemessen werden kann. Die Beschleunigung
+                kann in die drei verschiedenen Raumrichtungen (links-rechts, vorne-hinten und oben-unten) gemessen
+                werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Optionen; wähle, für welche Richtung der Wert ausgegeben
+                    werden soll. »x« ist die links-rechts-Achse, »y« die vorne-hinten-Achse, »z« ist die oben-unten
+                    Achse.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl; aktueller Wert der Beschleunigung in milli-g. 1g oder 1000
+                    milli-g wirken auf den Calliope mini aufgrund der Erdbeschleunigung, ohne das er bewegt wird.</li>
+            </ul>
+        </div>
+        <div id="robSensors_humidity_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»gib...LuftfeuchtigkeitssensorA1«[Experten-Block]">»gib ...
+                Luftfeuchtigkeitssensor A1« <span class="typcn typcn-star"></span></h3>
+            <p class="western">Dieser Block zeigt den Wert des Feuchtigkeitssensors. Dieser Sensor misst sowohl die
+                relative Luftfeuchtigkeit als auch die Temperatur der Umgebung und muss an den Pin A1 angeschlossen
+                werden.</p>
+            <p class="western">Der verwendete Sensor ist ein SHT31 und kommuniziert per I²C mit dem Calliope mini.</p>
+            <p class="western">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wert der Luftfeuchtigkeit in Prozent oder der Temperatur in
+                    Grad Celsius.</li>
+            </ul>
+            <p class="western auto-cursor-target">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option; wähle, ob du die Werte für die Luftfeuchtigkeit oder
+                    die Temperatur zurückbekommen möchtest.</li>
+            </ul>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»gibAbstandcmUltraschallsensor...«[Experten-Block]">»gib Abstand cm
+                Ultraschallsensor ...« <span class="typcn typcn-star"></span></h3>
+            <p class="western">Dieser Sensor misst den Abstand zum nächsten Objekt durch das Aussenden von
+                Ultraschallwellen. Dieser Senosor muss entweder am Calliope mini an den Pin A1 oder an den vorgesehenen
+                Platz am Calli:bot angeschlossen werden. Der verwendete Sensor ist ein Grove Ultraschall-Sensor auf
+                Basis eines HC-SR04, allerdings mit einem verbauten Mikrocontroller, der die Kommunikation übernimmt.
+            </p>
+            <p class="western">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, der Eingang kann entweder für Calliope mini oder den
+                    Calli:bot konfiguriert werden.</li>
+            </ul><br>
+            <p class="western">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wert des Ultraschallsensors - Abstand zum nächsten Objekt in
+                    Zentimetern.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»gibLinieInfrarotsensorCalli:bot...«[Experten-Block]">»gib Linie
+                Infrarotsensor Calli:bot ...« <span class="typcn typcn-star"></span></h3>
+            <p class="western">Dieser Sensor misst die Schattierung des Untergrunds und gibt zurück, ob es sich um einen
+                hellen oder dunklen Untergrund handelt.</p>
+            <p class="western">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn der Untergrund dunkel ist, sonst
+                    »falsch«.</li>
+            </ul>
+            <p class="western auto-cursor-target">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den linken oder rechten Calli:bot Sensor aus.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_colourtcs3472_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»Gib...FarbsensorTCS3472...«[Experten-Block]"><br>»Gib ... Farbsensor
+                TCS3472 ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du den Farbsensor TCS3472 abfragen. Dieser Sensor kann die Farbe, die Helligkeit
+                und die Farbzusammensetzung seiner Umgebung messen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Eigenschaft aus, die du messen möchtest. Es
+                    steht Farbe, Licht und RGB zur Auswahl.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Sensor aus, den du abfragen möchtest.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die Farbe der Umgebung.</li>
+                <li class="typcn typcn-arrow-right">Zahl, die Helligkeit der Umgebung in Prozent.</li>
+                <li class="typcn typcn-arrow-right">Liste von Zahlen, die Aufteilung der Farbe in Werte von Rot, Grün
+                    und Blau.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wennmachesonst«">»Wenn mache sonst«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wiederholeunendlichoft«">»Wiederhole unendlich
+                oft«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wiederholenmal«">»Wiederhole n mal«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wiederholesolange/bis«[Experten-Block]">
+                »Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»FürWertausderListe«[Experten-Block]">»Für Wert
+                aus der Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Zählevonbis«[Experten-Block]">»Zähle von bis«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="ProgrammierBlöckeCalliope-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wartems...«">»Warte ms ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wartebis...«.1">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»MathematischeFunktionen«[Experten-Block]">
+                »Mathematische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»TrigonometrischeFunktionen«[Experten-Block]">
+                »Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Konstanten«[Experten-Block]">»Konstanten« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Zahleneigenschaft«[Experten-Block]">
+                »Zahleneigenschaft« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»runden«[Experten-Block]">»runden« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Listeauswerten«[Experten-Block]">»Liste
+                auswerten« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Restvon«[Experten-Block]">»Rest von« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Begrenze«[Experten-Block]">»Begrenze« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»GanzzahligeZufallswerte«[Experten-Block]">
+                »Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Zufallszahl«">»Zufallszahl« </h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeCalliope-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in
+                Zeichenkette« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeCalliope-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»ErstelleText«[Experten-Block]">»Erstelle Text«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeCalliope-»Textanhängen«[Experten-Block]">»Text anhängen«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeCalliope-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeCalliope-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ...
+                an Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeCalliope-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeCalliope-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste«
+                <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeCalliope-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeCalliope-»istleer?«[Experten-Block]">»ist leer?« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeCalliope-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeCalliope-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeCalliope-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammierBlöckeCalliope-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammierBlöckeCalliope-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammierBlöckeCalliope-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammierBlöckeCalliope-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeCalliope-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ...
+                Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeCalliope-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün
+                ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeCalliope-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün
+                ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb
+                einer Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="ProgrammierBlöckeCalliope-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="ProgrammierBlöckeCalliope-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage
+                innerhalb einer Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne
+                Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeCalliope-»FunktionsaufrufmitRückgabewert«">
+                »Funktionsaufruf mit Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="mbedImage_image" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»ErstelleBild«">»Erstelle Bild«<span style="color: rgb(0,0,0);"> </span>
+            </h3>
+            <p>Mit dem Block <span style="color: rgb(0,0,0);">»Erstelle Bild« kannst du eigene Bilder für die Anzeige
+                    des Calliope erstellen. Jede einzelne Leuchte ist durch einen Punkt im Raster dargestellt.</span>
+            </p>
+            <p><span style="color: rgb(0,0,0);">Du kannst für jede Leuchte eine Helligkeit zwischen 0 und 9 angeben, in
+                    der die jeweilige Lampe leuchten soll oder eine <span style="color: rgb(0,0,0);">»#« um die Lampe
+                        einfach einzuschalten</span>.</span></p>
+            <p><span style="color: rgb(0,0,0);">Ist das Feld leer, wird die Lampe nicht eingeschaltet.</span></p>
+            <p>Eingabewerte:<span style="color: rgb(0,0,0);"> </span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl; Helligkeit der Lampe im Raster, Zahl zwischen 0 und 9.</li>
+            </ul>
+        </div>
+        <div id="mbedImage_get_image" class="help beginner">
+            <h3 id="ProgrammierBlöckeCalliope-»Bild«"><span style="color: rgb(0,0,0);">»Bild«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Mit dem Block <span style="color: rgb(0,0,0);">»Bild« kannst du ein vordefiniertes Bild
+                    auswählen</span><span style="color: rgb(0,0,0);"><span>.</span></span></p>
+            <p>Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Bild, vordefiniertes Bild.</li>
+            </ul>
+        </div>
+        <div id="mbedImage_invert" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»invertiere«[Experten-Block]">»invertiere« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Ein Bild wird umgekehrt. Ursprünglich leuchtende LEDs im Calliope-Display werden ausgeschaltet,
+                ausgeschaltete LEDs werden eingeschaltet.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Bild, das invertiert werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Bild, das invertiert wurde.</li>
+            </ul>
+        </div>
+        <div id="mbedImage_shift" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»verschiebe«[Experten-Block]">»verschiebe« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Ein Bild wird um einzelne Positionen verschoben. Die Verschieberichtung und die Anzahl Positionen auf dem
+                Display werden eingegeben.</p>
+            <p>Eingabewerte und Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Bild, das verschoben werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Richtung, in die das Bild verschoben werden soll;
+                    Auswahlmöglichkeiten: oben, unten, links oder rechts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, um wie viele Positionen das Bild verschoben werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Bild, verschoben um die eingestellten Werte.</li>
+            </ul>
+        </div>
+        <div id="mbedCommunication_sendBlock" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»SendeNachrichtZeichenkette«[Experten-Block]">»Sende Nachricht
+                Zeichenkette« <span class="typcn typcn-star"></span></h3>
+            <p>Der Calliope sendet eine Nachricht. Alle Calliope in der nähren Umgebung können diese Nachricht
+                empfangen.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text; Nachricht, die gesendet werden soll</li>
+            </ul>
+        </div>
+        <div id="mbedCommunication_receiveBlock" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»EmpfangeNachrichtZeichenkette«[Experten-Block]">»Empfange Nachricht
+                Zeichenkette« <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block <span style="color: rgb(0,0,0);">kannst du nachschauen, ob von anderen Calliopes
+                    Nachrichten emfpangen wurden und die letzte dann in deinem Programm verwenden.<br>Wenn noch keine
+                    neue Nachricht angekommen ist wartet der Calliope dabei aber nicht, bis eine neue Nachricht ankommt.
+                    Es kann also sein, dass du keine Nachricht erhälst.<br></span></p>
+            <p><span style="color: rgb(0,0,0);"> Je nach ausgewähltem Nachrichtentyp erhälst du dann eine "0", eine
+                    unbekannte Zeichenkette oder "false" als Wert zurück.</span></p>
+            <p><span style="color: rgb(0,0,0);">Wenn du eine Zeichenkette empfangen möchtest musst du den unbekannten
+                    Wert erst einmal in deinem Programm in einer Variable speichern, damit du überprüfen kannst, ob
+                    überhaupt eine Nachricht angekommen ist. Dafür kannst du am Anfang deines Programms eine Variable
+                    anlegen und in ihr mit diesem Block eine Nachricht speichern. Da du am Anfang noch keine Nachricht
+                    empfangen hast, wird dadurch der unbekannte Wert in deiner Variable gespeichert. Später kannst du
+                    empfangene Nachrichten mit deiner Variable (dem unbekannten Wert darin) vergleichen, um
+                    herauszufinden, ob wirklich eine Nachricht angekommen ist.</span></p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Nachrichtentyp, »Zeichenkette«, »Zahl« oder »logischer Wert«.
+                </li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Die letzte Nachricht, die dein Calliope emfpangen hat.</p>
+                    <p>Wenn noch keine neue Nachricht angekommen ist erhälst du eine leere Nachricht. Je nach
+                        ausgewähltem Nachrichtentyp ist dies:</p>
+                    <ul>
+                        <li>Zeichenkette: Leere Zeichenkette</li>
+                        <li>Zahl: 0</li>
+                        <li>Logischer Wert: Falsch</li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+        <div id="mbedCommunication_setChannel" class="help expert">
+            <h3 id="ProgrammierBlöckeCalliope-»SetzeKanalauf...«[Experten-Block]">»Setze Kanal auf ...« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Dieser Block steuert den Kanal, auf dem der Calliope mini Nachrichten empfängt. Der Calliope mini kann
+                nur Nachrichten empfangen, die auf seinem Kanal gesendet worden sind.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl; Der Kanal, auf dem der Calliope mini Nachrichten senden und
+                    empfangen soll.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_calliope_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_calliope_en.html
@@ -1,472 +1,1749 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="ProgrammingblocksCalliope-»start«"><span style="color: rgb(0,0,0);">»start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Each program starts with the red »start« block.</p><p>This block is always available in the Open Roberta Lab and cannot be deleted. The little triangle below the start block is called  »sequence connector«. The first block you want to use will be connected by using the »sequence connector« at the start block.  The sequence connector color changes to yellow when a suitable block comes into its range.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">create a new global variable</li><li class="typcn typcn-minus">delete the global variable</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable</li><li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Colour«, »Image«, »List Number«, »List Boolean«, »List String«, »List Image«</li><li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial value of the variable.</li>
-</ul></div><div id="mbedActions_display_text" class="help beginner"><h3 id="ProgrammingblocksCalliope-»showtext/character«"><span style="color: rgb(0,0,0);">»show text/character«</span></h3><p>With the »show text/character« block you can display text and numbers on the display of your robot. </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Text (floats over the display) or character (are shown after each other).</li><li class="typcn typcn-arrow-left">Text or number you want to show.</li>
-</ul></div><div id="mbedActions_display_image" class="help beginner"><h3 id="ProgrammingblocksCalliope-»showimage/animation«"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»show image/animation«</span><br></span></h3><p>With the »show image/animation« block you can show selfmade or predefined images on the display.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Image or Animation (images are shown sequentially).</li><li class="typcn typcn-arrow-left">single image or list of images.</li>
-</ul></div><div id="mbedActions_display_clear" class="help beginner"><h3 id="ProgrammingblocksCalliope-»cleardisplay«"><span style="color: rgb(0,0,255);"> <span style="color: rgb(0,0,0);">»clear display«</span><br></span></h3><p>With the »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">clear display</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« block you can delete what is shown on the display</span></span>.</p></div><div id="mbedActions_display_setBrightness" class="help expert"><h3 id="ProgrammingblocksCalliope-»setbrightness«[Expert-Block]">»set brightness« <span class="typcn typcn-star"></span></h3><p>The brightness of all LEDs on the Calliope display will be set to a uniform value. 0 switches off all LEDs, 9 is the maximum value.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, value between 0 and 9.</li>
-</ul></div><div id="mbedActions_display_getBrightness" class="help expert"><h3 id="ProgrammingblocksCalliope-»getbrightness«[Expert-Block]">»get brightness« <span class="typcn typcn-star"></span></h3><p>The brightness of all LEDs on the Calliope display will be read. 0 indicates that all LEDs are switched off, 9 is the maximum value.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, value between 0 and 9.</li>
-</ul></div><div id="mbedActions_display_setPixel" class="help expert"><h3 id="ProgrammingblocksCalliope-»setLEDxybrightness«[Expert-Block]">»set LED x y brightness« <span class="typcn typcn-star"></span></h3><p>The brightness of a single LED on the screen of your Calliope mini is set to a value. The position of the LED is determined by x-axis and y-axis. x is the horizontal axis and y is the vertical axis. 0 turns off the LEDs, 9 is the maximum brightness value.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, value between 0 and 4 for the x position of the LED. 0 stands for the first LED in the row and 4 for the fifth and last LED in the row.</li><li class="typcn typcn-arrow-left">Number, value between 0 and 4 for the y position of the LED. 0 stands for the first LED in the column and 4 for the fifth and last LED in the column.</li><li class="typcn typcn-arrow-left">Number, value between 0 and 9, where 0 means the LED is off and 9 is the maximum brightness.</li>
-</ul></div><div id="mbedActions_display_getPixel" class="help expert"><h3 id="ProgrammingblocksCalliope-»getLEDbrightnessxy«[Expert-Block]">»get LED brightness x y« <span class="typcn typcn-star"></span></h3><p>The brightness of a single LED on the Calliope display will be read. The position of the LED is defined by x and y. A brightness value of 0 indicates that the LED is switches , 9 is the maximum value.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, value between 0 and 4 for the x position of the LED. 0 stands for the first LED in the row and 4 for the fifth and last LED in the row.</li><li class="typcn typcn-arrow-left">Number, value between 0 and 4 for the y position of the LED. 0 stands for the first LED in the column and 4 for the fifth and last LED in the column.</li>
-</ul><p class="auto-cursor-target">Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, brightness of the selected LED.</li>
-</ul></div><div id="robActions_serial_print" class="help expert"><h3 id="ProgrammingblocksCalliope-»ShowonSerialMonitor...«[Expert-block]"><br>» Show on Serial Monitor ... « <span class="typcn typcn-star"></span></h3><p>With the block "Show on Serial Monitor..." you can display the output in a Serial Monitor of your choice (e.g. Arduino Serial Monitor / (Chrome) Browser Serial Monitor).</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Specify what should be displayed on your Serial Monitor. Possible variants are: Number, boolean, string or color.</li>
-</ul><br></div><div id="mbedActions_fourDigitDisplay_show" class="help expert"><h3 id="ProgrammingblocksCalliope-»Show4-DigitDisplayNumber...position...colon...«[Expert-block]">» Show 4-Digit Display Number ... position ... colon ... « <span class="typcn typcn-star"></span></h3><p>With this block you can display a number from 0 to 9999 on the Grove 4-digit display of Seeed. The display must be connected to the right Grove connector (A1). The position from 0 to 3 indicates the starting position of the number.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, Value between 0 and 9999. This number will be shown on the display.</li><li class="typcn typcn-arrow-sorted-down">Number, Value between 0 and 3. This is the starting position of the number.</li><li class="typcn typcn-arrow-sorted-down">Boolean, true or false. Specifies whether to display a colon in the center.</li>
-</ul></div><div id="mbedActions_fourDigitDisplay_clear" class="help expert"><h3 id="ProgrammingblocksCalliope-»Cleardisplay4-DigitDisplay«[Expert-block]">» Clear display 4-Digit Display « <span class="typcn typcn-star"></span></h3><p>This block deletes the output on Seeed's Grove display when it is connected to the right Grove connector (A1).</p></div><div id="mbedActions_leds_on" class="help beginner"><h3 id="ProgrammingblocksCalliope-»turnLEDoncolour...«">»turn LED on colour ...«</h3><p>With the  »turn LED on colour ...« you can turn on the status LED in a particular colour.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Colour in which the LED should light up.</li>
-</ul></div><div id="mbedActions_leds_off" class="help beginner"><h3 id="ProgrammingblocksCalliope-»turnLEDoff«">»turn LED off«</h3><p>With the »turn LED off« block you can turn off the status LED or the LEDs on the Calli:bot.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose which LED you want to turn off.</li>
-</ul><br></div><div id="mbedActions_ledBar_set" class="help expert"><h3 id="ProgrammingblocksCalliope-»setLEDBarx...brightness...«[Expertblock]">» set LED Bar x ... brightness ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control the Grove LED-Bar v2.0 by Seed. The LED-Bar needs to be connected to the A1 port of your Calliope mini. The first LED of the LED-Bar is red, the second orange and the other eight are green.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, position of the LED that you want to change, value between 0 and 9.</li><li class="typcn typcn-arrow-left">Number, brightness of the LED, value between 0 and 8, with 0 being off and 8 being the maximum brightness.</li>
-</ul></div><div id="robActions_brickLight_on" class="help expert"><h3 id="ProgrammingblocksCalliope-»turnLEDonCalli:bot......«[Expert-Block]">» turn LED on Calli:bot ... ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control the LEDs on the Calli:bot, you can either turn them off or on.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose which LED you want to control.</li><li class="typcn typcn-arrow-sorted-down">option, choose whether you want to turn the LED on or off.</li>
-</ul></div><div id="mbedActions_motors_on" class="help expert"><h3 id="ProgrammingblocksCalliope-»motor......onspeed%......«[Expert-Block]">»motor ... ... on speed % ... ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control two motors at the same time with different speed settings.</p><p>You can choose between the motors connected directly to the Calliope mini or the motors of the Calli:bot.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor; pick the motors you want to control.</li><li class="typcn typcn-arrow-left">number, speed you want the first motor to rotate at, between 0 and 100.</li><li class="typcn typcn-arrow-left">number, speed you want the second motor to rotate at, between 0 and 100.</li>
-</ul></div><div id="mbedActions_motors_stop" class="help expert"><h3 id="ProgrammingblocksCalliope-»stopmotorportA+B«">» stop motor port A + B «</h3><p>With this block you can stop the two motors connected directly to the Calliope mini.</p></div><div id="mbedActions_motor_on" class="help expert"><h3 id="ProgrammingblocksCalliope-»motor...onspeed%...«[Expert-Block]">»motor ... on speed % ... « <span class="typcn typcn-star"></span></h3><p>The block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">motor <span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">... on speed</span></span></span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« can be used to turn on a motor and to control its speed</span></span>.</p><p>You can choose between a motor connected directly to the Calliope mini or a motor of the Calli:bot.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor; pick the motor you want to control.</li><li class="typcn typcn-arrow-left">number, speed you want the motor to rotate at, between 0 and 100.</li>
-</ul></div><div id="mbedActions_motor_stop" class="help expert"><h3 id="ProgrammingblocksCalliope-»stopmotor...«[Expert-Block]">»stop motor ... « <span class="typcn typcn-star"></span></h3><p>With this block you can stop one of the connected motors at once.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the motor that you want to stop.</li>
-</ul></div><div id="mbedActions_single_motor_on" class="help expert"><h3 id="ProgrammingblocksCalliope-»motoronspeed%...«[Expert-Block]">»motor on speed % ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control the motor connected to motor control pins aboce the RGB-LED.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, speed you want the motor to rotate at, between 0 and 100.</li>
-</ul></div><div id="mbedActions_single_motor_stop" class="help expert"><h3 id="ProgrammingblocksCalliope-»motorstop...«[Expert-Block]">»motor stop ... « <span class="typcn typcn-star"></span></h3><p>Using this block you can stop the connected motor either immediatly, let it run out or make it go to sleep.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, float, brake or sleep; make your choice.</li>
-</ul></div><div id="mbedActions_servo_set" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»setservomotor...to°...«[Expert-Block]">»set servo motor ... to ° ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control the chosen servo motor and turn its arm.</p><p>Input values and options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the port or pin the servo motor is connected to.</li><li class="typcn typcn-arrow-sorted-down">number, angle or position that you want the servo arm to turn to. Value between 180 and  180.</li>
-</ul><br></div><div id="mbedActions_motionkit_single_set" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»MotionKit......«[Expert-Block]">»MotionKit ... ... « <span class="typcn typcn-star"></span></h3><p>With  this block you can control one of the motors of the MotionKit and set it to turn either for-  or backwards.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, chose with motor you want to control.</li><li class="typcn typcn-arrow-sorted-down">option, chose the direction you want the motor to turn in.</li>
-</ul><br></div><div id="mbedActions_motionkit_dual_set" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»MotionKitleft...right...«[Expert-Block]">»MotionKit left ... right ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control both motors of the MotionKit individually.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, direction you want the left motor to  turn in.</li><li class="typcn typcn-arrow-sorted-down">option, direction you want the right motor to turn in.</li>
-</ul><br></div><div id="mbedActions_play_note" class="help beginner"><h3 id="ProgrammingblocksCalliope-»play...«">»play...«</h3><p>With the »play ...« block you can play notes on your Calliope.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Note length; select the length of the note that is going to be played.</li><li class="typcn typcn-arrow-sorted-down">Note pitch; select the note that is going to be played.</li>
-</ul></div><div id="mbedActions_play_tone" class="help beginner"><h3 id="ProgrammingblocksCalliope-»playfrequency«[Expert-Block]">»play frequency« <span class="typcn typcn-star"></span></h3><p>With the »play frequency« block you can program the frequency (pitch level) and the time (how long the sound should be played) of the sound that is played. The sound is played by the built-in speaker of your Calliope for a defined of time. The frequency setting corresponds directly to the frequency in Hertz, for example, setting the frequency to 400 corresponds to 400 Hertz. Example: 261 = C.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Note that the human ear can perceive frequencies from about 30Hz to about 15,000Hz (15kHz). This can vary depending on the person and their age.</p></div></div><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, desired frequency in Hz (Hertz) .</li><li class="typcn typcn-arrow-left">Number, desired duration in milliseconds (ms).</li>
-</ul></div><div id="mbedActions_write_to_pin" class="help expert"><h3 id="ProgrammingblocksCalliope-»writeanalog/digitalvaluetopin...«[Expert-Block]">»write analog/digital value to pin ...« <span class="typcn typcn-star"></span></h3><p>With the »write analog/digital value to pin....« block you can send signals to an outputpin .</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">analog or digital.</li><li class="typcn typcn-arrow-sorted-down">In and output pin 0 to 3.</li><li class="typcn typcn-arrow-left">Number: value to write</li>
-</ul></div><div id="mbedActions_switch_led_matrix" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»switchLEDmatrix...«[Expertblock]">» switch LED matrix ... « <span class="typcn typcn-star"></span></h3><p>With this block you can either switch the LED matrix on or off.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose if you want to switch the matrix off or on.</li>
-</ul></div><div id="robSensors_key_getSample" class="help beginner"> <h3 id="ProgrammingblocksCalliope-»button...pressed?«">»button ... pressed?«</h3><p>With the block »button ... pressed?« you can "tell" another block whether a button is pressed or not. This block returns the logical values <em>true = pressed</em> or <em>false = not pressed</em>. This block can only be used in conjunction with another block which requires a logical value as an input parameter, for example together with the »if do« block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Button, select the button you want to check.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value: »true«, if the button is pressed, otherwise »false«.</li>
-</ul> </div><div id="robSensors_pintouch_getSample" class="help beginner"> <h3 id="ProgrammingblocksCalliope-»ispin...touched?«">»is pin ... touched?«</h3><p>You can check whether a pin of the Calliiope is touched or not by using the block »is pin ... touched?« . This block returns logical values (true if the pin is touched and false if not)</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Pin, select the pin you want to check.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logical value: »true«, if the pin is touched, »false« else.</li>
-</ul> </div><div id="robSensors_gesture_getSample" class="help beginner"> <h3 id="ProgrammingblocksCalliope-»gesture...aktive?«">»gesture ... aktive?«</h3><p>With the block  »gesture ... aktive?« you can  "tell" another block whether the Calliope is in a specific gesture or not .</p><p>If the Calliope is in the checked gesture the return value will be true. If not it will be false.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">gesture to be checked.</li>
-</ul> </div><div id="robSensors_compass_getSample" class="help beginner"> <h3 id="ProgrammingblocksCalliope-»getvaluecompasssensor«">»get value compass sensor«</h3><p>With the »get value compass sensor« block, you can read the orientation of your Calliope minis in relation to the Cardinal Directions, just like on a compass.</p><p>To do this, calibrate the Calliope mini by tilting it in all directions until all LEDs on the Calliope mini display light up.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, orientation in degrees from 0° to 360°. Where 0° means your Calliope mini is facing north.</li>
-</ul> </div><div id="robSensors_sound_getSample" class="help beginner"> <h3 id="ProgrammingblocksCalliope-»getvaluemicrophone«">»get value microphone«</h3><p>Get the value of noise close to the Calliope. The microphone is not very sensitive, so the sound you check should not be far away.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, volume level from 0 (quiet) to 100 (loud). For older versions of the Calliope it is possible that only values between 0 and 10 are given.</li>
-</ul> </div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="ProgrammingblocksCalliope-»getvaluetimerinms«">»get value timer in ms«</h3><p>With the block »get value timer in ms« you can "tell" another block the current time in milliseconds of the internal timer.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, milliseconds since program start or since the last reset of the timer.</li>
-</ul></div><div id="mbedSensors_timer_reset" class="help beginner"><h3 id="ProgrammingblocksCalliope-»resettimer«">»reset timer«</h3><p>With the block »reset timer« the internal timer can be reseted to the value 0.</p> </div><div id="robSensors_temperature_getSample" class="help beginner"> <h3 id="ProgrammingblocksCalliope-»getvaluetemperaturesensor«">»get value temperature sensor«</h3><p>with the »get value temperature sensor« you can read out the currently measured temperature.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number; Temperature in degrees.</li>
-</ul> </div><div id="robSensors_rssi_getSample" class="help expert"> <h3 id="ProgrammingblocksCalliope-»getvaluesignalstrength«[Expert-Block]">»get value signal strength « <span class="typcn typcn-star"></span></h3><p>With this block you can "sense" the brightness of your surroundings. This block queries the built-in light sensor of the Calliope mini.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, strength of the last received message.</li>
-</ul><br> </div><div id="robSensors_light_getSample" class="help beginner"> <br><h3 id="ProgrammingblocksCalliope-»getvalue%lightsensor«">»get value % light sensor«</h3><p>With the block »get value ambient light« you can measure the brightness of the ambient light.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number; brightness between 0 and 255.</li>
-</ul> </div><div id="robSensors_pin_getSample" class="help expert"> <h3 id="ProgrammingblocksCalliope-»getanalog/digitalvaluepin...«[Expert-Block]">»get analog/digital value pin ...« <span class="typcn typcn-star"></span></h3><p>With the »get analog/digital value pin ...« block you can read out a analog or digital input value. You can connect other devices or additional modules to a  pin.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Analog/Digital; which kind of signal do you want to read?</li><li class="typcn typcn-arrow-sorted-down">Pin, select the pin you want to read out.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number; current input signal.</li>
-</ul> </div><div id="robSensors_gyro_getSample" class="help expert"> <h3 id="ProgrammingblocksCalliope-»getvaluerotation...«[Expert-Block]">»get value rotation ...« <span class="typcn typcn-star"></span></h3><p>Read the value of rotation in degrees, how the Calliope was pitched or rolled.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»pitch« for measurement related to the transversal axis; »roll« for measurement related to the longitudinal axis.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, degrees within the range of -180 and 180.</li>
-</ul> </div><div id="robSensors_accelerometer_getSample" class="help expert"> <h3 id="ProgrammingblocksCalliope-»getvalueaccelerationmg...«[Expert-Block]">»get value acceleration mg ...« <span class="typcn typcn-star"></span></h3><p>The acceleration of the Calliope will be given, according to the three coordinate axes x, y and z.</p><p>Setting:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">x/y/z-strength; for which direction do you want to read the acceleration value? z for instance is the falling direction where the earth gravitation acts. Strength is the sum of all directions.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">number, acceleration in that direction, measured in milli-g where 1000 mg = 1 g = 9.81 m/s²</li>
-</ul> </div><div id="robSensors_humidity_getSample" class="help expert"><h3 id="ProgrammingblocksCalliope-»get...humiditysensor«[Expert-Block]">»get ... humidity sensor « <span class="typcn typcn-star"></span></h3><p>This block shows the value of the humidity sensor. This sensor measures both the relative humidity and the temperature of the environment and must be connected to pin A1.</p><p>The sensor used is an SHT31 and communicates via I²C with the Calliope mini.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose which value you want to measure, either temperature or humidity.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, relative humidity in % or temperature in °C.</li>
-</ul> </div><div id="robSensors_ultrasonic_getSample" class="help expert"><h3 id="ProgrammingblocksCalliope-»getdistancecmultrasonicsensor...«[Expert-Block]">»get distance cm ultrasonic sensor ... « <span class="typcn typcn-star"></span></h3><p>This sensor measures the distance to the next object by emitting ultrasonic waves. This sensor must be connected either to pin A1 on the Calliope mini or to the intended location on the Calli:bot. The sensor used is a Grove ultrasonic sensor based on a HC-SR04, but with a built-in microcontroller that handles the communication.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, port to which the sensor is connected.</li>
-</ul><p class="auto-cursor-target">Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, distance to the nearest object in centimetern.</li>
-</ul> </div><div id="robSensors_infrared_getSample" class="help expert"><h3 id="ProgrammingblocksCalliope-»getlineinfraredsensorCalli:bot...«[Expert-Block]">»get line infrared sensor Calli:bot ... « <span class="typcn typcn-star"></span></h3><p>This sensor measures the shade of the ground and returns whether it is a bright or dark underground.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, position of the infrared-sensor, either left or right.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, true if the ground is dark, false otherwise.</li>
-</ul></div><div id="robSensors_colourtcs3472_getSample" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»get...coloursensorTCS3472...«[Expert-Block]">»get ... colour sensor TCS3472 ... « <span class="typcn typcn-star"></span></h3><p>With this block you can poll the colour sensor TCS3472. This sensor can measure the colour, brightness and colour composition of its surroundings.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select the property you want to measure. You can choose between colour, light and RGB.</li><li class="typcn typcn-arrow-sorted-down">Option, choose the colour sensor you want to poll.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Colour, the colour of the surroundings.</li><li class="typcn typcn-arrow-right">Number, the brightness of the surroundings in percent.</li><li class="typcn typcn-arrow-right">List of numbers, dividing the colour into values of red, green and blue.</li>
-</ul><br></div><div id="robControls_if" class="help beginner"><h3 id="ProgrammingblocksCalliope-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="ProgrammingblocksCalliope-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="ProgrammingblocksCalliope-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="ProgrammingblocksCalliope-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="ProgrammingblocksCalliope-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="ProgrammingblocksCalliope-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="ProgrammingblocksCalliope-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="ProgrammingblocksCalliope-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="ProgrammingblocksCalliope-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="ProgrammingblocksCalliope-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="ProgrammingblocksCalliope-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="ProgrammingblocksCalliope-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="ProgrammingblocksCalliope-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="ProgrammingblocksCalliope-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="ProgrammingblocksCalliope-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="ProgrammingblocksCalliope-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="ProgrammingblocksCalliope-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="ProgrammingblocksCalliope-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="ProgrammingblocksCalliope-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="ProgrammingblocksCalliope-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="ProgrammingblocksCalliope-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="ProgrammingblocksCalliope-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="ProgrammingblocksCalliope-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="ProgrammingblocksCalliope-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="ProgrammingblocksCalliope-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksCalliope-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="ProgrammingblocksCalliope-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="ProgrammingblocksCalliope-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="ProgrammingblocksCalliope-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="ProgrammingblocksCalliope-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingblocksCalliope-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingblocksCalliope-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="ProgrammingblocksCalliope-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="ProgrammingblocksCalliope-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksCalliope-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingblocksCalliope-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingblocksCalliope-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksCalliope-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksCalliope-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksCalliope-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksCalliope-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksCalliope-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksCalliope-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksCalliope-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksCalliope-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingblocksCalliope-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammingblocksCalliope-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammingblocksCalliope-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingblocksCalliope-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="ProgrammingblocksCalliope-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="ProgrammingblocksCalliope-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammingblocksCalliope-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="ProgrammingblocksCalliope-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammingblocksCalliope-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammingblocksCalliope-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammingblocksCalliope-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="ProgrammingblocksCalliope-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="ProgrammingblocksCalliope-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammingblocksCalliope-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div><div id="mbedImage_image" class="help beginner"><br><h3 id="ProgrammingblocksCalliope-»createimage«">»create image«<span style="color: rgb(0,0,0);"> </span></h3><p>You can use the block <span style="color: rgb(0,0,0);">»create image« to create images, which can be displayed on the Calliope. Every single light is  represented by a dot in the grid.</span></p><p><span style="color: rgb(0,0,0);">You can type in a number between 0 and 9 t<span style="color: rgb(0,0,0);">o adjust the brightness of the light or just a<span style="color: rgb(0,0,0);"> </span><span style="color: rgb(0,0,0);">»#« to turn it on. Every empty field represents a turned off light.</span></span></span></p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number; brightness of the light in the grid, between 0 and 9.</li>
-</ul></div><div id="mbedImage_get_image" class="help beginner"><h3 id="ProgrammingblocksCalliope-»image«"><span style="color: rgb(0,0,0);">»image«</span><span style="color: rgb(0,0,0);"> </span></h3><p>By using the <span style="color: rgb(0,0,0);">»image« block you can select predefined images</span><span style="color: rgb(0,0,0);"><span>.</span></span></p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Image, predefined image.</li>
-</ul></div><div id="mbedImage_invert" class="help expert"><h3 id="ProgrammingblocksCalliope-»invertimage«[Expertblock]">»invert image« <span class="typcn typcn-star"></span></h3><p>An image will be inverted. Lightened LEDs of the calliope display will be switched of and vice versa.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"><span>Image to be inverted<br></span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Image, the inversion of the input image</li>
-</ul></div><div id="mbedImage_shift" class="help expert"><h3 id="ProgrammingblocksCalliope-»shiftimage...«[Expertblock]">»shift image ...« <span class="typcn typcn-star"></span></h3><p>An image will be shifted by some positions on the Calliope display. You may select the shift direction and the amount of shifting.</p><p>Input values and settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"><span>Image to be shifted<br></span></li><li class="typcn typcn-arrow-sorted-down">Direction of shifting; up, down, left or right</li><li class="typcn typcn-arrow-left"><span>Number, amount for shifting<br></span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Image, shifted</li>
-</ul></div><div id="mbedCommunication_sendBlock" class="help expert"><br><h3 id="ProgrammingblocksCalliope-»sendmessage«[Expertblock]">»send message« <span class="typcn typcn-star"></span></h3><p>Using the  <span style="color: rgb(0,0,0);">»send message« block you can send a message, which can be received by every Calliope in reach.</span></p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text; message to be send</li>
-</ul></div><div id="mbedCommunication_receiveBlock" class="help expert"><br><h3 id="ProgrammingblocksCalliope-»receivemessage«[Expertblock]">»receive message« <span class="typcn typcn-star"></span></h3><p>With <span style="color: rgb(0,0,0);">the »receive message« block you can receive messages, sent by other calliopes in reach and <span style="color: rgb(0,0,0);">»tell« them to another block.</span></span></p><p><span style="color: rgb(0,0,0);">Performing the <span style="color: rgb(0,0,0);">»receive message« block the Calliope is not waiting for a message, so it wont receive a message, if none was sent. Instead, it will return a default value if you did not receive a message, wich is an unknown string, 0 or "false", depending on the secelted data type.<br></span></span></p><p>If you want to receive a string, but want to check if you really received a message, you need to store the unknown default value for your calliope mini first. To do that, just add a new variable at the beginning of your program and save a string message in it at the beginning of your program with this block. Like this, your calliope will save the unknown value in the variable and you can use it later to compare the messages you receive against it.</p><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">message type, »String«.</li>
-</ul></div><div id="mbedCommunication_setChannel" class="help expert"><h3 id="ProgrammingblocksCalliope-»setchannelto...«[Expertblock]">»set channel to ... « <span class="typcn typcn-star"></span></h3><p>With this block you can set the channel of your Calliope mini. The Calliope mini can only send and receive messages on this channel, not on any others. So it is very important that two Calliope minis are set to the same channel for them to be able to communicate with one another.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">number, the channel for your Calliope mini.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»start«"><span style="color: rgb(0,0,0);">»start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Each program starts with the red »start« block.</p>
+            <p>This block is always available in the Open Roberta Lab and cannot be deleted. The little triangle below
+                the start block is called »sequence connector«. The first block you want to use will be connected by
+                using the »sequence connector« at the start block. The sequence connector color changes to yellow when a
+                suitable block comes into its range.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">create a new global variable</li>
+                <li class="typcn typcn-minus">delete the global variable</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Colour«,
+                    »Image«, »List Number«, »List Boolean«, »List String«, »List Image«</li>
+                <li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial
+                    value of the variable.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_text" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»showtext/character«"><span style="color: rgb(0,0,0);">»show
+                    text/character«</span></h3>
+            <p>With the »show text/character« block you can display text and numbers on the display of your robot. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Text (floats over the display) or character (are shown after
+                    each other).</li>
+                <li class="typcn typcn-arrow-left">Text or number you want to show.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_image" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»showimage/animation«"><span style="color: rgb(0,0,255);"><span
+                        style="color: rgb(0,0,0);">»show image/animation«</span><br></span></h3>
+            <p>With the »show image/animation« block you can show selfmade or predefined images on the display.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Image or Animation (images are shown sequentially).</li>
+                <li class="typcn typcn-arrow-left">single image or list of images.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_clear" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»cleardisplay«"><span style="color: rgb(0,0,255);"> <span
+                        style="color: rgb(0,0,0);">»clear display«</span><br></span></h3>
+            <p>With the »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">clear
+                        display</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« block
+                        you can delete what is shown on the display</span></span>.</p>
+        </div>
+        <div id="mbedActions_display_setBrightness" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»setbrightness«[Expert-Block]">»set brightness« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The brightness of all LEDs on the Calliope display will be set to a uniform value. 0 switches off all
+                LEDs, 9 is the maximum value.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, value between 0 and 9.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_getBrightness" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»getbrightness«[Expert-Block]">»get brightness« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The brightness of all LEDs on the Calliope display will be read. 0 indicates that all LEDs are switched
+                off, 9 is the maximum value.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, value between 0 and 9.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_setPixel" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»setLEDxybrightness«[Expert-Block]">»set LED x y brightness« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The brightness of a single LED on the screen of your Calliope mini is set to a value. The position of the
+                LED is determined by x-axis and y-axis. x is the horizontal axis and y is the vertical axis. 0 turns off
+                the LEDs, 9 is the maximum brightness value.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, value between 0 and 4 for the x position of the LED. 0 stands
+                    for the first LED in the row and 4 for the fifth and last LED in the row.</li>
+                <li class="typcn typcn-arrow-left">Number, value between 0 and 4 for the y position of the LED. 0 stands
+                    for the first LED in the column and 4 for the fifth and last LED in the column.</li>
+                <li class="typcn typcn-arrow-left">Number, value between 0 and 9, where 0 means the LED is off and 9 is
+                    the maximum brightness.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_getPixel" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»getLEDbrightnessxy«[Expert-Block]">»get LED brightness x y« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The brightness of a single LED on the Calliope display will be read. The position of the LED is defined
+                by x and y. A brightness value of 0 indicates that the LED is switches , 9 is the maximum value.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, value between 0 and 4 for the x position of the LED. 0 stands
+                    for the first LED in the row and 4 for the fifth and last LED in the row.</li>
+                <li class="typcn typcn-arrow-left">Number, value between 0 and 4 for the y position of the LED. 0 stands
+                    for the first LED in the column and 4 for the fifth and last LED in the column.</li>
+            </ul>
+            <p class="auto-cursor-target">Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, brightness of the selected LED.</li>
+            </ul>
+        </div>
+        <div id="robActions_serial_print" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»ShowonSerialMonitor...«[Expert-block]"><br>» Show on Serial Monitor ... «
+                <span class="typcn typcn-star"></span></h3>
+            <p>With the block "Show on Serial Monitor..." you can display the output in a Serial Monitor of your choice
+                (e.g. Arduino Serial Monitor / (Chrome) Browser Serial Monitor).</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Specify what should be displayed on your Serial Monitor. Possible
+                    variants are: Number, boolean, string or color.</li>
+            </ul><br>
+        </div>
+        <div id="mbedActions_fourDigitDisplay_show" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»Show4-DigitDisplayNumber...position...colon...«[Expert-block]">» Show
+                4-Digit Display Number ... position ... colon ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can display a number from 0 to 9999 on the Grove 4-digit display of Seeed. The
+                display must be connected to the right Grove connector (A1). The position from 0 to 3 indicates the
+                starting position of the number.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, Value between 0 and 9999. This number will be shown on
+                    the display.</li>
+                <li class="typcn typcn-arrow-sorted-down">Number, Value between 0 and 3. This is the starting position
+                    of the number.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean, true or false. Specifies whether to display a colon
+                    in the center.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_fourDigitDisplay_clear" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»Cleardisplay4-DigitDisplay«[Expert-block]">» Clear display 4-Digit
+                Display « <span class="typcn typcn-star"></span></h3>
+            <p>This block deletes the output on Seeed's Grove display when it is connected to the right Grove connector
+                (A1).</p>
+        </div>
+        <div id="mbedActions_leds_on" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»turnLEDoncolour...«">»turn LED on colour ...«</h3>
+            <p>With the »turn LED on colour ...« you can turn on the status LED in a particular colour.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Colour in which the LED should light up.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_leds_off" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»turnLEDoff«">»turn LED off«</h3>
+            <p>With the »turn LED off« block you can turn off the status LED or the LEDs on the Calli:bot.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose which LED you want to turn off.</li>
+            </ul><br>
+        </div>
+        <div id="mbedActions_ledBar_set" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»setLEDBarx...brightness...«[Expertblock]">» set LED Bar x ... brightness
+                ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can control the Grove LED-Bar v2.0 by Seed. The LED-Bar needs to be connected to the
+                A1 port of your Calliope mini. The first LED of the LED-Bar is red, the second orange and the other
+                eight are green.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, position of the LED that you want to change, value between 0
+                    and 9.</li>
+                <li class="typcn typcn-arrow-left">Number, brightness of the LED, value between 0 and 8, with 0 being
+                    off and 8 being the maximum brightness.</li>
+            </ul>
+        </div>
+        <div id="robActions_brickLight_on" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»turnLEDonCalli:bot......«[Expert-Block]">» turn LED on Calli:bot ... ...
+                « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can control the LEDs on the Calli:bot, you can either turn them off or on.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose which LED you want to control.</li>
+                <li class="typcn typcn-arrow-sorted-down">option, choose whether you want to turn the LED on or off.
+                </li>
+            </ul>
+        </div>
+        <div id="mbedActions_motors_on" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»motor......onspeed%......«[Expert-Block]">»motor ... ... on speed % ...
+                ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can control two motors at the same time with different speed settings.</p>
+            <p>You can choose between the motors connected directly to the Calliope mini or the motors of the Calli:bot.
+            </p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor; pick the motors you want to control.</li>
+                <li class="typcn typcn-arrow-left">number, speed you want the first motor to rotate at, between 0 and
+                    100.</li>
+                <li class="typcn typcn-arrow-left">number, speed you want the second motor to rotate at, between 0 and
+                    100.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_motors_stop" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»stopmotorportA+B«">» stop motor port A + B «</h3>
+            <p>With this block you can stop the two motors connected directly to the Calliope mini.</p>
+        </div>
+        <div id="mbedActions_motor_on" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»motor...onspeed%...«[Expert-Block]">»motor ... on speed % ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">motor <span
+                            style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">... on
+                                speed</span></span></span></span><span style="color: rgb(0,0,255);"><span
+                        style="color: rgb(0,0,0);">« can be used to turn on a motor and to control its
+                        speed</span></span>.</p>
+            <p>You can choose between a motor connected directly to the Calliope mini or a motor of the Calli:bot.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor; pick the motor you want to control.</li>
+                <li class="typcn typcn-arrow-left">number, speed you want the motor to rotate at, between 0 and 100.
+                </li>
+            </ul>
+        </div>
+        <div id="mbedActions_motor_stop" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»stopmotor...«[Expert-Block]">»stop motor ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can stop one of the connected motors at once.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the motor that you want to stop.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_single_motor_on" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»motoronspeed%...«[Expert-Block]">»motor on speed % ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can control the motor connected to motor control pins aboce the RGB-LED.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, speed you want the motor to rotate at, between 0 and 100.
+                </li>
+            </ul>
+        </div>
+        <div id="mbedActions_single_motor_stop" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»motorstop...«[Expert-Block]">»motor stop ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Using this block you can stop the connected motor either immediatly, let it run out or make it go to
+                sleep.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, float, brake or sleep; make your choice.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_servo_set" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»setservomotor...to°...«[Expert-Block]">»set
+                servo motor ... to ° ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can control the chosen servo motor and turn its arm.</p>
+            <p>Input values and options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the port or pin the servo motor is connected
+                    to.</li>
+                <li class="typcn typcn-arrow-sorted-down">number, angle or position that you want the servo arm to turn
+                    to. Value between 180 and 180.</li>
+            </ul><br>
+        </div>
+        <div id="mbedActions_motionkit_single_set" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»MotionKit......«[Expert-Block]">»MotionKit ...
+                ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can control one of the motors of the MotionKit and set it to turn either for- or
+                backwards.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, chose with motor you want to control.</li>
+                <li class="typcn typcn-arrow-sorted-down">option, chose the direction you want the motor to turn in.
+                </li>
+            </ul><br>
+        </div>
+        <div id="mbedActions_motionkit_dual_set" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»MotionKitleft...right...«[Expert-Block]">
+                »MotionKit left ... right ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can control both motors of the MotionKit individually.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, direction you want the left motor to turn in.</li>
+                <li class="typcn typcn-arrow-sorted-down">option, direction you want the right motor to turn in.</li>
+            </ul><br>
+        </div>
+        <div id="mbedActions_play_note" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»play...«">»play...«</h3>
+            <p>With the »play ...« block you can play notes on your Calliope.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Note length; select the length of the note that is going to be
+                    played.</li>
+                <li class="typcn typcn-arrow-sorted-down">Note pitch; select the note that is going to be played.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_play_tone" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»playfrequency«[Expert-Block]">»play frequency« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the »play frequency« block you can program the frequency (pitch level) and the time (how long the
+                sound should be played) of the sound that is played. The sound is played by the built-in speaker of your
+                Calliope for a defined of time. The frequency setting corresponds directly to the frequency in Hertz,
+                for example, setting the frequency to 400 corresponds to 400 Hertz. Example: 261 = C.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Note that the human ear can perceive frequencies from about 30Hz to about 15,000Hz (15kHz). This
+                        can vary depending on the person and their age.</p>
+                </div>
+            </div>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, desired frequency in Hz (Hertz) .</li>
+                <li class="typcn typcn-arrow-left">Number, desired duration in milliseconds (ms).</li>
+            </ul>
+        </div>
+        <div id="mbedActions_write_to_pin" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»writeanalog/digitalvaluetopin...«[Expert-Block]">»write analog/digital
+                value to pin ...« <span class="typcn typcn-star"></span></h3>
+            <p>With the »write analog/digital value to pin....« block you can send signals to an outputpin .</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">analog or digital.</li>
+                <li class="typcn typcn-arrow-sorted-down">In and output pin 0 to 3.</li>
+                <li class="typcn typcn-arrow-left">Number: value to write</li>
+            </ul>
+        </div>
+        <div id="mbedActions_switch_led_matrix" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»switchLEDmatrix...«[Expertblock]">» switch LED
+                matrix ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can either switch the LED matrix on or off.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose if you want to switch the matrix off or on.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»button...pressed?«">»button ... pressed?«</h3>
+            <p>With the block »button ... pressed?« you can "tell" another block whether a button is pressed or not.
+                This block returns the logical values <em>true = pressed</em> or <em>false = not pressed</em>. This
+                block can only be used in conjunction with another block which requires a logical value as an input
+                parameter, for example together with the »if do« block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Button, select the button you want to check.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value: »true«, if the button is pressed, otherwise »false«.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_pintouch_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»ispin...touched?«">»is pin ... touched?«</h3>
+            <p>You can check whether a pin of the Calliiope is touched or not by using the block »is pin ... touched?« .
+                This block returns logical values (true if the pin is touched and false if not)</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Pin, select the pin you want to check.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logical value: »true«, if the pin is touched, »false« else.</li>
+            </ul>
+        </div>
+        <div id="robSensors_gesture_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»gesture...aktive?«">»gesture ... aktive?«</h3>
+            <p>With the block »gesture ... aktive?« you can "tell" another block whether the Calliope is in a specific
+                gesture or not .</p>
+            <p>If the Calliope is in the checked gesture the return value will be true. If not it will be false.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">gesture to be checked.</li>
+            </ul>
+        </div>
+        <div id="robSensors_compass_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»getvaluecompasssensor«">»get value compass sensor«</h3>
+            <p>With the »get value compass sensor« block, you can read the orientation of your Calliope minis in
+                relation to the Cardinal Directions, just like on a compass.</p>
+            <p>To do this, calibrate the Calliope mini by tilting it in all directions until all LEDs on the Calliope
+                mini display light up.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, orientation in degrees from 0° to 360°. Where 0° means your
+                    Calliope mini is facing north.</li>
+            </ul>
+        </div>
+        <div id="robSensors_sound_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»getvaluemicrophone«">»get value microphone«</h3>
+            <p>Get the value of noise close to the Calliope. The microphone is not very sensitive, so the sound you
+                check should not be far away.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, volume level from 0 (quiet) to 100 (loud). For older
+                    versions of the Calliope it is possible that only values between 0 and 10 are given.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»getvaluetimerinms«">»get value timer in ms«</h3>
+            <p>With the block »get value timer in ms« you can "tell" another block the current time in milliseconds of
+                the internal timer.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, milliseconds since program start or since the last reset of
+                    the timer.</li>
+            </ul>
+        </div>
+        <div id="mbedSensors_timer_reset" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»resettimer«">»reset timer«</h3>
+            <p>With the block »reset timer« the internal timer can be reseted to the value 0.</p>
+        </div>
+        <div id="robSensors_temperature_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»getvaluetemperaturesensor«">»get value temperature sensor«</h3>
+            <p>with the »get value temperature sensor« you can read out the currently measured temperature.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number; Temperature in degrees.</li>
+            </ul>
+        </div>
+        <div id="robSensors_rssi_getSample" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»getvaluesignalstrength«[Expert-Block]">»get value signal strength « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can "sense" the brightness of your surroundings. This block queries the built-in
+                light sensor of the Calliope mini.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, strength of the last received message.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner"> <br>
+            <h3 id="ProgrammingblocksCalliope-»getvalue%lightsensor«">»get value % light sensor«</h3>
+            <p>With the block »get value ambient light« you can measure the brightness of the ambient light.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number; brightness between 0 and 255.</li>
+            </ul>
+        </div>
+        <div id="robSensors_pin_getSample" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»getanalog/digitalvaluepin...«[Expert-Block]">»get analog/digital value
+                pin ...« <span class="typcn typcn-star"></span></h3>
+            <p>With the »get analog/digital value pin ...« block you can read out a analog or digital input value. You
+                can connect other devices or additional modules to a pin.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Analog/Digital; which kind of signal do you want to read?</li>
+                <li class="typcn typcn-arrow-sorted-down">Pin, select the pin you want to read out.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number; current input signal.</li>
+            </ul>
+        </div>
+        <div id="robSensors_gyro_getSample" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»getvaluerotation...«[Expert-Block]">»get value rotation ...« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Read the value of rotation in degrees, how the Calliope was pitched or rolled.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»pitch« for measurement related to the transversal axis;
+                    »roll« for measurement related to the longitudinal axis.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, degrees within the range of -180 and 180.</li>
+            </ul>
+        </div>
+        <div id="robSensors_accelerometer_getSample" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»getvalueaccelerationmg...«[Expert-Block]">»get value acceleration mg ...«
+                <span class="typcn typcn-star"></span></h3>
+            <p>The acceleration of the Calliope will be given, according to the three coordinate axes x, y and z.</p>
+            <p>Setting:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">x/y/z-strength; for which direction do you want to read the
+                    acceleration value? z for instance is the falling direction where the earth gravitation acts.
+                    Strength is the sum of all directions.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">number, acceleration in that direction, measured in milli-g
+                    where 1000 mg = 1 g = 9.81 m/s²</li>
+            </ul>
+        </div>
+        <div id="robSensors_humidity_getSample" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»get...humiditysensor«[Expert-Block]">»get ... humidity sensor « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block shows the value of the humidity sensor. This sensor measures both the relative humidity and
+                the temperature of the environment and must be connected to pin A1.</p>
+            <p>The sensor used is an SHT31 and communicates via I²C with the Calliope mini.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose which value you want to measure, either
+                    temperature or humidity.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, relative humidity in % or temperature in °C.</li>
+            </ul>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»getdistancecmultrasonicsensor...«[Expert-Block]">»get distance cm
+                ultrasonic sensor ... « <span class="typcn typcn-star"></span></h3>
+            <p>This sensor measures the distance to the next object by emitting ultrasonic waves. This sensor must be
+                connected either to pin A1 on the Calliope mini or to the intended location on the Calli:bot. The sensor
+                used is a Grove ultrasonic sensor based on a HC-SR04, but with a built-in microcontroller that handles
+                the communication.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, port to which the sensor is connected.</li>
+            </ul>
+            <p class="auto-cursor-target">Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, distance to the nearest object in centimetern.</li>
+            </ul>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»getlineinfraredsensorCalli:bot...«[Expert-Block]">»get line infrared
+                sensor Calli:bot ... « <span class="typcn typcn-star"></span></h3>
+            <p>This sensor measures the shade of the ground and returns whether it is a bright or dark underground.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, position of the infrared-sensor, either left or right.
+                </li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, true if the ground is dark, false otherwise.</li>
+            </ul>
+        </div>
+        <div id="robSensors_colourtcs3472_getSample" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»get...coloursensorTCS3472...«[Expert-Block]">
+                »get ... colour sensor TCS3472 ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can poll the colour sensor TCS3472. This sensor can measure the colour, brightness
+                and colour composition of its surroundings.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select the property you want to measure. You can
+                    choose between colour, light and RGB.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the colour sensor you want to poll.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Colour, the colour of the surroundings.</li>
+                <li class="typcn typcn-arrow-right">Number, the brightness of the surroundings in percent.</li>
+                <li class="typcn typcn-arrow-right">List of numbers, dividing the colour into values of red, green and
+                    blue.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="ProgrammingblocksCalliope-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»breakout/continuewithnextiterationofloop«[Expert-block]">»break
+                out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammingblocksCalliope-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="ProgrammingblocksCalliope-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»mathematicalfunction«[Expert-block]">»mathematical function« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»constant«[Expert-block]">»constant« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksCalliope-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»constrain«[Expert-block]">»constrain« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingblocksCalliope-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingblocksCalliope-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="ProgrammingblocksCalliope-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="ProgrammingblocksCalliope-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksCalliope-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingblocksCalliope-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingblocksCalliope-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to
+                Number« <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksCalliope-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksCalliope-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksCalliope-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksCalliope-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksCalliope-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksCalliope-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksCalliope-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksCalliope-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingblocksCalliope-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingblocksCalliope-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammingblocksCalliope-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingblocksCalliope-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red
+                ... green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="ProgrammingblocksCalliope-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green
+                ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingblocksCalliope-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ...
+                green ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function
+                blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function
+                blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»ifblocktobeusedwithinafunction«">»if block to be used within a function«
+            </h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="ProgrammingblocksCalliope-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function
+                with return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="ProgrammingblocksCalliope-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a
+                function with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»functioncallwithoutreturnvalue«">»function call without return value «
+            </h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingblocksCalliope-»functioncallwithreturnvalue«">»function call
+                with return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul>
+        </div>
+        <div id="mbedImage_image" class="help beginner"><br>
+            <h3 id="ProgrammingblocksCalliope-»createimage«">»create image«<span style="color: rgb(0,0,0);"> </span>
+            </h3>
+            <p>You can use the block <span style="color: rgb(0,0,0);">»create image« to create images, which can be
+                    displayed on the Calliope. Every single light is represented by a dot in the grid.</span></p>
+            <p><span style="color: rgb(0,0,0);">You can type in a number between 0 and 9 t<span
+                        style="color: rgb(0,0,0);">o adjust the brightness of the light or just a<span
+                            style="color: rgb(0,0,0);"> </span><span style="color: rgb(0,0,0);">»#« to turn it on. Every
+                            empty field represents a turned off light.</span></span></span></p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number; brightness of the light in the grid, between 0 and 9.</li>
+            </ul>
+        </div>
+        <div id="mbedImage_get_image" class="help beginner">
+            <h3 id="ProgrammingblocksCalliope-»image«"><span style="color: rgb(0,0,0);">»image«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>By using the <span style="color: rgb(0,0,0);">»image« block you can select predefined images</span><span
+                    style="color: rgb(0,0,0);"><span>.</span></span></p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Image, predefined image.</li>
+            </ul>
+        </div>
+        <div id="mbedImage_invert" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»invertimage«[Expertblock]">»invert image« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>An image will be inverted. Lightened LEDs of the calliope display will be switched of and vice versa.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"><span>Image to be inverted<br></span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Image, the inversion of the input image</li>
+            </ul>
+        </div>
+        <div id="mbedImage_shift" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»shiftimage...«[Expertblock]">»shift image ...« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>An image will be shifted by some positions on the Calliope display. You may select the shift direction
+                and the amount of shifting.</p>
+            <p>Input values and settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"><span>Image to be shifted<br></span></li>
+                <li class="typcn typcn-arrow-sorted-down">Direction of shifting; up, down, left or right</li>
+                <li class="typcn typcn-arrow-left"><span>Number, amount for shifting<br></span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Image, shifted</li>
+            </ul>
+        </div>
+        <div id="mbedCommunication_sendBlock" class="help expert"><br>
+            <h3 id="ProgrammingblocksCalliope-»sendmessage«[Expertblock]">»send message« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Using the <span style="color: rgb(0,0,0);">»send message« block you can send a message, which can be
+                    received by every Calliope in reach.</span></p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text; message to be send</li>
+            </ul>
+        </div>
+        <div id="mbedCommunication_receiveBlock" class="help expert"><br>
+            <h3 id="ProgrammingblocksCalliope-»receivemessage«[Expertblock]">»receive message« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With <span style="color: rgb(0,0,0);">the »receive message« block you can receive messages, sent by other
+                    calliopes in reach and <span style="color: rgb(0,0,0);">»tell« them to another block.</span></span>
+            </p>
+            <p><span style="color: rgb(0,0,0);">Performing the <span style="color: rgb(0,0,0);">»receive message« block
+                        the Calliope is not waiting for a message, so it wont receive a message, if none was sent.
+                        Instead, it will return a default value if you did not receive a message, wich is an unknown
+                        string, 0 or "false", depending on the secelted data type.<br></span></span></p>
+            <p>If you want to receive a string, but want to check if you really received a message, you need to store
+                the unknown default value for your calliope mini first. To do that, just add a new variable at the
+                beginning of your program and save a string message in it at the beginning of your program with this
+                block. Like this, your calliope will save the unknown value in the variable and you can use it later to
+                compare the messages you receive against it.</p>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">message type, »String«.</li>
+            </ul>
+        </div>
+        <div id="mbedCommunication_setChannel" class="help expert">
+            <h3 id="ProgrammingblocksCalliope-»setchannelto...«[Expertblock]">»set channel to ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can set the channel of your Calliope mini. The Calliope mini can only send and
+                receive messages on this channel, not on any others. So it is very important that two Calliope minis are
+                set to the same channel for them to be able to communicate with one another.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">number, the channel for your Calliope mini.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_edison_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_edison_de.html
@@ -1,373 +1,1425 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»Programmstart«"><br>»Programmstart«</h3><p>Jedes Programm beginnt mit dem »Programmstart-Block«, welcher nicht gelöscht werden kann. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am Programmstart-Block. </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
-</ul><br><p>Wenn globale Variablen erzeugt wurden:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variable.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variable.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variable.</li>
-</ul></div><div id="robActions_motor_on" class="help expert"><br><h3 id="ProgrammierBlöckeEdisonV2.0-»Motor...anTempo...«[Experten-Block]">»Motor ... an Tempo ... « <span class="typcn typcn-star"></span></h3><p>Dieser Block steuert einen Motor des Roboters, indem er die Geschwindigkeit auf den angegebenen Wert ändert.</p><p>Eingabe- und Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, steuert welcher Motor angesprochen werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Tempo des Motors zwischen -100 und 100.</li>
-</ul></div><div id="robActions_motor_stop" class="help expert"><h3 id="ProgrammierBlöckeEdisonV2.0-»StoppeMotor...«[Experten-Block]"><br>»Stoppe Motor ...« <span class="typcn typcn-star"></span></h3><p>Dieser Block stoppt den ausgewählten Motor sofort.</p><p>Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, der Motor, der gestoppt werden soll.</li>
-</ul></div><div id="robActions_motorDiff_on_for" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»Fahre...Tempo...Strecke...«"><br>»Fahre ... Tempo ... Strecke ... «</h3><p>Dieser Block lässt den Roboter vorwärts oder rückwärts die gewählte Strecke mit der gewählten Geschwindigkeit fahren.</p><p>Eingabe- und Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, vorwärts oder rückwärts, die Richtung, in die der Roboter fahren soll.</li><li class="typcn typcn-arrow-left">Zahl, Tempo mit dem die Strecke zuückgelegt werden soll, zwischen 1 und 100.</li><li class="typcn typcn-arrow-left">Zahl, Strecke die zurück gelegt werden soll, in Zentimetern.</li>
-</ul></div><div id="robActions_motorDiff_on" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»Fahre...Tempo...«"><br>»Fahre ... Tempo ... «</h3><p>Mit diesem Block lässt du deinen Roboter unendlich weit mit dem eingestellten Tempo fahren. Beachte also, dass du deinen Roboter durch dein Programm davon abhalten solltest immer weiter in eine Richtung zu fahren, da der Roboter sonst immer weiter gegen eine Wand oder ein Hindernis fahren könnte.</p><p>Eingabe- und Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">vorwärts oder rückwärts, die Richtung in die dein Roboter fahren soll.</li><li class="typcn typcn-arrow-left">Zahl, Tempo mit dem sich der Roboter bewegen soll, zwischen 1 und 100.</li>
-</ul></div><div id="robActions_motorDiff_stop" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»Stoppe«"><br>»Stoppe«</h3><p>Dieser Block stoppt deinen Roboter sofort.</p></div><div id="robActions_motorDiff_turn_for" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»Drehe...Tempo...Grad...«"><br>»Drehe ... Tempo ... Grad ... «</h3><p>Dieser Block dreht deinen Roboter  um einen gewählten Wert mit einem gewählten Tempo.</p><p>Eingabe- und Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, die Richtung in die sich dein Roboter drehen soll.</li><li class="typcn typcn-arrow-left">Zahl, Tempo mit der sich dein Roboter drehen soll, zwischen 1 und 100</li><li class="typcn typcn-arrow-left">Zahl, Grad um die sich dein Roboter drehen soll. Dabei ist 360 Grad eine ganze Drehung.</li>
-</ul></div><div id="robActions_motorDiff_turn" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»Drehe...Tempo...«"><br>»Drehe ... Tempo ... «</h3><p>Dieser Block dreht deinen Roboter mit dem festgelegten Tempo in die gewählte Richtung. Der Roboter dreht sich ohne Kontrolle immer weiter in diese Richtung.</p><p>Eingabe- und Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, die Richtung, in die sich dein Roboter drehen soll.</li><li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter drehen soll, zwischen 1 und 100.</li>
-</ul></div><div id="robActions_motorDiff_curve_for" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»Steure...Tempolinks...Temporechts...Strecke...«"><br>»Steure ... Tempo links ... Tempo rechts ... Strecke ... «</h3><p>Mit diesem Block kannst du deinen Roboter vorwärts oder rückwärts fahren lassen und dabei die Geschwindigkeit der Motoren einzeln steuern, sodass du z.B. Kurven fahren kannst. Außerdem kannst du die Strecke angeben, die dein Roboter fahren soll.</p><p>Eingabe- und Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, vorwärts oder rückwärts, die Richtung in die dein Roboter fahren soll.</li><li class="typcn typcn-arrow-left">Zahl, das Tempo für den linken Motor, zwischen 1 und 100.</li><li class="typcn typcn-arrow-left">Zahl, das Tempo für den rechten Motor, zwischen 1 und 100.</li><li class="typcn typcn-arrow-left">Zahl, Strecke in Zentimetern, die zurück gelegt werden soll.</li>
-</ul></div><div id="robActions_motorDiff_curve" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»Steure...Tempolinks...Temporechts...«"><br>»Steure ... Tempo links ... Tempo rechts ... «</h3><p>Mit diesem Block kannst du deinen Roboter vorwärts oder rückwärts fahren lassen und dabei die Geschwindigkeit der Motoren einzeln steuern. Der Roboter fährt keine festgelegte Strecke, sondern immer weiter, bis du ihn durch dein Programm stoppst.</p><p>Eingabe- und Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, vorwärts oder rückwärts, die Richtung in die dein Roboter fahren soll.</li><li class="typcn typcn-arrow-left">Zahl, das Tempo des linken Motors, zwischen 1 und 100.</li><li class="typcn typcn-arrow-left">Zahl, das Tempo des rechten Motors, zwischen 1 und 100.</li>
-</ul></div><div id="robActions_play_tone" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»SpieleFrequenz...Dauer...«"><br>»Spiele Frequenz ... Dauer ... «</h3><p>Dieser Block lässt deinen Roboter einen Ton mit der gewählten Frequenz für die gewählte Dauer ausgeben. Beachte dabei, dass das menschliche Gehör nur Töne zwischen  etwa 20 und 20000 Hertz wahrnehmen kann.</p><p>Eingabe- und Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl zwischen 20 und 20000, Frequenz des Tons, der abgespielt werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Zeit, für die der Ton abgespielt werden soll.</li>
-</ul></div><div id="mbedActions_play_note" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»Spiele...Note....«"><br>»Spiele ... Note .... «</h3><p>Dieser Block lässt deinen Roboter eine ausgewählte Note spielen.</p><p>Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Dauer der Note, die gespielt werden soll. Von ganzer bis sechzehntel Note.</li><li class="typcn typcn-arrow-sorted-down">Option, Note, die gespielt werden soll.</li>
-</ul></div><div id="robActions_play_file" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»SpieleStück...«"><br>»Spiele Stück ... «</h3><p>Dieser Block lässt deinen Roboter eins der vorgefertigten Stücke abspielen.</p><p>Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Nummer des Stückes, das gespielt werden soll.</li>
-</ul><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><p>Dieser Block kann nicht in Funktionen benutzt werden.</p></div></div></div><div id="robActions_led_on" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»SchalteLEDan...«"><br>»Schalte LED an ... «</h3><p>Dieser Block schaltet die ausgewählte LED deines Roboters an.</p><p>Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Auswahl der LED, die eingeschaltet werden soll.</li>
-</ul></div><div id="robActions_led_off" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»SchalteLEDaus...«"><br>»Schalte LED aus ... «</h3><p>Dieser Block schaltet die ausgewählte LED deines Roboters aus.</p><p>Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Auswahl der LED, die ausgeschaltet werden soll.</li>
-</ul></div><div id="robSensors_key_getSample" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»Taste...gedrückt?«"><br>»Taste ... gedrückt?«</h3><p>Dieser Block fragt ab, ob die ausgewählte Taste gedrückt wird. Er gibt »wahr« zurück, wenn die Taste gedrückt wird, sonst »falsch«.</p><p>Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Taste, die abgefragt werden soll. Entweder »Wiedergabe«- oder »Aufnahme«-Taste</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« wenn die ausgewählte Taste gedrückt ist, sonst »falsch«.</li>
-</ul></div><div id="robSensors_infrared_getSample" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»GibHindernis...Infrarotsensor«"><br>»Gib Hindernis ... Infrarotsensor «</h3><p>Dieser Block fragt die Infrarotsensoren an der Front des Roboters ab, ob sie ein Hindernis erkennen, also ob sich ein Hindernis (z.B. eine Wand) in sehr geringem Abstand vor dem Roboter befindet.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Auswahl des Abschnittes an der Front, der kontrolliert werden soll. Die Abschnitte sind durch Linien an der Front gekennzeichnet.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, »wahr« wenn ein Hindernis erkannt worden ist, sonst »falsch«.</li>
-</ul></div><div id="robSensors_irseeker_getSample" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»GibR/CCodeInfrarotempfänger«"><br>»Gib R/C Code Infrarotempfänger «</h3><p>Dieser Block steuert den Infrarotsensor des Roboters. Dieser kann Infrarotsignale von anderen Geräten empfangen, also z.B. von Fernbedienungen und mit diesen ferngesteuert werden.</p><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, der Wert des Infrarot-Signals, der empfangen wurde.</li>
-</ul></div><div id="robSensors_light_getSample" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»GibLichtLichtsensor...«"><br>»Gib Licht Lichtsensor ... «</h3><p>Dieser Block steuert den Lichtsensor deines Roboters. Dieser misst, wie viel Licht auf deinen Roboter fällt und gibt diesen Wert zurück.</p><p>Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Position des Lichtsensors</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gemessene Lichteinstrahlung</li>
-</ul></div><div id="robSensors_sound_getSample" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»GibGeräuschGeräuschsensor«"><br>»Gib Geräusch Geräuschsensor «</h3><p>Dieser Block steuert den Geräuschsensor, also eine Art Mikrofon, deines Roboters. Wenn du z.B. in die Hände klatscht, erzeugt das ein lautes Geräusch, dass dein Roboter »wahrnehmen«, also messen, kann.</p><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr«, wenn ein lautes Geräusch, z.B. Klatschen registriert worden ist, sonst »falsch«.</li>
-</ul><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><p>Diesen Block nicht direkt nach einem »Fahre«-Block verwenden, zuerst einen »Warte«-Befehl dazwischen schalten.</p></div></div></div><div id="edisonSensors_sensor_reset" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»Setze...zurück«"><br>»Setze ... zurück «</h3><p>Dieser Block setzt den ausgewählten Sensor zurück, er löscht also alle vorangegangenen Kallibrationen, die vorgenommen worden sind.</p><p>Auswahlmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Sensor, der zurückgesetzt werden soll.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEdisonV2.0-»Wartebis...«">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wartems...«">»Warte ms ... «</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wartebis...«.1">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Zufallszahl«">»Zufallszahl« </h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeEdisonV2.0-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeEdisonV2.0-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt werden soll. Zahl zwischen 0 und 255.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeEdisonV2.0-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von der verwendeten Programmiersprache des Roboters abhängt. </span><span style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt, sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der Zeichenkette »52abcd« die Zahl 52.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeEdisonV2.0-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li><li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte das die Nummerierung bei 0 anfängt.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEdisonV2.0-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEdisonV2.0-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEdisonV2.0-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEdisonV2.0-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEdisonV2.0-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEdisonV2.0-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEdisonV2.0-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="ProgrammierBlöckeEdisonV2.0-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammierBlöckeEdisonV2.0-»Farbwahl«">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammierBlöckeEdisonV2.0-»Farbwahl«.1">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammierBlöckeEdisonV2.0-»Farbwahl«.2">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEdisonV2.0-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, die  Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEdisonV2.0-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEdisonV2.0-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="ProgrammierBlöckeEdisonV2.0-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammierBlöckeEdisonV2.0-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammierBlöckeEdisonV2.0-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammierBlöckeEdisonV2.0-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="ProgrammierBlöckeEdisonV2.0-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="ProgrammierBlöckeEdisonV2.0-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammierBlöckeEdisonV2.0-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen Wert zurück.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEdisonV2.0-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit Rückgabewert «</h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
-</ul><br></div><div id="edisonCommunication_ir_sendBlock" class="help expert"><h3 id="ProgrammierBlöckeEdisonV2.0-»SendeNachricht...«"><br>»Sende Nachricht ... «</h3><p>Mit diesem Block kann dein Edison V2.0 eine Nachricht an alle anderen Edison V2.0 in seiner Umgebung schicken. Er tut dies über Infrarot-Signale.</p><p>Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Nachricht, die geschickt werden soll.</li>
-</ul></div><div id="edisonCommunication_ir_receiveBlock" class="help expert"><h3 id="ProgrammierBlöckeEdisonV2.0-»EmpfangeNachricht«"><br>»Empfange Nachricht«</h3><p>Dieser Block lässt deinen Edison V2.0 Nachrichten von anderen Edison V2.0 in seiner Umgebung empfangen.</p><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Nachricht, die empfangen worden ist.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Programmstart«"><br>»Programmstart«</h3>
+            <p>Jedes Programm beginnt mit dem »Programmstart-Block«, welcher nicht gelöscht werden kann. Den ersten
+                Block, den man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am
+                Programmstart-Block. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
+            </ul><br>
+            <p>Wenn globale Variablen erzeugt wurden:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variable.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variable.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on" class="help expert"><br>
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Motor...anTempo...«[Experten-Block]">»Motor ... an Tempo ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Dieser Block steuert einen Motor des Roboters, indem er die Geschwindigkeit auf den angegebenen Wert
+                ändert.</p>
+            <p>Eingabe- und Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, steuert welcher Motor angesprochen
+                    werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo des Motors zwischen -100 und 100.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_stop" class="help expert">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»StoppeMotor...«[Experten-Block]"><br>»Stoppe Motor ...« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Dieser Block stoppt den ausgewählten Motor sofort.</p>
+            <p>Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, der Motor, der gestoppt werden
+                    soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_on_for" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Fahre...Tempo...Strecke...«"><br>»Fahre ... Tempo ... Strecke ... «
+            </h3>
+            <p>Dieser Block lässt den Roboter vorwärts oder rückwärts die gewählte Strecke mit der gewählten
+                Geschwindigkeit fahren.</p>
+            <p>Eingabe- und Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, vorwärts oder rückwärts, die Richtung, in die der
+                    Roboter fahren soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo mit dem die Strecke zuückgelegt werden soll, zwischen 1
+                    und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Strecke die zurück gelegt werden soll, in Zentimetern.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_on" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Fahre...Tempo...«"><br>»Fahre ... Tempo ... «</h3>
+            <p>Mit diesem Block lässt du deinen Roboter unendlich weit mit dem eingestellten Tempo fahren. Beachte also,
+                dass du deinen Roboter durch dein Programm davon abhalten solltest immer weiter in eine Richtung zu
+                fahren, da der Roboter sonst immer weiter gegen eine Wand oder ein Hindernis fahren könnte.</p>
+            <p>Eingabe- und Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">vorwärts oder rückwärts, die Richtung in die dein Roboter
+                    fahren soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo mit dem sich der Roboter bewegen soll, zwischen 1 und
+                    100.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_stop" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Stoppe«"><br>»Stoppe«</h3>
+            <p>Dieser Block stoppt deinen Roboter sofort.</p>
+        </div>
+        <div id="robActions_motorDiff_turn_for" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Drehe...Tempo...Grad...«"><br>»Drehe ... Tempo ... Grad ... «</h3>
+            <p>Dieser Block dreht deinen Roboter um einen gewählten Wert mit einem gewählten Tempo.</p>
+            <p>Eingabe- und Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, die Richtung in die sich dein
+                    Roboter drehen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo mit der sich dein Roboter drehen soll, zwischen 1 und 100
+                </li>
+                <li class="typcn typcn-arrow-left">Zahl, Grad um die sich dein Roboter drehen soll. Dabei ist 360 Grad
+                    eine ganze Drehung.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_turn" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Drehe...Tempo...«"><br>»Drehe ... Tempo ... «</h3>
+            <p>Dieser Block dreht deinen Roboter mit dem festgelegten Tempo in die gewählte Richtung. Der Roboter dreht
+                sich ohne Kontrolle immer weiter in diese Richtung.</p>
+            <p>Eingabe- und Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, die Richtung, in die sich dein
+                    Roboter drehen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter drehen soll, zwischen 1 und
+                    100.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_curve_for" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Steure...Tempolinks...Temporechts...Strecke...«"><br>»Steure ... Tempo
+                links ... Tempo rechts ... Strecke ... «</h3>
+            <p>Mit diesem Block kannst du deinen Roboter vorwärts oder rückwärts fahren lassen und dabei die
+                Geschwindigkeit der Motoren einzeln steuern, sodass du z.B. Kurven fahren kannst. Außerdem kannst du die
+                Strecke angeben, die dein Roboter fahren soll.</p>
+            <p>Eingabe- und Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, vorwärts oder rückwärts, die Richtung in die dein
+                    Roboter fahren soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, das Tempo für den linken Motor, zwischen 1 und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, das Tempo für den rechten Motor, zwischen 1 und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Strecke in Zentimetern, die zurück gelegt werden soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_curve" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Steure...Tempolinks...Temporechts...«"><br>»Steure ... Tempo links ...
+                Tempo rechts ... «</h3>
+            <p>Mit diesem Block kannst du deinen Roboter vorwärts oder rückwärts fahren lassen und dabei die
+                Geschwindigkeit der Motoren einzeln steuern. Der Roboter fährt keine festgelegte Strecke, sondern immer
+                weiter, bis du ihn durch dein Programm stoppst.</p>
+            <p>Eingabe- und Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, vorwärts oder rückwärts, die Richtung in die dein
+                    Roboter fahren soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, das Tempo des linken Motors, zwischen 1 und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, das Tempo des rechten Motors, zwischen 1 und 100.</li>
+            </ul>
+        </div>
+        <div id="robActions_play_tone" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»SpieleFrequenz...Dauer...«"><br>»Spiele Frequenz ... Dauer ... «</h3>
+            <p>Dieser Block lässt deinen Roboter einen Ton mit der gewählten Frequenz für die gewählte Dauer ausgeben.
+                Beachte dabei, dass das menschliche Gehör nur Töne zwischen etwa 20 und 20000 Hertz wahrnehmen kann.</p>
+            <p>Eingabe- und Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl zwischen 20 und 20000, Frequenz des Tons, der abgespielt werden
+                    soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeit, für die der Ton abgespielt werden soll.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_play_note" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Spiele...Note....«"><br>»Spiele ... Note .... «</h3>
+            <p>Dieser Block lässt deinen Roboter eine ausgewählte Note spielen.</p>
+            <p>Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Dauer der Note, die gespielt werden soll. Von ganzer
+                    bis sechzehntel Note.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, Note, die gespielt werden soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_play_file" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»SpieleStück...«"><br>»Spiele Stück ... «</h3>
+            <p>Dieser Block lässt deinen Roboter eins der vorgefertigten Stücke abspielen.</p>
+            <p>Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Nummer des Stückes, das gespielt werden soll.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <p>Dieser Block kann nicht in Funktionen benutzt werden.</p>
+                </div>
+            </div>
+        </div>
+        <div id="robActions_led_on" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»SchalteLEDan...«"><br>»Schalte LED an ... «</h3>
+            <p>Dieser Block schaltet die ausgewählte LED deines Roboters an.</p>
+            <p>Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Auswahl der LED, die eingeschaltet werden soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_off" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»SchalteLEDaus...«"><br>»Schalte LED aus ... «</h3>
+            <p>Dieser Block schaltet die ausgewählte LED deines Roboters aus.</p>
+            <p>Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Auswahl der LED, die ausgeschaltet werden soll.</li>
+            </ul>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Taste...gedrückt?«"><br>»Taste ... gedrückt?«</h3>
+            <p>Dieser Block fragt ab, ob die ausgewählte Taste gedrückt wird. Er gibt »wahr« zurück, wenn die Taste
+                gedrückt wird, sonst »falsch«.</p>
+            <p>Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Taste, die abgefragt werden soll. Entweder
+                    »Wiedergabe«- oder »Aufnahme«-Taste</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« wenn die ausgewählte Taste gedrückt ist,
+                    sonst »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»GibHindernis...Infrarotsensor«"><br>»Gib Hindernis ... Infrarotsensor «
+            </h3>
+            <p>Dieser Block fragt die Infrarotsensoren an der Front des Roboters ab, ob sie ein Hindernis erkennen, also
+                ob sich ein Hindernis (z.B. eine Wand) in sehr geringem Abstand vor dem Roboter befindet.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Auswahl des Abschnittes an der Front, der kontrolliert
+                    werden soll. Die Abschnitte sind durch Linien an der Front gekennzeichnet.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, »wahr« wenn ein Hindernis erkannt worden ist,
+                    sonst »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_irseeker_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»GibR/CCodeInfrarotempfänger«"><br>»Gib R/C Code Infrarotempfänger «
+            </h3>
+            <p>Dieser Block steuert den Infrarotsensor des Roboters. Dieser kann Infrarotsignale von anderen Geräten
+                empfangen, also z.B. von Fernbedienungen und mit diesen ferngesteuert werden.</p>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der Wert des Infrarot-Signals, der empfangen wurde.</li>
+            </ul>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»GibLichtLichtsensor...«"><br>»Gib Licht Lichtsensor ... «</h3>
+            <p>Dieser Block steuert den Lichtsensor deines Roboters. Dieser misst, wie viel Licht auf deinen Roboter
+                fällt und gibt diesen Wert zurück.</p>
+            <p>Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Position des Lichtsensors</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gemessene Lichteinstrahlung</li>
+            </ul>
+        </div>
+        <div id="robSensors_sound_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»GibGeräuschGeräuschsensor«"><br>»Gib Geräusch Geräuschsensor «</h3>
+            <p>Dieser Block steuert den Geräuschsensor, also eine Art Mikrofon, deines Roboters. Wenn du z.B. in die
+                Hände klatscht, erzeugt das ein lautes Geräusch, dass dein Roboter »wahrnehmen«, also messen, kann.</p>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr«, wenn ein lautes Geräusch, z.B. Klatschen
+                    registriert worden ist, sonst »falsch«.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <p>Diesen Block nicht direkt nach einem »Fahre«-Block verwenden, zuerst einen »Warte«-Befehl
+                        dazwischen schalten.</p>
+                </div>
+            </div>
+        </div>
+        <div id="edisonSensors_sensor_reset" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Setze...zurück«"><br>»Setze ... zurück «</h3>
+            <p>Dieser Block setzt den ausgewählten Sensor zurück, er löscht also alle vorangegangenen Kallibrationen,
+                die vorgenommen worden sind.</p>
+            <p>Auswahlmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Sensor, der zurückgesetzt werden soll.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wennmachesonst«">»Wenn mache sonst«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wiederholeunendlichoft«">»Wiederhole
+                unendlich oft«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wiederholenmal«">»Wiederhole n mal«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wiederholesolange/bis«[Experten-Block]">
+                »Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»FürWertausderListe«[Experten-Block]">»Für
+                Wert aus der Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Zählevonbis«[Experten-Block]">»Zähle von bis«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="ProgrammierBlöckeEdisonV2.0-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeEdisonV2.0-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wartems...«">»Warte ms ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wartebis...«.1">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»MathematischeFunktionen«[Experten-Block]">
+                »Mathematische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»TrigonometrischeFunktionen«[Experten-Block]">
+                »Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Konstanten«[Experten-Block]">»Konstanten«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Zahleneigenschaft«[Experten-Block]">
+                »Zahleneigenschaft« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Erhöheumx«[Experten-Block]">»Erhöhe um x«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»runden«[Experten-Block]">»runden« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Listeauswerten«[Experten-Block]">»Liste
+                auswerten« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Restvon«[Experten-Block]">»Rest von« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Begrenze«[Experten-Block]">»Begrenze« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»GanzzahligeZufallswerte«[Experten-Block]">
+                »Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Zufallszahl«">»Zufallszahl« </h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in
+                Zeichenkette« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»ErstelleText«[Experten-Block]">»Erstelle
+                Text« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEdisonV2.0-»Textanhängen«[Experten-Block]">»Text
+                anhängen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen
+                ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in
+                Liste« <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»istleer?«[Experten-Block]">»ist leer?« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeEdisonV2.0-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot
+                ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeEdisonV2.0-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün
+                ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeEdisonV2.0-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ...
+                Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage
+                innerhalb einer Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="ProgrammierBlöckeEdisonV2.0-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage
+                innerhalb einer Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="ProgrammierBlöckeEdisonV2.0-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage
+                innerhalb einer Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne
+                Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeEdisonV2.0-»FunktionsaufrufmitRückgabewert«">
+                »Funktionsaufruf mit Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="edisonCommunication_ir_sendBlock" class="help expert">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»SendeNachricht...«"><br>»Sende Nachricht ... «</h3>
+            <p>Mit diesem Block kann dein Edison V2.0 eine Nachricht an alle anderen Edison V2.0 in seiner Umgebung
+                schicken. Er tut dies über Infrarot-Signale.</p>
+            <p>Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Nachricht, die geschickt werden soll.</li>
+            </ul>
+        </div>
+        <div id="edisonCommunication_ir_receiveBlock" class="help expert">
+            <h3 id="ProgrammierBlöckeEdisonV2.0-»EmpfangeNachricht«"><br>»Empfange Nachricht«</h3>
+            <p>Dieser Block lässt deinen Edison V2.0 Nachrichten von anderen Edison V2.0 in seiner Umgebung empfangen.
+            </p>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Nachricht, die empfangen worden ist.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_edison_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_edison_en.html
@@ -1,367 +1,1347 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»Start«">»Start«</h3><p>Each program starts with the »Program start block«, which cannot be deleted. The first block to be used is connected directly to the »Sequence connection« on the program start block.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Create a new global variable.</li><li class="typcn typcn-minus">Remove the global variable.</li>
-</ul><p class="auto-cursor-target">If global variables were created:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable.</li><li class="typcn typcn-arrow-sorted-down">Type of the variable.</li><li class="typcn typcn-arrow-left">Value, initial value of the variable.</li>
-</ul></div><div id="robActions_motor_on" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»Motor...onspeed...«[Expertblock]">»Motor ... on speed ... « <span class="typcn typcn-star"></span></h3><p>This block controls a motor of the robot by changing the speed to the specified value.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, left or right, controls which motor is to be addressed.</li><li class="typcn typcn-arrow-left">Number, speed of the motor between -100 and 100.</li>
-</ul></div><div id="robActions_motor_stop" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingBlocksEdisonV2.0-»StopMotor...«">»Stop Motor ... «</h3><p>This block stops the chosen motor immediately.
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, motor you want to stop.</li>
-</ul></div><div id="robActions_motorDiff_on_for" class="help beginner"><br><h3 id="ProgrammingBlocksEdisonV2.0-»Drive...Speed...Distance...«">»Drive ... Speed ... Distance ... «</h3><p>This block allows the robot to move forwards or backwards the selected distance at the selected speed.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, forwards or backwards, the direction in which the robot is to move.</li><li class="typcn typcn-arrow-left">Number, speed at which the distance is to be covered, between 1 and 100.</li><li class="typcn typcn-arrow-left">Number, distance to be covered, in centimeters.</li>
-</ul></div><div id="robActions_motorDiff_on" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»Drive...Speed...«">»Drive ... Speed ... «</h3><p>With this block you make your robot drive infinitely far with the set speed. Note that your program should prevent your robot from moving in one direction, otherwise the robot could drive against a wall or an another obstacle.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, forwards or backwards, the direction in which your robot should move.</li><li class="typcn typcn-arrow-left">Number, speed at which the robot should move, between 1 and 100.</li>
-</ul></div><div id="robActions_motorDiff_stop" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»Stop«">»Stop«</h3><p>This block stops your robot immediately.</p></div><div id="robActions_motorDiff_turn_for" class="help beginner"><br><h3 id="ProgrammingBlocksEdisonV2.0-»Turn...Speed...degrees...«">»Turn ... Speed ... degrees ... «</h3><p>This block rotates your robot by a selected value at a selected speed.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, left or right, the direction in which you want your robot to turn.</li><li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and 100.</li><li class="typcn typcn-arrow-left">Number, degrees you want your robot to rotate. 360 degrees is a whole turn.</li>
-</ul></div><div id="robActions_motorDiff_turn" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»Turn...Speed...«">»Turn ... Speed ... «</h3><p>This block rotates your robot in the selected direction at the set speed, but the robot continues to rotate in that direction without control.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, left or right, the direction in which you want your robot to turn.</li><li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and 100.</li>
-</ul></div><div id="robActions_motorDiff_curve_for" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»Steer...Tempoleft...Temporight...Distance...«">»Steer... Tempo left ... Tempo right ... Distance ... «</h3><p>With this block you can let your robot drive forwards or backwards and control the speed of the motors individually, so that you can drive e.g. curves. You can also specify the length of the track your robot should drive.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, forward or backward, the direction your robot should drive.</li><li class="typcn typcn-arrow-left">Number, the speed for the left motor, between 1 and 100.</li><li class="typcn typcn-arrow-left">Number, the speed for the richt motor, between 1 and 100.</li><li class="typcn typcn-arrow-left">Number, distance in centimetres which is to be covered.</li>
-</ul></div><div id="robActions_motorDiff_curve" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»Steer...speedleft...speedright...«">»Steer... speed left ... speed right ... «</h3><p>With this block you can let your robot drive forwards or backwards and control the speed of the motors individually. The robot does not drive a fixed distance, but always continues until you stop it with your program.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, forward or backward, the direction your robot should go.</li><li class="typcn typcn-arrow-left">Number, the speed for the left motor, between 1 and 100.</li><li class="typcn typcn-arrow-left">Number, the speed for the right motor, between 1 and 100.</li>
-</ul></div><div id="robActions_play_tone" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»Playfrequency...Duration...«">»Play frequency ... Duration ... «</h3><p>This block lets your robot output a tone with the selected frequency for the selected duration. Note that the human ear can only hear sounds between 20 and 20000 Hertz.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, frequency of the sound to be played, between 20 and 20000.</li><li class="typcn typcn-arrow-left">Number, time for which the sound is to be played.</li>
-</ul></div><div id="mbedActions_play_note" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»Play...Note....«">»Play ... Note .... «</h3><p>This block lets your robot play a selected note.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, duration of the note to be played, from whole to sixteenth note.</li><li class="typcn typcn-arrow-sorted-down">Note that is to be played.</li>
-</ul></div><div id="robActions_play_file" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»Playfile...«">»Play file ... «</h3><p>This block lets your robot play one of the prefabricated file.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, number of the file to be played.</li>
-</ul><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><p>This Block can't be used within a function.</p></div></div></div><div id="robActions_led_on" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»TurnonLED...«">»Turn on LED... «</h3><p>This block turns on the selected LED of your robot.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select the LED to turn on.</li>
-</ul></div><div id="robActions_led_off" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»TurnofftheLED...«">»Turn off the LED... «</h3><p>This block turns off the selected LED of your robot.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select the LED to turn off.</li>
-</ul></div><div id="robSensors_key_getSample" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»Button...pressed?«">»Button ... pressed?«</h3><p>This block asks if the selected key is pressed. It returns »true« when the key is pressed, otherwise »false«.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select the key to be polled. Either »Play« or »Record« button.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, »true« if the selected key is pressed, otherwise »false«.</li>
-</ul></div><div id="robSensors_infrared_getSample" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»Giveobstacle...Infraredsensor«">»Give obstacle ... Infrared sensor «</h3><p>This block checks the infrared sensors at the front of the robot to see if there is an obstacle, i.e. if there is an obstacle like a wall at a very small distance in front of the robot.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, selection of the section on the front that is to be checked. The sections are marked by lines at the front.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, »true« if an obstacle has been detected, otherwise »false«.</li>
-</ul></div><div id="robSensors_irseeker_getSample" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»GiveR/CCodeIRSeeker«">»Give R/C Code IR Seeker «</h3><p>This block controls the infrared sensor of the robot. It can receive infrared signals from other devices, e.g. from remote controls and be remote controlled with these.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the RC-Code of the scanned barcode.</li>
-</ul></div><div id="robSensors_light_getSample" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»GetLightLightsensor...«">»Get Light Lightsensor ... «</h3><p>This block controls the light sensor of your robot and returns the measured value of surrounding light.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose if you want</li><li class="typcn typcn-arrow-sorted-down">Option, position of the Sensor</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, measured light in percent, between 0 and 100.</li>
-</ul></div><div id="robSensors_sound_getSample" class="help beginner"><br><h3 id="ProgrammingBlocksEdisonV2.0-»getsoundsoundsensor«">»get sound sound sensor «</h3><p>This block controls the sound sensor, a kind of microphone, of your robot. For example, if you clap your hands, it makes a loud noise that your robot can »perceive«, i.e. measure.</p><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, »true«, if a loud noise, e.g. clapping, has been registered, otherwise »false«.</li>
-</ul><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><p>Do not use this block right after a »move«-command, place a »wait«-command between them.</p></div></div></div><div id="edisonSensors_sensor_reset" class="help beginner"><br><h3 id="ProgrammingBlocksEdisonV2.0-»Reset...«">»Reset ...«</h3><p>This block resets the selected sensor, i.e. it deletes all previous calibrations that have been performed.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, sensor that is to be reset.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="ProgrammingBlocksEdisonV2.0-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="ProgrammingBlocksEdisonV2.0-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="ProgrammingBlocksEdisonV2.0-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEdisonV2.0-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksEdisonV2.0-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksEdisonV2.0-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="ProgrammingBlocksEdisonV2.0-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammingBlocksEdisonV2.0-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="ProgrammingBlocksEdisonV2.0-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEdisonV2.0-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksEdisonV2.0-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksEdisonV2.0-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEdisonV2.0-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEdisonV2.0-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEdisonV2.0-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEdisonV2.0-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEdisonV2.0-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEdisonV2.0-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEdisonV2.0-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEdisonV2.0-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingBlocksEdisonV2.0-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammingBlocksEdisonV2.0-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammingBlocksEdisonV2.0-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingBlocksEdisonV2.0-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="ProgrammingBlocksEdisonV2.0-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="ProgrammingBlocksEdisonV2.0-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="ProgrammingBlocksEdisonV2.0-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="ProgrammingBlocksEdisonV2.0-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="ProgrammingBlocksEdisonV2.0-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingBlocksEdisonV2.0-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div><div id="edisonCommunication_ir_sendBlock" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»Sendmessage...«">»Send message ... «</h3><p>With this block your Edison V2.0 can send a message to all other Edison V2.0 in its environment. It does this via infrared signals.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, message to be sent.</li>
-</ul></div><div id="edisonCommunication_ir_receiveBlock" class="help expert"><h3 id="ProgrammingBlocksEdisonV2.0-»Receivemessage«">»Receive message«</h3><p>This block lets your Edison V2.0 receive messages from other Edison V2.0 in its environment.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, message received.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Start«">»Start«</h3>
+            <p>Each program starts with the »Program start block«, which cannot be deleted. The first block to be used
+                is connected directly to the »Sequence connection« on the program start block.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Create a new global variable.</li>
+                <li class="typcn typcn-minus">Remove the global variable.</li>
+            </ul>
+            <p class="auto-cursor-target">If global variables were created:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable.</li>
+                <li class="typcn typcn-arrow-left">Value, initial value of the variable.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Motor...onspeed...«[Expertblock]">»Motor ... on speed ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block controls a motor of the robot by changing the speed to the specified value.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, left or right, controls which motor is to be
+                    addressed.</li>
+                <li class="typcn typcn-arrow-left">Number, speed of the motor between -100 and 100.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_stop" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEdisonV2.0-»StopMotor...«">»Stop Motor ... «</h3>
+            <p>This block stops the chosen motor immediately.
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, motor you want to stop.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_on_for" class="help beginner"><br>
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Drive...Speed...Distance...«">»Drive ... Speed ... Distance ... «</h3>
+            <p>This block allows the robot to move forwards or backwards the selected distance at the selected speed.
+            </p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, forwards or backwards, the direction in which the
+                    robot is to move.</li>
+                <li class="typcn typcn-arrow-left">Number, speed at which the distance is to be covered, between 1 and
+                    100.</li>
+                <li class="typcn typcn-arrow-left">Number, distance to be covered, in centimeters.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_on" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Drive...Speed...«">»Drive ... Speed ... «</h3>
+            <p>With this block you make your robot drive infinitely far with the set speed. Note that your program
+                should prevent your robot from moving in one direction, otherwise the robot could drive against a wall
+                or an another obstacle.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, forwards or backwards, the direction in which your
+                    robot should move.</li>
+                <li class="typcn typcn-arrow-left">Number, speed at which the robot should move, between 1 and 100.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_stop" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Stop«">»Stop«</h3>
+            <p>This block stops your robot immediately.</p>
+        </div>
+        <div id="robActions_motorDiff_turn_for" class="help beginner"><br>
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Turn...Speed...degrees...«">»Turn ... Speed ... degrees ... «</h3>
+            <p>This block rotates your robot by a selected value at a selected speed.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, left or right, the direction in which you want your
+                    robot to turn.</li>
+                <li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and 100.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, degrees you want your robot to rotate. 360 degrees is a whole
+                    turn.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_turn" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Turn...Speed...«">»Turn ... Speed ... «</h3>
+            <p>This block rotates your robot in the selected direction at the set speed, but the robot continues to
+                rotate in that direction without control.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, left or right, the direction in which you want your
+                    robot to turn.</li>
+                <li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and 100.
+                </li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_curve_for" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Steer...Tempoleft...Temporight...Distance...«">»Steer... Tempo left ...
+                Tempo right ... Distance ... «</h3>
+            <p>With this block you can let your robot drive forwards or backwards and control the speed of the motors
+                individually, so that you can drive e.g. curves. You can also specify the length of the track your robot
+                should drive.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, forward or backward, the direction your robot should
+                    drive.</li>
+                <li class="typcn typcn-arrow-left">Number, the speed for the left motor, between 1 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, the speed for the richt motor, between 1 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, distance in centimetres which is to be covered.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_curve" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Steer...speedleft...speedright...«">»Steer... speed left ... speed
+                right ... «</h3>
+            <p>With this block you can let your robot drive forwards or backwards and control the speed of the motors
+                individually. The robot does not drive a fixed distance, but always continues until you stop it with
+                your program.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, forward or backward, the direction your robot should
+                    go.</li>
+                <li class="typcn typcn-arrow-left">Number, the speed for the left motor, between 1 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, the speed for the right motor, between 1 and 100.</li>
+            </ul>
+        </div>
+        <div id="robActions_play_tone" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Playfrequency...Duration...«">»Play frequency ... Duration ... «</h3>
+            <p>This block lets your robot output a tone with the selected frequency for the selected duration. Note that
+                the human ear can only hear sounds between 20 and 20000 Hertz.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, frequency of the sound to be played, between 20 and 20000.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, time for which the sound is to be played.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_play_note" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Play...Note....«">»Play ... Note .... «</h3>
+            <p>This block lets your robot play a selected note.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, duration of the note to be played, from whole to
+                    sixteenth note.</li>
+                <li class="typcn typcn-arrow-sorted-down">Note that is to be played.</li>
+            </ul>
+        </div>
+        <div id="robActions_play_file" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Playfile...«">»Play file ... «</h3>
+            <p>This block lets your robot play one of the prefabricated file.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, number of the file to be played.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <p>This Block can't be used within a function.</p>
+                </div>
+            </div>
+        </div>
+        <div id="robActions_led_on" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»TurnonLED...«">»Turn on LED... «</h3>
+            <p>This block turns on the selected LED of your robot.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select the LED to turn on.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_off" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»TurnofftheLED...«">»Turn off the LED... «</h3>
+            <p>This block turns off the selected LED of your robot.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select the LED to turn off.</li>
+            </ul>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Button...pressed?«">»Button ... pressed?«</h3>
+            <p>This block asks if the selected key is pressed. It returns »true« when the key is pressed, otherwise
+                »false«.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select the key to be polled. Either »Play« or »Record«
+                    button.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, »true« if the selected key is pressed, otherwise »false«.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Giveobstacle...Infraredsensor«">»Give obstacle ... Infrared sensor «
+            </h3>
+            <p>This block checks the infrared sensors at the front of the robot to see if there is an obstacle, i.e. if
+                there is an obstacle like a wall at a very small distance in front of the robot.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, selection of the section on the front that is to be
+                    checked. The sections are marked by lines at the front.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, »true« if an obstacle has been detected, otherwise »false«.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_irseeker_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»GiveR/CCodeIRSeeker«">»Give R/C Code IR Seeker «</h3>
+            <p>This block controls the infrared sensor of the robot. It can receive infrared signals from other devices,
+                e.g. from remote controls and be remote controlled with these.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the RC-Code of the scanned barcode.</li>
+            </ul>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»GetLightLightsensor...«">»Get Light Lightsensor ... «</h3>
+            <p>This block controls the light sensor of your robot and returns the measured value of surrounding light.
+            </p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose if you want</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the Sensor</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, measured light in percent, between 0 and 100.</li>
+            </ul>
+        </div>
+        <div id="robSensors_sound_getSample" class="help beginner"><br>
+            <h3 id="ProgrammingBlocksEdisonV2.0-»getsoundsoundsensor«">»get sound sound sensor «</h3>
+            <p>This block controls the sound sensor, a kind of microphone, of your robot. For example, if you clap your
+                hands, it makes a loud noise that your robot can »perceive«, i.e. measure.</p>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, »true«, if a loud noise, e.g. clapping, has been
+                    registered, otherwise »false«.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <p>Do not use this block right after a »move«-command, place a »wait«-command between them.</p>
+                </div>
+            </div>
+        </div>
+        <div id="edisonSensors_sensor_reset" class="help beginner"><br>
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Reset...«">»Reset ...«</h3>
+            <p>This block resets the selected sensor, i.e. it deletes all previous calibrations that have been
+                performed.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, sensor that is to be reset.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»breakout/continuewithnextiterationofloop«[Expert-block]">»break
+                out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»mathematicalfunction«[Expert-block]">»mathematical function« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»constant«[Expert-block]">»constant« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»constrain«[Expert-block]">»constrain« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEdisonV2.0-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to
+                Number« <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red
+                ... green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ...
+                green ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ...
+                green ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Functionblockswith/withoutinputparametersandnoreturnstatement«">
+                »Function blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Functionblockswith/withoutinputparameterswithreturnstatements«">
+                »Function blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»ifblocktobeusedwithinafunction«">»if block to be used within a
+                function«</h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="ProgrammingBlocksEdisonV2.0-Ifstatementwithinafunctionwithreturnvalue:">If statement within a
+                function with return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="ProgrammingBlocksEdisonV2.0-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a
+                function with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»functioncallwithoutreturnvalue«">»function call without return value «
+            </h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEdisonV2.0-»functioncallwithreturnvalue«">»function call
+                with return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul>
+        </div>
+        <div id="edisonCommunication_ir_sendBlock" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Sendmessage...«">»Send message ... «</h3>
+            <p>With this block your Edison V2.0 can send a message to all other Edison V2.0 in its environment. It does
+                this via infrared signals.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, message to be sent.</li>
+            </ul>
+        </div>
+        <div id="edisonCommunication_ir_receiveBlock" class="help expert">
+            <h3 id="ProgrammingBlocksEdisonV2.0-»Receivemessage«">»Receive message«</h3>
+            <p>This block lets your Edison V2.0 receive messages from other Edison V2.0 in its environment.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, message received.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_ev3_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_ev3_de.html
@@ -1,472 +1,1939 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am »Start«-Block.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li><li class="typcn typcn-input-checked">Zeige Sensordaten - während des Programmablaufs werden im Display die Werte der angeschlossenen Sensoren gezeigt.</li>
-</ul><br><p>Wenn globale Variablen erzeugt wurden:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variablen.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
-</ul><br></div><div id="robActions_motor_on" class="help expert"><h3 id="ProgrammierBlöckeEV3-»MotorPort...anTempo«[Experten-Block]"><span style="color: rgb(0,0,0);">»Motor Port ... an Tempo« </span><span class="typcn typcn-star"></span></h3><p>Mit dem Block »Motor Port ... an Tempo« programmierst du das Tempo (Geschwindigkeit) eines Motors. Dein Roboter startet den gewählten Motor, bis er gestoppt wird oder ein anderer Block zum Fahren verwendet wird.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor Port, wähle den Motor Port aus, an dem der Motor angeschlossen ist.</li><li class="typcn typcn-arrow-left">Tempo, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li>
-</ul><br></div><div id="robActions_motor_on_for" class="help expert"><h3 id="ProgrammierBlöckeEV3-»MotorPort...anTempo...Umdrehungen/Grad«[Experten-Block]"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Motor Port ... an  Tempo ... Umdrehungen/Grad« <span class="typcn typcn-star"></span></span><br></span></h3><p>Mit dem Block »Motor Port ... an Tempo ... Umdrehungen/Grad« stellst du das Tempo (Geschwindigkeit) eines Motors ein. Dein Roboter startet den gewählten Motor, bis er die eingestellte Anzahl Umdrehungen bzw. Winkelgrade gemacht hat.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor Port, wähle den Motorport aus, an dem der Motor angeschlossen ist.</li><li class="typcn typcn-arrow-left">Tempo,  Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li><li class="typcn typcn-arrow-sorted-down">Umdrehungen oder Grad. 1 Umdrehung entspricht 360 Grad.</li><li class="typcn typcn-arrow-left">Zahl, Anzahl der Umdrehungen bzw. Winkelgrade. Es sind nur positive Zahlen zugelassen.</li>
-</ul><br></div><div id="robActions_motor_getPower" class="help expert"><h3 id="ProgrammierBlöckeEV3-»GibTempoMotorPort«[Experten-Block]"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Gib Tempo Motor Port« <span class="typcn typcn-star"></span></span><br></span></h3><p>Der Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Gib Tempo Motor Port</span></span>« liest das Tempo (Geschwindigkeit) eines Motors aus.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, dessen Tempo gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl; Geschwindigkeit , die am ausgewählten Motor Port eingestellt ist.</li>
-</ul><br></div><div id="robActions_motor_setPower" class="help expert"><h3 id="ProgrammierBlöckeEV3-»SetzeMotorPort...Tempo«[Experten-Block]"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Setze Motor Port ... <span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Tempo</span></span>« <span class="typcn typcn-star"></span></span><br></span></h3><p>Der Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Setze Motor Port <span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">... Tempo</span></span></span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);"><span> </span><span> </span>« setzt </span></span>das Tempo (Geschwindigkeit) eines Motors auf einen neuen Wert.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, für den dasTempo eingestellt werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li>
-</ul><br></div><div id="robActions_motor_stop" class="help expert"><h3 id="ProgrammierBlöckeEV3-»StoppeMotorPort«[Experten-Block]"><span style="color: rgb(0,0,255);"> <span style="color: rgb(0,0,0);">»Stoppe Motor Port« <span class="typcn typcn-star"></span></span><br></span></h3><p>Der Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Stoppe Motor Port</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);"><span> </span>« schaltet den </span></span>Motor an einem ausgewählten Motor-Port aus. Du kannst einstellen, ob der Motor langsam ausläuft oder gebremst wird.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motorport aus, der ausgeschaltet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Stoppmöglichkeiten; »auslaufen<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">«</span></span> sorgt dafür, dass der Motor langsam ausläuft; »bremsen<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">«</span></span> sorgt dafür, dass der Motor abrupt abgebremst wird.</li>
-</ul><br></div><div id="robActions_motorDiff_on" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»Fahre...Tempo«">»Fahre ... Tempo«</h3><p>Mit dem Block »Fahre ... Tempo« kannst du die Richtung und das Tempo (Geschwindigkeit) deines Roboters programmieren. Dein Roboter fährt so lange vorwärts oder rückwärts, bis er gestoppt wird oder ein anderer Block zum Fahren verwendet wird.</p><p>»Fahre« steuert beide Motoren des Roboters gleichzeitig.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Richtung, wähle die gewünschte Fahrrichtung aus.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen sich die Motoren rückwärts.</li>
-</ul><br></div><div id="robActions_motorDiff_on_for" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»Fahre...Tempo...Strecke«">»Fahre ... Tempo ... Strecke«</h3><p>Mit dem Block »Fahre ... Tempo ... Strecke« kannst du zusätzlich zu Richtung und Tempo auch die Fahrstrecke des Roboters programmieren. Dein Roboter fährt so lange, bis die eingestellte Strecke gefahren ist. Die Geschwindigkeit kannst du im Feld Tempo einstellen. Wenn dieser Block »zu Ende« ist, stoppen die Motoren automatisch.</p><p>»Fahre« steuert beide Motoren des Roboters gleichzeitig.</p><p>Wenn die eingestellten Werte der Aktionen mit der Programmausführung nicht übereinstimmen, prüfe die Roboter-Konfiguration, insbesondere den Raddurchmesser.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Fahrtrichtung, wähle die gewünschte Richtung.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen sich die Motoren rückwärts.</li><li class="typcn typcn-arrow-left">Zahl, Länge für die Strecke in cm.</li>
-</ul><br></div><div id="robActions_motorDiff_stop" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»Stoppe«">»Stoppe«</h3><p>Mit dem Block »Stoppe« werden die Motoren deines Roboters gestoppt. Das bedeutet, dein Roboter hält an.</p></div><div id="robActions_motorDiff_turn" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»Drehe...Tempo«">»Drehe ... Tempo«</h3><p>Mit dem Block »Drehe ...  Tempo« kannst du die Richtung (rechts/links), in der sich der Roboter drehen soll, programmieren. Dein Roboter dreht sich so lange auf der Stelle, bis er gestoppt wird oder ein anderer Block zum Fahren verwendet wird. Die Geschwindigkeit kannst Du im Feld »Tempo« einstellen. »Drehe« steuert beide Motoren des Roboters gleichzeitig in entgegengesetzten Richtungen, dadurch dreht sich der Roboter auf der Stelle.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Drehrichtung, wähle die gewünschte Drehrichtung aus.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen sich die Motoren rückwärts.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><p>Falls sich dein Roboter in die falsche Richtung dreht, sind die Motoren an die falschen Ports angeschlossen. Es genügt dann, die Ports zu tauschen, damit der Roboter in die richtige Richtung dreht.</p></div></div></div><div id="robActions_motorDiff_turn_for" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»Drehe...Tempo...Grad«">»Drehe ... Tempo ... Grad«</h3><p>Mit dem Block »Drehe ... Tempo ... Grad« kannst du die Richtung (rechts/links), in der sich der Roboter um die eigene Achse drehen soll, programmieren. Zusätzlich zur Richtung kann noch im Feld »Grad« angegeben werden, um wie viel Grad sich dein Roboter (um die eigene Achse) drehen soll. Dies bedeutet, dass du beispielsweise mit der Einstellung 360 Grad deinen Roboter einmal um die eigene Achse drehen lassen kannst. Der Block »Drehe ... Tempo ... Grad« steuert beide Motoren des Roboters, damit sich der Roboter um die eigene Achse dreht.</p><p>Wenn die eingestellten Werte der Aktionen mit der Programmausführung nicht übereinstimmen, prüfe die Roboter-Konfiguration, insbesondere den Raddurchmesser und die Spurbreite.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Drehrichtung, wähle die gewünschte Drehrichtung aus.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen sich die Motoren rückwärts.</li><li class="typcn typcn-arrow-left">Gradzahl, um die der Roboter sich drehen soll. Negative Zahlen sind nicht zugelassen.</li>
-</ul><br></div><div id="robActions_motorDiff_curve" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»Steure...Tempolinks...Temporechts...«">»Steure ... Tempo links ... Tempo rechts ...«</h3><p>Mit dem Block »Steure ... Tempo links ... Tempo rechts ...« kannst du den Roboter so programmieren, dass er eine Kurve fährt, indem du das Tempo für den linken und den rechten Motor auf unterschiedliche Werte setzt. Die Roboterkonfiguration beeinflusst den Radius der Kurve in Abhängigkeit von Radabstand und Raddurchmesser. Mit der Drehrichtung legst du die Fahrtrichtung fest.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Drehrichtung, wähle die gewünschte Drehrichtung aus.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den linken Motor. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den rechten Motor. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li>
-</ul><br></div><div id="robActions_motorDiff_curve_for" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»Steure...Tempolinks...Temporechts...Strecke...«">»Steure ... Tempo links ... Tempo rechts ... Strecke ...«</h3><p>Mit dem Block »Steure ... Tempo links ... Tempo rechts ... Strecke ...« kannst du den Roboter so programmieren, dass er eine vorgegebene Strecke als Kurve fährt, indem du das Tempo für den linken und den rechten Motor auf unterschiedliche Werte setzt. Die Strecke bezieht sich auf die Mitte zwischen beiden Rädern. Die Roboterkonfiguration beeinflusst den Radius der Kurve in Abhängigkeit von Radabstand und Raddurchmesser. Mit der Richtung legst du die Fahrtrichtung fest.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Richtung, wähle die gewünschte Fahrtrichtung aus.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den linken Motor. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den rechten Motor. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li><li class="typcn typcn-arrow-left">Zahl, Strecke in Zentimetern, die zurückgelegt werden soll.</li>
-</ul><br></div><div id="robActions_display_text" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»ZeigeText«">»Zeige Text«</h3><p>Mit dem Block »Zeige Text« kannst du Text und Zahlen auf dem Display deines Roboters anzeigen lassen. Dabei kannst du zusätzlich noch bestimmen, in welcher Spalte und in welcher Zeile der Text auf dem EV3-Bildschirm erscheinen soll.</p><p>Das Display eines EV3 ist für Texte in mehreren Zeilen (von links nach rechts) und Spalten (von oben nach unten) eingeteilt. Je nach System (lejos oder EV3dev) stehen unterschiedlich viele Zeilen und Spalten zur Verfügung. Die Zählung beginnt jeweils bei 0.</p><p>Wenn zuvor schon etwas auf dem Display angezeigt war, werden nur die Stellen überschrieben, in die der Text geschrieben wird.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li><li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li><li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
-</ul><br></div><div id="robActions_display_picture_new" class="help expert"><h3 id="ProgrammierBlöckeEV3-»ZeigeBild«[Experten-Block]">»Zeige Bild« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »Zeige Bild« kannst du eines von mehreren Bildern auf dem EV3-Display deines Roboters anzeigen lassen. Verfügbare Bilder sind »Brille«, »Augen auf«, »Augen zu«, »Blumen«, »Tacho«.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Bild, wähle ein Bild aus, das auf dem Display erscheinen soll.</li><li class="typcn typcn-arrow-left">Zahl für x, die Spaltennummer, in der das Bild beginnen soll.</li><li class="typcn typcn-arrow-left">Zahl für y, die Zeilennummer, in der das Bild beginnen soll.</li>
-</ul><br></div><div id="robActions_display_clear" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»LöscheBildschirm«">»Lösche Bildschirm«</h3><p>Mit dem Block »Lösche Bildschirm« kannst du Text und Zahlen auf dem Display deines Roboters löschen. Das Display ist anschließend leer.</p></div><div id="robActions_play_tone" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»SpieleFrequenz...Dauer«">»Spiele Frequenz ... Dauer«</h3><p>Mit dem Block »Spiele Frequenz ... Dauer« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie lange der Ton gespielt wird) programmieren. Der Ton wird über den eingebauten Lautsprecher deines LEGO MINDSTORMS EV3 Steins abgespielt, bis die eingestellte Dauer erreicht ist.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Bitte beachte, dass das menschliche Gehör Frequenzen zwischen ca. 30 Hz bis ca. 15.000 Hz (15 kHz) wahrnehmen kann - je nach Mensch und Alter kann dies unterschiedlich sein.</p></div></div><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, gewünschte Frequenz in Hz (Hertz) eingeben.</li><li class="typcn typcn-arrow-left"> Zahl, gewünschte Dauer des Tons in Millisekunden (ms) eingeben.</li>
-</ul><br></div><div id="mbedActions_play_note" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»SpieleNote...«">»Spiele Note ... «</h3><p>Mit diesem Block kann dein  Roboter eine Note abspielen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die  Länge der Note aus.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle die Note aus, die dein Roboter spielen soll.</li>
-</ul></div><div id="robActions_play_file" class="help expert"><h3 id="ProgrammierBlöckeEV3-»SpieleStück«[Experten-Block]">»Spiele Stück« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »Spiele Stück« bringst du deinen Roboter dazu, einen von fünf hinterlegten Klängen zu spielen.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zahl, Nummer für ein Stück zwischen 1 und 5 mit folgenden Zuordnungen:<br>1 - einfacher Piepton<br>2 - doppelter Piepton<br>3 - aufsteigender Klang aus 4 Tönen<br>4 - absteigender Klang aus 4 Tönen<br>5 - einfacher tiefer Ton</li>
-</ul><br></div><div id="robActions_play_setVolume" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»SetzeLautstärke«">»Setze Lautstärke«</h3><p>Mit dem Block »Setze Lautstärke« kannst du die Lautstärke eines Tons programmieren. Die Lautstärke kann von 0 (kein Ton) bis 100 (volle Lautstärke) eingestellt werden. Die Lautstärke bleibt so lange eingestellt, bis du sie mit einem anderen Block »Setze Lautstärke« neu programmierst.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl für die Lautstärke.</li>
-</ul><br></div><div id="robActions_play_getVolume" class="help expert"><h3 id="ProgrammierBlöckeEV3-»GibLautstärke«[Experten-Block]">»Gib Lautstärke« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »Gib Lautstärke« kannst du die aktuell eingestellte Lautstärke auslesen. 0 = kein Ton, 100 = maximale Lautstärke.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, aktuell eingestellter Lautstärkewert.</li>
-</ul><br></div><div id="robActions_setLanguage" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»SetzeSprache...«[Experten-Block]">»Setze Sprache  ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du die Sprache deines Roboters steuern. Wenn  du C4EV3 als dein Robotersystem verwendest, musst du zusätzliche Dateien für die Sprachausgabe herunterladen. Eine Anleitung dazu findest du <a href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo/Vorbereitung+EV3+-+System+C4EV3">hier</a>.</span></p><p><span style="letter-spacing: -0.006em;">Optionen:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Sprache der Sprachauswahl.</li>
-</ul><br></div><div id="robActions_sayText" class="help beginner "><h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»Sage...«">»Sage ...  «</h3><p>Mit diesem Block kannst du die Sprachausgabe deines Roboters steuern. Dabei verwendet der Roboter die Sprache, die du mit dem »Setze Sprache ...« Block festgelegt hast. Die Standardsprache ist Deutsch.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zeichenkette, der Text, den dein Roboter sagen soll.</li>
-</ul><br></div><div id="robActions_sayText_parameters" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»Sage...Sprechgeschwindigkeit...Stimmlage...«[Experten-Block]">»Sage ... Sprechgeschwindigkeit ... Stimmlage ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du die Sprachausgabe deines Roboters steuern. Du kannst dabei auch die Stimmlage und die Sprechgeschwindigkeit deines Roboters steuern.</span></p><p><span style="letter-spacing: -0.006em;">Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, der Text, den dein Roboter sagen soll.</li><li class="typcn typcn-arrow-left">Zahl, Sprechgeschwindigkeit in Prozent,  also meine Zahl zwischen 1 und 100. Je höher die Zahl ist, desto schneller spricht der Roboter.</li><li class="typcn typcn-arrow-left">Zahl, Stimmlage des Roboters in Prozent. Zahl zwischen 1 und 100. Je höher die Zahl, desto höher ist auch die Stimmlage des Roboters.</li>
-</ul><br></div><div id="robActions_brickLight_on" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»Statusleuchte«">»Statusleuchte«</h3><p>Mit dem Block »Statusleuchte« kannst du die Statusleuchte, also die Hintergrundfarbe der Knöpfe an deinem EV3-Stein programmieren. Folgende Farben stehen zur Auswahl: grün, orange, rot. Zusätzlich kannst du einstellen, wie die Statusleuchte leuchten soll: »an«, »blinkend« oder »doppel blinkend«.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Farbe, wähle eine Farbe aus.</li><li class="typcn typcn-arrow-sorted-down">Anzeige Wähle aus, wie die Statusleuchte leuchten soll.</li>
-</ul><br></div><div id="robActions_brickLight_off" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»Statusleuchteaus«">»Statusleuchte aus«</h3><p>Mit dem Block »Statusleuchte aus« kannst du die Statusanzeige an deinem EV3-Stein ausschalten.</p></div><div id="robActions_brickLight_reset" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»SetzeStatusleuchtezurück«">»Setze Statusleuchte zurück«</h3><p>Mit dem Block »Setze Statusleuchte zurück« kannst du die Statusanzeige auf den Standardwert zurücksetzen.</p></div><div id="robSensors_touch_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeEV3-»Berührungssensor«">»Berührungssensor«</h3><p>Mit dem Block »Berührungssensor« kannst du einem anderen Block »mitteilen«,  ob der Berührungssensor gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>wahr = gedrückt</em> oder <em>falsch = nicht gedrückt</em> zurück.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle den Sensorport aus, an dem dein Berührungssensor angeschlossen ist.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn der Berührungssensor gedrückt ist, sonst »falsch«.</li>
-</ul><br> </div><div id="robSensors_ultrasonic_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeEV3-»GibAbstand/AnwesenheitUltraschallsensor«">»Gib Abstand/Anwesenheit Ultraschallsensor«</h3><p>Mit dem Block »Gib Abstand/Anwesenheit Ultraschallsensor« kannst du einem anderen Block »mitteilen«, welchen Abstand der Ultraschallsensor misst. Der Abstand wird als Zahl (in cm) übermittelt. Andererseits kann dieser Block im Auswahlmenü auf »Anwesenheit« gestellt werden. Mit dieser Einstellung kann geprüft werden, ob ein anderer Ultraschallsensor aktiv ist. In dieser Einstellung gibt er die logischen Werte <em>true = weiterer Ultraschallsensor anwesend</em> oder <em>false = kein weiterer Ultraschallsensor anwesend</em> zurück.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Ultraschall, der nicht vom eigenen Ultraschallsensor ausgesandt wurde, kann zu fehlerhaften Messungen führen.</p></div></div><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Messmethode, wähle Anwesenheit oder Abstand.</li><li class="typcn typcn-arrow-sorted-down">Port, wähle den Sensorport aus, an dem dein Ultraschallsensor angeschlossen ist.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Wenn »Anwesenheit« gewählt wurde, wird ein logischer Wert zurückgegeben.</p><p>Wenn »Abstand« gewählt wurde, wird der Abstand zwischen Ultraschallsensor und Hindernis angegeben.</p></li>
-</ul><br> </div><div id="robSensors_colour_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeEV3-»GibFarbe«">»Gib Farbe«</h3><p>Mit dem Block »Gib Farbe« kannst du einem anderen Block »mitteilen«, welche Farbe der Farbsensor misst. Die Farbe wird als Datentyp »Farbe« übermittelt. Zudem kann dieser Block im Auswahlmenü auf »Licht«, »RGB« und »Umgebungslicht« gestellt werden. Diese drei zusätzlichen Typen übermitteln jeweils den Datentyp »Zahl«. Die Zahlenwerte liegen je nach gewählter Messmethode zwischen 0 und 255. Mit diesen verschiedenen Einstellung kann dieser Block je nach Anforderung eingestellt werden.</p><p>Im Modus »Farbe« sendet der Farbsensor Licht aus und erkennt, welche Grundfarbe unter dem Sensor erkannt wurde. Die Grundfarbwerte sind BLACK, WHITE, GREY, RED, GREEN, BLUE, YELLOW, BROWN.</p><p>Im Modus »Licht« sendet der Farbsensor mittels seiner roten LED Licht aus und misst die reflektierte Lichtstärke auf einer Skala von 0 bis 100.</p><p>Im Modus »RGB« sendet der Farbsensor rotes, grünes und blaues Licht aus und misst das reflektierte Licht entsprechend der Anteile Rot, Grün und Blau auf einer Skala von 0 bis 255 pro Farbe. Es wird eine Liste mit drei Werten für die jeweiligen Farben ausgegeben.</p><p>Im Modus »Umgebungslicht« wird dieselbe Skala (0-100) wie im Modus Licht verwendet. Dabei wird das ins Sensorfenster einfallende Umgebungslicht gemessen.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Messmethode, wähle aus, was gemessen werden soll.</li><li class="typcn typcn-arrow-sorted-down"> Port, wähle den Sensorport aus, an dem dein Lichtsensor/Farbsensor angeschlossen ist.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Je nach gewählter Messmethode werden die zugehörigen Werte ausgegeben.</li>
-</ul><br> </div><div id="robSensors_infrared_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeEV3-»GibAbstand/AnwesenheitInfrarotsensor«">»Gib Abstand/Anwesenheit Infrarotsensor«</h3><p>Mit dem Block »Gib Abstand/Anwesenheit Infrarotsensor« kannst du einem anderen Block »mitteilen«, welchen Abstand der Infrarotsensor misst.</p><p>Im Modus »Abstand« wird der Abstand als Zahl  zwischen 0 (ganz nah) und 100 (weit entfernt) übermittelt, nicht als Entfernungsmaß in Zentimetern. Der Sensor kann Objekte bis zu einem Abstand von 70 cm erkennen.</p><p>Zudem kann dieser Block im Auswahlmenü auf »Anwesenheit« gestellt werden. Mit dieser Einstellung kann geprüft werden, ob ein Infrarotsender (Beacon) aktiv ist. Diese Einstellung gibt eine Liste (Array)  von 4 Wertepaaren, also insgesamt 8 Werte zurück. Jedes Wertepaar gibt mit dem ersten Wert die <strong>Richtung </strong>und mit dem zweiten Wert den <strong>Abstand</strong> zum Infrarotsender an. Das erste Wertepaar betrachtet dabei die Werte, die auf dem Kanal 1 des Senders übermittelt werden, das zweite Wertepaar entsprechend Kanal 2 usw.. Die Richtung kann Werte von -25 bis +25 annehmen. Dabei bedeutet 0, dass das Infrarotsignal direkt von vorne kommt. -25 bzw. +25 stehen für Winkel von 110° nach links bzw. rechts. Der Abstand zum Sender ist ein Wert zwischen 0 (ganz nah) und 100 (weit entfernt). Infrarotsignale von Sendern können aus bis zu 200 cm Entfernung empfangen werden.</p><p><strong>Beispiel</strong>: Ergebnis einer Messung mit dem Infrarotsensor ist [ 0 0 -10 40 0 0 0 0 ]. Das bedeutet, dass auf Kanal 2 die Richtung des Senders mit -10 gemessen wurde, was etwa 60 Grad links entspricht, sowie ein Abstand von 40, was ungefähr 80 cm entspricht.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Ein exakte Messung der Abstände in cm ist mit dem Infrarotsensor nicht möglich. Die gemessenen Abstände sind also ungefähre Werte.</p></div></div><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»Abstand« oder »Anwesenheit«. Stelle ein, wie der Infrarotsensor messen soll.</li><li class="typcn typcn-arrow-sorted-down">Port, wähle aus, an welchem Port der Infrarotsensor angeschlossen ist.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, bei »Abstand«, maximaler Abstand 70 cm.</p><p>Liste mit Zahlen, bei »Anwesenheit«.</p></li>
-</ul><br> </div><div id="robSensors_encoder_reset" class="help beginner"> <h3 id="ProgrammierBlöckeEV3-»SetzeDrehsensorzurück«">»Setze Drehsensor zurück«</h3><p>Mit dem Block »Setze Drehsensor zurück« kann der interne Sensor (Motor-Encoder) eines Motors auf den Wert 0 zurückgesetzt werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle aus, an welchem Port der Drehsensor/Motor angeschlossen ist.</li>
-</ul><br> </div><div id="robSensors_encoder_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeEV3-»GibUmdrehungen/Grad/AbstandDrehsensorPor«">»Gib Umdrehungen/Grad/Abstand Drehsensor Por«</h3><p>Mit dem Block »Gib Umdrehungen/Grad/Abstand Drehsensor« kannst du einem anderen Block die Motorumdrehungen »mitteilen«.</p><p>Wenn »Umdrehungen« eingestellt wurde, wird die Zahl der Umdrehungen ausgegeben.</p><p>Wenn »Grad« eingestellt wurde, wird die Gradzahl aller Umdrehungen ausgegeben, wobei eine volle Umdrehung genau 360 Grad entspricht.</p><p>Wenn »Abstand« eingestellt wurde, wird berechnet, welche Strecke das Rad des Motors zurückgelegt hat. Das ist natürlich abhängig davon, wie groß das Rad in der Roboterkonfiguration eingestellt ist.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Messmethode, stelle ein, wie gemessen werden soll.</li><li class="typcn typcn-arrow-sorted-down">Port, stelle ein, an welchem Port der Drehsensor bzw. Motor angeschlossen ist.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die je nach eingestellter Messmethode entweder die Umdrehungszahl, die Gradzahl oder die zurückgelegte Strecke darstellt.</li>
-</ul><br> </div><div id="robSensors_key_getSample" class="help beginner">  <h3 id="ProgrammierBlöckeEV3-»Taste...gedrückt?«">»Taste ... gedrückt?«</h3><p>Mit dem Block »Taste« kannst du einem anderen Block »mitteilen« , ob die ausgewählte Taste auf dem EV3 gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>true = gedrückt</em> oder <em>false = nicht gedrückt</em> zurück. Auswahl aus »Mitte« / »Oben« / »Unten« / »Rechts« / »Links« / »Zurück« / »irgendeine«.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Taste; wähle die Taste, die du überprüfen möchtest.</li>
-</ul><br><p><br>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »true«, wenn die gewählte Taste gedrückt ist, sonst »false«.</li>
-</ul><br> </div><div id="robSensors_gyro_reset" class="help beginner">  <h3 id="ProgrammierBlöckeEV3-»SetzeKreiselsensorPort...zurück«">»Setze Kreiselsensor Port ... zurück«</h3><p>Mit dem Block »Setze Kreiselsensor zurück« kann der Kreiselsensor (auch Gyroskop genannt) auf den Wert 0 zurückgesetzt werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zahl, wähle den Sensorport, an dem der Kreiselsensor angeschlossen ist.</li>
-</ul><br></div><div id="robSensors_gyro_getSample" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»GibWinkel/DrehrateKreiselsensor«">»Gib Winkel/Drehrate Kreiselsensor«</h3><p>Mit dem Block »Gib Winkel/Drehrate Kreiselsensor« kannst du einem anderen Block »mitteilen«, um welchen Winkel der Kreiselsensor um seine vertikale Achse gedreht wurde. Der Winkel wird als Zahl übermittelt. Zudem kann dieser Block im Auswahlmenü auf »Drehrate« gestellt werden. Mit dieser Einstellung wird statt des Winkels die Drehung des Sensor in »Grad pro Sekunde« übermittelt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Im Modus Drehrate können maximal 440 Grad/Sekunde erfasst werden. Im Modus Winkel beträgt die Genauigkeit des Kreiselsensors +/- 3 Grad.</p></div></div><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Messmethode: »Winkel« oder »Drehrate«</li><li class="typcn typcn-arrow-sorted-down">Port, wähle den Port, an dem der Drehsensor angeschlossen ist.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die je nach eingestellter Messmethode entweder Winkelgrade oder die Grad pro Sekunde anzeigt.</li>
-</ul><br></div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»GibWertZeitgeber...«">»Gib Wert Zeitgeber ...«</h3><p>Mit dem Block »Gib Wert Zeitgeber« kannst du einem anderen Block den aktuellen Stand des internen Zeitgebers in Millisekunden »mitteilen«. Der Zeitgeber wird automatisch mit dem Beginn eines Programms gestartet. Es stehen 5 Zeitgeber zur Verfügung.</p><p>Einstellöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zeitgeber-Nummer, wähle den Zeitgeber aus, dessen Wert du ermitteln möchtest.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl Millisekunden, die seit dem Programmstart oder dem letzten Zurücksetzen des Zeitgebers vergangen sind.</li>
-</ul><br></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück«</h3><p>Mit dem Block »Setze Zeitgeber« können die internen Zeitgeber (1 bis 5) auf den Wert 0 zurückgesetzt werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zeitgeber-Nummer, wähle den Zeitgeber aus, den du zurücksetzen möchtest.</li>
-</ul><br></div><div id="robSensors_sound_getSample" class="help expert"><h3 id="ProgrammierBlöckeEV3-»GibGeräusch%GeräuschsensorPort...«[Experten-Block]">»Gib Geräusch % Geräuschsensor Port ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du die Lautstärke abfragen, die der Geräuschsensor misst.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den Port, an dem der Geräuschsensor angeschlossen ist.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die gemessene Lautstärke in Prozent.</li>
-</ul></div><div id="robSensors_compass_calibrate" class="help expert"><h3 id="ProgrammierBlöckeEV3-»KalibriereHTKompasssensorPort...«[Experten-Block]">»Kalibriere HT Kompasssensor Port ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du einen angeschlossenen HT Kompasssensor neu kalibrieren. Dieser Sensor misst das Erdmagnetfeld und berechnet aus dessen Verlauf eine aktuelle Orientierung deines Roboters. Damit diese berechnung möglicht genau funktioniert, musst du den Kompasssensor zu Beginn deines Programms neu kalibrieren, um störende Einflüsse wie z.B. Motoren zu reduzieren.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den Port, an dem der Sensor angeschlossen ist.</li>
-</ul></div><div id="robSensors_compass_getSample" class="help expert"><h3 id="ProgrammierBlöckeEV3-»Gib...HTKompasssensorPort...«[Experten-Block]">»Gib ... HT Kompasssensor Port ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du verschiedene Werte des Kompasssensors abfragen. Der Kompasssensor kann dabei den Winkel und die Kompassorientierung deines Roboters messen. Allerdings solltest du den Sensor neu kalibrieren, bevor du ihn in deinem Programm verwendest.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Eigenschaft, die du messen möchtest. Entweder der Winkel deines Roboters oder die Kompassorientierung.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle den Port an dem dein Sensor angeschlossen ist.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zahl, entweder der Winkel deines Roboters oder die Kompassorientierung. Zahl zwischen 0 und 359.</li>
-</ul></div><div id="robSensors_irseeker_getSample" class="help expert"><h3 id="ProgrammierBlöckeEV3-»Gib...HTInfrarotsensorPort...«[Experten-Block]">»Gib ... HT Infrarotsensor Port ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du den HT Infrarotsensor deines Roboters abfragen. Dieser Sensor sendet und empfängt Infrarot-Signale und kann so die Distanz zu einem Objekt berechnen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle zwischen einem modulierten oder einem unmodulierten Signal.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle den Port deines Sensors.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Entfernung zum nächsten Objekt in Zentimetern.</li>
-</ul></div><div id="robSensors_htcolour_getSample" class="help expert"><h3 id="ProgrammierBlöckeEV3-»Gibt...HTFarbsensorPort...«[Experten-Block]">»Gibt ... HT Farbsensor Port ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du den HT Farbsensor deines Roboters abfragen. Dieser Sensor verwendet mehrere Leuchtdioden um den Untergrund zu beleuchten und misst dann, welche Farbe wie stark reflektiert wird. Aus diesen Werten lassen sich Farben und RGB-Werte berechnen. Der Sensor kann außerdem die Helligkeit des Untergrunds und der Umgebung messen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle welche Eigenschaft du messen möchtest. Du hast die Wahl zwischen Farbe, Licht, Umgebungslicht und RGB-Aufspaltung.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle den Port deines Sensors aus.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die Farbe des Untergrunds.</li><li class="typcn typcn-arrow-right">Zahl, die Helligkeit des Untergrunds oder der Umgebung.</li><li class="typcn typcn-arrow-right">Liste von Zahlen, die Aufspaltung der Farbe des Untergrunds in Rot, Grün und Blau.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»Wartebis...«">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wartems...«">»Warte ms ... «</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wartebis...«.1">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Zufallszahl«">»Zufallszahl« </h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeEV3-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeEV3-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt werden soll. Zahl zwischen 0 und 255.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeEV3-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von der verwendeten Programmiersprache des Roboters abhängt. </span><span style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt, sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der Zeichenkette »52abcd« die Zahl 52.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeEV3-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li><li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte das die Nummerierung bei 0 anfängt.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEV3-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEV3-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEV3-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEV3-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEV3-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEV3-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeEV3-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="ProgrammierBlöckeEV3-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammierBlöckeEV3-»Farbwahl«">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammierBlöckeEV3-»Farbwahl«.1">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammierBlöckeEV3-»Farbwahl«.2">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, die  Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="ProgrammierBlöckeEV3-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammierBlöckeEV3-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammierBlöckeEV3-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammierBlöckeEV3-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="ProgrammierBlöckeEV3-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="ProgrammierBlöckeEV3-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammierBlöckeEV3-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen Wert zurück.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit Rückgabewert «</h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
-</ul><br></div><div id="robCommunication_startConnection" class="help expert"><h3 id="ProgrammierBlöckeEV3-VerbindemitRobotername[Experten-Block]">Verbinde mit Robotername <span class="typcn typcn-star"></span></h3><p>Der Verbindungsaufbau wird von einem EV3-Roboter initiiert, wie z.B. ein Telefonanruf von einem Anrufer. Dazu muss bekannt sein, wie der Kommunikationspartner heißt.</p><p>Die Verbindung zwischen zwei EV3-Robotern wird in einer globalen Variablen vom Typ "Verbindung" gespeichert. Solange diese globale Verbindungsvariable gültig ist, "steht" die Nachrichtenverbindung. Achte darauf, dass die Roboter unterschiedliche Namen haben.</p><p>Schritt 1: Erzeuge eine globale Variable vom Typ "Verbindung".</p><p>Schritt 2: Füge einen Verbindungsblock an. Gib als Eingabewert den Namen des EV3-Roboters ein, mit dem die Nachrichtenverbingung aufgebaut werden soll.</p><p>Beim Kommunikationspartner wird die Verbindungsvariable automatisch über den Experten-Block "Warte auf Verbindung" gesetzt. Die Verbindungsvariable wird gesetzt, wenn der rufende EV3-Roboter den Block "Verbinde mit Robotername" ausgeführt hat.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Name des Roboters, zu dem eine Verbindung aufgebaut werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Verbindungsobjekt, das an eine globale Verbindungsvariable gebunden werden kann</li>
-</ul><br></div><div id="robCommunication_sendBlock" class="help expert"><h3 id="ProgrammierBlöckeEV3-SendeNachrichtüberVerbindung[Experten-Block]">Sende Nachricht über Verbindung <span class="typcn typcn-star"></span></h3><p>Eine Nachricht wird über eine globale Verbindungsvariable übermittelt. Die Nachricht wird über einen Block eingegeben, der dem Nachrichtentyp entspricht (gegenwärtig: Zeichenkette). Damit der Roboter weiß, über welche Verbindung die Kommunikation stattfindet, wird der Wert der globalen Verbindungsvariablen gelesen.</p><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><p>Es können gegenwärtig nur Textnachrichten via Bluetooth verschickt werden.</p></div></div><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Nachrichtentyp, »Zeichenkette«.</li><li class="typcn typcn-arrow-left">Nachricht, Zeichenkette, die übermittelt werden soll.</li><li class="typcn typcn-arrow-sorted-down">Verbindungsmedium, »Bluetooth«.</li><li class="typcn typcn-arrow-left">Verbindung, Verbindungsvariable, über die die Kommunikation erfolgt.</li>
-</ul><br></div><div id="robCommunication_receiveBlock" class="help expert"><h3 id="ProgrammierBlöckeEV3-EmpfangeNachrichtüberVerbindung[Experten-Block]">Empfange Nachricht über Verbindung <span class="typcn typcn-star"></span></h3><p>Eine Textnachricht wird über eine globale Verbindungsvariable übermittelt. Die Textnachricht wird an einen Textblock übergeben. Damit der EV3-Roboter weiß, über welche Verbindung die Kommunikation stattfindet, wird der Wert der globalen Verbindungsvariablen gelesen.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Nachrichtentyp, »Zeichenkette«.</li><li class="typcn typcn-arrow-sorted-down">Verbindungsmedium, »Bluetooth«.</li><li class="typcn typcn-arrow-left">Verbindung, Verbindungsvariable, über die die Kommunikation erfolgt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, Inhalt der empfangenen Nachricht.</li>
-</ul><br></div><div id="robCommunication_waitForConnection" class="help expert"><h3 id="ProgrammierBlöckeEV3-WarteaufVerbindung[Experten-Block]">Warte auf Verbindung <span class="typcn typcn-star"></span></h3><p>Der Verbindungsaufbau wird von einem EV3-Roboter initiiert, wie z.B. ein Telefonanruf von einem Anrufer. Ein angerufener Roboter wartet auf eine Verbindung.</p><p>Die Verbindung zwischen zwei EV3-Robotern wird in einer globalen Variablen vom Typ "Verbindung" gespeichert. Solange diese globale Verbindungsvariable gültig ist, "steht" die Nachrichtenverbindung.</p><p>Schritt 1: Erzeuge eine globale Variable vom Typ "Verbindung".</p><p>Schritt 2: Als Wert der globalen Verbindungsvariablen wird auf den Wert des Experten-Blocks "Warte auf Verbindung" gesetzt.</p><p>Die Verbindungsvariable wird dann gesetzt, wenn der rufende EV3-Roboter die Verbindung aufgerufen hat (siehe oben: Verbinde mit Robotername).</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Verbindungsobjekt, das an eine Verbindungsvariable gebunden werden kann.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den
+                man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am »Start«-Block.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
+                <li class="typcn typcn-input-checked">Zeige Sensordaten - während des Programmablaufs werden im Display
+                    die Werte der angeschlossenen Sensoren gezeigt.</li>
+            </ul><br>
+            <p>Wenn globale Variablen erzeugt wurden:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variablen.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»MotorPort...anTempo«[Experten-Block]"><span style="color: rgb(0,0,0);">»Motor
+                    Port ... an Tempo« </span><span class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »Motor Port ... an Tempo« programmierst du das Tempo (Geschwindigkeit) eines Motors. Dein
+                Roboter startet den gewählten Motor, bis er gestoppt wird oder ein anderer Block zum Fahren verwendet
+                wird.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor Port, wähle den Motor Port aus, an dem der Motor
+                    angeschlossen ist.</li>
+                <li class="typcn typcn-arrow-left">Tempo, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
+                    sich der Motor rückwärts.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on_for" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»MotorPort...anTempo...Umdrehungen/Grad«[Experten-Block]"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Motor Port ... an Tempo ...
+                        Umdrehungen/Grad« <span class="typcn typcn-star"></span></span><br></span></h3>
+            <p>Mit dem Block »Motor Port ... an Tempo ... Umdrehungen/Grad« stellst du das Tempo (Geschwindigkeit) eines
+                Motors ein. Dein Roboter startet den gewählten Motor, bis er die eingestellte Anzahl Umdrehungen bzw.
+                Winkelgrade gemacht hat.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor Port, wähle den Motorport aus, an dem der Motor
+                    angeschlossen ist.</li>
+                <li class="typcn typcn-arrow-left">Tempo, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
+                    sich der Motor rückwärts.</li>
+                <li class="typcn typcn-arrow-sorted-down">Umdrehungen oder Grad. 1 Umdrehung entspricht 360 Grad.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anzahl der Umdrehungen bzw. Winkelgrade. Es sind nur positive
+                    Zahlen zugelassen.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_getPower" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»GibTempoMotorPort«[Experten-Block]"><span style="color: rgb(0,0,255);"><span
+                        style="color: rgb(0,0,0);">»Gib Tempo Motor Port« <span
+                            class="typcn typcn-star"></span></span><br></span></h3>
+            <p>Der Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Gib Tempo Motor
+                        Port</span></span>« liest das Tempo (Geschwindigkeit) eines Motors aus.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, dessen Tempo gelesen werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl; Geschwindigkeit , die am ausgewählten Motor Port eingestellt
+                    ist.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_setPower" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»SetzeMotorPort...Tempo«[Experten-Block]"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Setze Motor Port ... <span
+                            style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Tempo</span></span>« <span
+                            class="typcn typcn-star"></span></span><br></span></h3>
+            <p>Der Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Setze Motor Port <span
+                            style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">...
+                                Tempo</span></span></span></span><span style="color: rgb(0,0,255);"><span
+                        style="color: rgb(0,0,0);"><span> </span><span> </span>« setzt </span></span>das Tempo
+                (Geschwindigkeit) eines Motors auf einen neuen Wert.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, für den dasTempo eingestellt
+                    werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
+                    sich der Motor rückwärts.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_stop" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»StoppeMotorPort«[Experten-Block]"><span style="color: rgb(0,0,255);"> <span
+                        style="color: rgb(0,0,0);">»Stoppe Motor Port« <span
+                            class="typcn typcn-star"></span></span><br></span></h3>
+            <p>Der Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Stoppe Motor
+                        Port</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);"><span>
+                        </span>« schaltet den </span></span>Motor an einem ausgewählten Motor-Port aus. Du kannst
+                einstellen, ob der Motor langsam ausläuft oder gebremst wird.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motorport aus, der ausgeschaltet werden soll.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Stoppmöglichkeiten; »auslaufen<span
+                        style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">«</span></span> sorgt dafür, dass
+                    der Motor langsam ausläuft; »bremsen<span style="color: rgb(0,0,255);"><span
+                            style="color: rgb(0,0,0);">«</span></span> sorgt dafür, dass der Motor abrupt abgebremst
+                    wird.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_on" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»Fahre...Tempo«">»Fahre ... Tempo«</h3>
+            <p>Mit dem Block »Fahre ... Tempo« kannst du die Richtung und das Tempo (Geschwindigkeit) deines Roboters
+                programmieren. Dein Roboter fährt so lange vorwärts oder rückwärts, bis er gestoppt wird oder ein
+                anderer Block zum Fahren verwendet wird.</p>
+            <p>»Fahre« steuert beide Motoren des Roboters gleichzeitig.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Richtung, wähle die gewünschte Fahrrichtung aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
+                    sich die Motoren rückwärts.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_on_for" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»Fahre...Tempo...Strecke«">»Fahre ... Tempo ... Strecke«</h3>
+            <p>Mit dem Block »Fahre ... Tempo ... Strecke« kannst du zusätzlich zu Richtung und Tempo auch die
+                Fahrstrecke des Roboters programmieren. Dein Roboter fährt so lange, bis die eingestellte Strecke
+                gefahren ist. Die Geschwindigkeit kannst du im Feld Tempo einstellen. Wenn dieser Block »zu Ende« ist,
+                stoppen die Motoren automatisch.</p>
+            <p>»Fahre« steuert beide Motoren des Roboters gleichzeitig.</p>
+            <p>Wenn die eingestellten Werte der Aktionen mit der Programmausführung nicht übereinstimmen, prüfe die
+                Roboter-Konfiguration, insbesondere den Raddurchmesser.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Fahrtrichtung, wähle die gewünschte Richtung.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
+                    sich die Motoren rückwärts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Länge für die Strecke in cm.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_stop" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»Stoppe«">»Stoppe«</h3>
+            <p>Mit dem Block »Stoppe« werden die Motoren deines Roboters gestoppt. Das bedeutet, dein Roboter hält an.
+            </p>
+        </div>
+        <div id="robActions_motorDiff_turn" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»Drehe...Tempo«">»Drehe ... Tempo«</h3>
+            <p>Mit dem Block »Drehe ... Tempo« kannst du die Richtung (rechts/links), in der sich der Roboter drehen
+                soll, programmieren. Dein Roboter dreht sich so lange auf der Stelle, bis er gestoppt wird oder ein
+                anderer Block zum Fahren verwendet wird. Die Geschwindigkeit kannst Du im Feld »Tempo« einstellen.
+                »Drehe« steuert beide Motoren des Roboters gleichzeitig in entgegengesetzten Richtungen, dadurch dreht
+                sich der Roboter auf der Stelle.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Drehrichtung, wähle die gewünschte Drehrichtung aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
+                    sich die Motoren rückwärts.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <p>Falls sich dein Roboter in die falsche Richtung dreht, sind die Motoren an die falschen Ports
+                        angeschlossen. Es genügt dann, die Ports zu tauschen, damit der Roboter in die richtige Richtung
+                        dreht.</p>
+                </div>
+            </div>
+        </div>
+        <div id="robActions_motorDiff_turn_for" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»Drehe...Tempo...Grad«">»Drehe ... Tempo ... Grad«</h3>
+            <p>Mit dem Block »Drehe ... Tempo ... Grad« kannst du die Richtung (rechts/links), in der sich der Roboter
+                um die eigene Achse drehen soll, programmieren. Zusätzlich zur Richtung kann noch im Feld »Grad«
+                angegeben werden, um wie viel Grad sich dein Roboter (um die eigene Achse) drehen soll. Dies bedeutet,
+                dass du beispielsweise mit der Einstellung 360 Grad deinen Roboter einmal um die eigene Achse drehen
+                lassen kannst. Der Block »Drehe ... Tempo ... Grad« steuert beide Motoren des Roboters, damit sich der
+                Roboter um die eigene Achse dreht.</p>
+            <p>Wenn die eingestellten Werte der Aktionen mit der Programmausführung nicht übereinstimmen, prüfe die
+                Roboter-Konfiguration, insbesondere den Raddurchmesser und die Spurbreite.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Drehrichtung, wähle die gewünschte Drehrichtung aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
+                    sich die Motoren rückwärts.</li>
+                <li class="typcn typcn-arrow-left">Gradzahl, um die der Roboter sich drehen soll. Negative Zahlen sind
+                    nicht zugelassen.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_curve" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»Steure...Tempolinks...Temporechts...«">»Steure ... Tempo links ... Tempo
+                rechts ...«</h3>
+            <p>Mit dem Block »Steure ... Tempo links ... Tempo rechts ...« kannst du den Roboter so programmieren, dass
+                er eine Kurve fährt, indem du das Tempo für den linken und den rechten Motor auf unterschiedliche Werte
+                setzt. Die Roboterkonfiguration beeinflusst den Radius der Kurve in Abhängigkeit von Radabstand und
+                Raddurchmesser. Mit der Drehrichtung legst du die Fahrtrichtung fest.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Drehrichtung, wähle die gewünschte Drehrichtung aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den linken Motor. Wenn die Zahl
+                    negativ ist, dreht sich der Motor rückwärts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den rechten Motor. Wenn die Zahl
+                    negativ ist, dreht sich der Motor rückwärts.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_curve_for" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»Steure...Tempolinks...Temporechts...Strecke...«">»Steure ... Tempo links ...
+                Tempo rechts ... Strecke ...«</h3>
+            <p>Mit dem Block »Steure ... Tempo links ... Tempo rechts ... Strecke ...« kannst du den Roboter so
+                programmieren, dass er eine vorgegebene Strecke als Kurve fährt, indem du das Tempo für den linken und
+                den rechten Motor auf unterschiedliche Werte setzt. Die Strecke bezieht sich auf die Mitte zwischen
+                beiden Rädern. Die Roboterkonfiguration beeinflusst den Radius der Kurve in Abhängigkeit von Radabstand
+                und Raddurchmesser. Mit der Richtung legst du die Fahrtrichtung fest.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Richtung, wähle die gewünschte Fahrtrichtung aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den linken Motor. Wenn die Zahl
+                    negativ ist, dreht sich der Motor rückwärts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den rechten Motor. Wenn die Zahl
+                    negativ ist, dreht sich der Motor rückwärts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Strecke in Zentimetern, die zurückgelegt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_display_text" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»ZeigeText«">»Zeige Text«</h3>
+            <p>Mit dem Block »Zeige Text« kannst du Text und Zahlen auf dem Display deines Roboters anzeigen lassen.
+                Dabei kannst du zusätzlich noch bestimmen, in welcher Spalte und in welcher Zeile der Text auf dem
+                EV3-Bildschirm erscheinen soll.</p>
+            <p>Das Display eines EV3 ist für Texte in mehreren Zeilen (von links nach rechts) und Spalten (von oben nach
+                unten) eingeteilt. Je nach System (lejos oder EV3dev) stehen unterschiedlich viele Zeilen und Spalten
+                zur Verfügung. Die Zählung beginnt jeweils bei 0.</p>
+            <p>Wenn zuvor schon etwas auf dem Display angezeigt war, werden nur die Stellen überschrieben, in die der
+                Text geschrieben wird.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_display_picture_new" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»ZeigeBild«[Experten-Block]">»Zeige Bild« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »Zeige Bild« kannst du eines von mehreren Bildern auf dem EV3-Display deines Roboters
+                anzeigen lassen. Verfügbare Bilder sind »Brille«, »Augen auf«, »Augen zu«, »Blumen«, »Tacho«.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Bild, wähle ein Bild aus, das auf dem Display erscheinen soll.
+                </li>
+                <li class="typcn typcn-arrow-left">Zahl für x, die Spaltennummer, in der das Bild beginnen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl für y, die Zeilennummer, in der das Bild beginnen soll.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_display_clear" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»LöscheBildschirm«">»Lösche Bildschirm«</h3>
+            <p>Mit dem Block »Lösche Bildschirm« kannst du Text und Zahlen auf dem Display deines Roboters löschen. Das
+                Display ist anschließend leer.</p>
+        </div>
+        <div id="robActions_play_tone" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»SpieleFrequenz...Dauer«">»Spiele Frequenz ... Dauer«</h3>
+            <p>Mit dem Block »Spiele Frequenz ... Dauer« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie
+                lange der Ton gespielt wird) programmieren. Der Ton wird über den eingebauten Lautsprecher deines LEGO
+                MINDSTORMS EV3 Steins abgespielt, bis die eingestellte Dauer erreicht ist.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Bitte beachte, dass das menschliche Gehör Frequenzen zwischen ca. 30 Hz bis ca. 15.000 Hz (15
+                        kHz) wahrnehmen kann - je nach Mensch und Alter kann dies unterschiedlich sein.</p>
+                </div>
+            </div>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, gewünschte Frequenz in Hz (Hertz) eingeben.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, gewünschte Dauer des Tons in Millisekunden (ms) eingeben.</li>
+            </ul><br>
+        </div>
+        <div id="mbedActions_play_note" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»SpieleNote...«">»Spiele Note ... «</h3>
+            <p>Mit diesem Block kann dein Roboter eine Note abspielen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Länge der Note aus.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Note aus, die dein Roboter spielen soll.
+                </li>
+            </ul>
+        </div>
+        <div id="robActions_play_file" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»SpieleStück«[Experten-Block]">»Spiele Stück« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »Spiele Stück« bringst du deinen Roboter dazu, einen von fünf hinterlegten Klängen zu
+                spielen.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zahl, Nummer für ein Stück zwischen 1 und 5 mit folgenden
+                    Zuordnungen:<br>1 - einfacher Piepton<br>2 - doppelter Piepton<br>3 - aufsteigender Klang aus 4
+                    Tönen<br>4 - absteigender Klang aus 4 Tönen<br>5 - einfacher tiefer Ton</li>
+            </ul><br>
+        </div>
+        <div id="robActions_play_setVolume" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»SetzeLautstärke«">»Setze Lautstärke«</h3>
+            <p>Mit dem Block »Setze Lautstärke« kannst du die Lautstärke eines Tons programmieren. Die Lautstärke kann
+                von 0 (kein Ton) bis 100 (volle Lautstärke) eingestellt werden. Die Lautstärke bleibt so lange
+                eingestellt, bis du sie mit einem anderen Block »Setze Lautstärke« neu programmierst.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl für die Lautstärke.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_play_getVolume" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»GibLautstärke«[Experten-Block]">»Gib Lautstärke« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »Gib Lautstärke« kannst du die aktuell eingestellte Lautstärke auslesen. 0 = kein Ton, 100
+                = maximale Lautstärke.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, aktuell eingestellter Lautstärkewert.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_setLanguage" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»SetzeSprache...«[Experten-Block]">»Setze Sprache
+                ... « <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du die Sprache deines Roboters steuern.
+                    Wenn du C4EV3 als dein Robotersystem verwendest, musst du zusätzliche Dateien für die Sprachausgabe
+                    herunterladen. Eine Anleitung dazu findest du <a
+                        href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo/Vorbereitung+EV3+-+System+C4EV3">hier</a>.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Sprache der Sprachauswahl.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_sayText" class="help beginner ">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»Sage...«">»Sage ... «</h3>
+            <p>Mit diesem Block kannst du die Sprachausgabe deines Roboters steuern. Dabei verwendet der Roboter die
+                Sprache, die du mit dem »Setze Sprache ...« Block festgelegt hast. Die Standardsprache ist Deutsch.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zeichenkette, der Text, den dein Roboter sagen soll.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_sayText_parameters" class="help expert">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeEV3-»Sage...Sprechgeschwindigkeit...Stimmlage...«[Experten-Block]">»Sage ...
+                Sprechgeschwindigkeit ... Stimmlage ... « <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du die Sprachausgabe deines Roboters
+                    steuern. Du kannst dabei auch die Stimmlage und die Sprechgeschwindigkeit deines Roboters
+                    steuern.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, der Text, den dein Roboter sagen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Sprechgeschwindigkeit in Prozent, also meine Zahl zwischen 1
+                    und 100. Je höher die Zahl ist, desto schneller spricht der Roboter.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Stimmlage des Roboters in Prozent. Zahl zwischen 1 und 100. Je
+                    höher die Zahl, desto höher ist auch die Stimmlage des Roboters.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_brickLight_on" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»Statusleuchte«">»Statusleuchte«</h3>
+            <p>Mit dem Block »Statusleuchte« kannst du die Statusleuchte, also die Hintergrundfarbe der Knöpfe an deinem
+                EV3-Stein programmieren. Folgende Farben stehen zur Auswahl: grün, orange, rot. Zusätzlich kannst du
+                einstellen, wie die Statusleuchte leuchten soll: »an«, »blinkend« oder »doppel blinkend«.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Farbe, wähle eine Farbe aus.</li>
+                <li class="typcn typcn-arrow-sorted-down">Anzeige Wähle aus, wie die Statusleuchte leuchten soll.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_brickLight_off" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»Statusleuchteaus«">»Statusleuchte aus«</h3>
+            <p>Mit dem Block »Statusleuchte aus« kannst du die Statusanzeige an deinem EV3-Stein ausschalten.</p>
+        </div>
+        <div id="robActions_brickLight_reset" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»SetzeStatusleuchtezurück«">»Setze Statusleuchte zurück«</h3>
+            <p>Mit dem Block »Setze Statusleuchte zurück« kannst du die Statusanzeige auf den Standardwert zurücksetzen.
+            </p>
+        </div>
+        <div id="robSensors_touch_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»Berührungssensor«">»Berührungssensor«</h3>
+            <p>Mit dem Block »Berührungssensor« kannst du einem anderen Block »mitteilen«, ob der Berührungssensor
+                gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>wahr = gedrückt</em> oder
+                <em>falsch = nicht gedrückt</em> zurück.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle den Sensorport aus, an dem dein Berührungssensor
+                    angeschlossen ist.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn der Berührungssensor gedrückt ist,
+                    sonst »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»GibAbstand/AnwesenheitUltraschallsensor«">»Gib Abstand/Anwesenheit
+                Ultraschallsensor«</h3>
+            <p>Mit dem Block »Gib Abstand/Anwesenheit Ultraschallsensor« kannst du einem anderen Block »mitteilen«,
+                welchen Abstand der Ultraschallsensor misst. Der Abstand wird als Zahl (in cm) übermittelt. Andererseits
+                kann dieser Block im Auswahlmenü auf »Anwesenheit« gestellt werden. Mit dieser Einstellung kann geprüft
+                werden, ob ein anderer Ultraschallsensor aktiv ist. In dieser Einstellung gibt er die logischen Werte
+                <em>true = weiterer Ultraschallsensor anwesend</em> oder <em>false = kein weiterer Ultraschallsensor
+                    anwesend</em> zurück.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Ultraschall, der nicht vom eigenen Ultraschallsensor ausgesandt wurde, kann zu fehlerhaften
+                        Messungen führen.</p>
+                </div>
+            </div>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Messmethode, wähle Anwesenheit oder Abstand.</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle den Sensorport aus, an dem dein Ultraschallsensor
+                    angeschlossen ist.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Wenn »Anwesenheit« gewählt wurde, wird ein logischer Wert zurückgegeben.</p>
+                    <p>Wenn »Abstand« gewählt wurde, wird der Abstand zwischen Ultraschallsensor und Hindernis
+                        angegeben.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_colour_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»GibFarbe«">»Gib Farbe«</h3>
+            <p>Mit dem Block »Gib Farbe« kannst du einem anderen Block »mitteilen«, welche Farbe der Farbsensor misst.
+                Die Farbe wird als Datentyp »Farbe« übermittelt. Zudem kann dieser Block im Auswahlmenü auf »Licht«,
+                »RGB« und »Umgebungslicht« gestellt werden. Diese drei zusätzlichen Typen übermitteln jeweils den
+                Datentyp »Zahl«. Die Zahlenwerte liegen je nach gewählter Messmethode zwischen 0 und 255. Mit diesen
+                verschiedenen Einstellung kann dieser Block je nach Anforderung eingestellt werden.</p>
+            <p>Im Modus »Farbe« sendet der Farbsensor Licht aus und erkennt, welche Grundfarbe unter dem Sensor erkannt
+                wurde. Die Grundfarbwerte sind BLACK, WHITE, GREY, RED, GREEN, BLUE, YELLOW, BROWN.</p>
+            <p>Im Modus »Licht« sendet der Farbsensor mittels seiner roten LED Licht aus und misst die reflektierte
+                Lichtstärke auf einer Skala von 0 bis 100.</p>
+            <p>Im Modus »RGB« sendet der Farbsensor rotes, grünes und blaues Licht aus und misst das reflektierte Licht
+                entsprechend der Anteile Rot, Grün und Blau auf einer Skala von 0 bis 255 pro Farbe. Es wird eine Liste
+                mit drei Werten für die jeweiligen Farben ausgegeben.</p>
+            <p>Im Modus »Umgebungslicht« wird dieselbe Skala (0-100) wie im Modus Licht verwendet. Dabei wird das ins
+                Sensorfenster einfallende Umgebungslicht gemessen.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Messmethode, wähle aus, was gemessen werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down"> Port, wähle den Sensorport aus, an dem dein
+                    Lichtsensor/Farbsensor angeschlossen ist.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Je nach gewählter Messmethode werden die zugehörigen Werte
+                    ausgegeben.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»GibAbstand/AnwesenheitInfrarotsensor«">»Gib Abstand/Anwesenheit
+                Infrarotsensor«</h3>
+            <p>Mit dem Block »Gib Abstand/Anwesenheit Infrarotsensor« kannst du einem anderen Block »mitteilen«, welchen
+                Abstand der Infrarotsensor misst.</p>
+            <p>Im Modus »Abstand« wird der Abstand als Zahl zwischen 0 (ganz nah) und 100 (weit entfernt) übermittelt,
+                nicht als Entfernungsmaß in Zentimetern. Der Sensor kann Objekte bis zu einem Abstand von 70 cm
+                erkennen.</p>
+            <p>Zudem kann dieser Block im Auswahlmenü auf »Anwesenheit« gestellt werden. Mit dieser Einstellung kann
+                geprüft werden, ob ein Infrarotsender (Beacon) aktiv ist. Diese Einstellung gibt eine Liste (Array) von
+                4 Wertepaaren, also insgesamt 8 Werte zurück. Jedes Wertepaar gibt mit dem ersten Wert die
+                <strong>Richtung </strong>und mit dem zweiten Wert den <strong>Abstand</strong> zum Infrarotsender an.
+                Das erste Wertepaar betrachtet dabei die Werte, die auf dem Kanal 1 des Senders übermittelt werden, das
+                zweite Wertepaar entsprechend Kanal 2 usw.. Die Richtung kann Werte von -25 bis +25 annehmen. Dabei
+                bedeutet 0, dass das Infrarotsignal direkt von vorne kommt. -25 bzw. +25 stehen für Winkel von 110° nach
+                links bzw. rechts. Der Abstand zum Sender ist ein Wert zwischen 0 (ganz nah) und 100 (weit entfernt).
+                Infrarotsignale von Sendern können aus bis zu 200 cm Entfernung empfangen werden.</p>
+            <p><strong>Beispiel</strong>: Ergebnis einer Messung mit dem Infrarotsensor ist [ 0 0 -10 40 0 0 0 0 ]. Das
+                bedeutet, dass auf Kanal 2 die Richtung des Senders mit -10 gemessen wurde, was etwa 60 Grad links
+                entspricht, sowie ein Abstand von 40, was ungefähr 80 cm entspricht.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Ein exakte Messung der Abstände in cm ist mit dem Infrarotsensor nicht möglich. Die gemessenen
+                        Abstände sind also ungefähre Werte.</p>
+                </div>
+            </div>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»Abstand« oder »Anwesenheit«. Stelle ein, wie der
+                    Infrarotsensor messen soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle aus, an welchem Port der Infrarotsensor
+                    angeschlossen ist.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, bei »Abstand«, maximaler Abstand 70 cm.</p>
+                    <p>Liste mit Zahlen, bei »Anwesenheit«.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_encoder_reset" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»SetzeDrehsensorzurück«">»Setze Drehsensor zurück«</h3>
+            <p>Mit dem Block »Setze Drehsensor zurück« kann der interne Sensor (Motor-Encoder) eines Motors auf den Wert
+                0 zurückgesetzt werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle aus, an welchem Port der Drehsensor/Motor
+                    angeschlossen ist.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_encoder_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»GibUmdrehungen/Grad/AbstandDrehsensorPor«">»Gib Umdrehungen/Grad/Abstand
+                Drehsensor Por«</h3>
+            <p>Mit dem Block »Gib Umdrehungen/Grad/Abstand Drehsensor« kannst du einem anderen Block die
+                Motorumdrehungen »mitteilen«.</p>
+            <p>Wenn »Umdrehungen« eingestellt wurde, wird die Zahl der Umdrehungen ausgegeben.</p>
+            <p>Wenn »Grad« eingestellt wurde, wird die Gradzahl aller Umdrehungen ausgegeben, wobei eine volle Umdrehung
+                genau 360 Grad entspricht.</p>
+            <p>Wenn »Abstand« eingestellt wurde, wird berechnet, welche Strecke das Rad des Motors zurückgelegt hat. Das
+                ist natürlich abhängig davon, wie groß das Rad in der Roboterkonfiguration eingestellt ist.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Messmethode, stelle ein, wie gemessen werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, stelle ein, an welchem Port der Drehsensor bzw. Motor
+                    angeschlossen ist.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die je nach eingestellter Messmethode entweder die
+                    Umdrehungszahl, die Gradzahl oder die zurückgelegte Strecke darstellt.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»Taste...gedrückt?«">»Taste ... gedrückt?«</h3>
+            <p>Mit dem Block »Taste« kannst du einem anderen Block »mitteilen« , ob die ausgewählte Taste auf dem EV3
+                gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>true = gedrückt</em> oder <em>false
+                    = nicht gedrückt</em> zurück. Auswahl aus »Mitte« / »Oben« / »Unten« / »Rechts« / »Links« / »Zurück«
+                / »irgendeine«.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Taste; wähle die Taste, die du überprüfen möchtest.</li>
+            </ul><br>
+            <p><br>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »true«, wenn die gewählte Taste gedrückt ist, sonst
+                    »false«.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_gyro_reset" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»SetzeKreiselsensorPort...zurück«">»Setze Kreiselsensor Port ... zurück«</h3>
+            <p>Mit dem Block »Setze Kreiselsensor zurück« kann der Kreiselsensor (auch Gyroskop genannt) auf den Wert 0
+                zurückgesetzt werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zahl, wähle den Sensorport, an dem der Kreiselsensor
+                    angeschlossen ist.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_gyro_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»GibWinkel/DrehrateKreiselsensor«">»Gib Winkel/Drehrate Kreiselsensor«</h3>
+            <p>Mit dem Block »Gib Winkel/Drehrate Kreiselsensor« kannst du einem anderen Block »mitteilen«, um welchen
+                Winkel der Kreiselsensor um seine vertikale Achse gedreht wurde. Der Winkel wird als Zahl übermittelt.
+                Zudem kann dieser Block im Auswahlmenü auf »Drehrate« gestellt werden. Mit dieser Einstellung wird statt
+                des Winkels die Drehung des Sensor in »Grad pro Sekunde« übermittelt.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Im Modus Drehrate können maximal 440 Grad/Sekunde erfasst werden. Im Modus Winkel beträgt die
+                        Genauigkeit des Kreiselsensors +/- 3 Grad.</p>
+                </div>
+            </div>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Messmethode: »Winkel« oder »Drehrate«</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle den Port, an dem der Drehsensor angeschlossen ist.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die je nach eingestellter Messmethode entweder Winkelgrade
+                    oder die Grad pro Sekunde anzeigt.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»GibWertZeitgeber...«">»Gib Wert Zeitgeber ...«</h3>
+            <p>Mit dem Block »Gib Wert Zeitgeber« kannst du einem anderen Block den aktuellen Stand des internen
+                Zeitgebers in Millisekunden »mitteilen«. Der Zeitgeber wird automatisch mit dem Beginn eines Programms
+                gestartet. Es stehen 5 Zeitgeber zur Verfügung.</p>
+            <p>Einstellöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zeitgeber-Nummer, wähle den Zeitgeber aus, dessen Wert du
+                    ermitteln möchtest.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl Millisekunden, die seit dem Programmstart oder dem
+                    letzten Zurücksetzen des Zeitgebers vergangen sind.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück«</h3>
+            <p>Mit dem Block »Setze Zeitgeber« können die internen Zeitgeber (1 bis 5) auf den Wert 0 zurückgesetzt
+                werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zeitgeber-Nummer, wähle den Zeitgeber aus, den du zurücksetzen
+                    möchtest.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_sound_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»GibGeräusch%GeräuschsensorPort...«[Experten-Block]">»Gib Geräusch %
+                Geräuschsensor Port ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du die Lautstärke abfragen, die der Geräuschsensor misst.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Port, an dem der Geräuschsensor
+                    angeschlossen ist.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die gemessene Lautstärke in Prozent.</li>
+            </ul>
+        </div>
+        <div id="robSensors_compass_calibrate" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»KalibriereHTKompasssensorPort...«[Experten-Block]">»Kalibriere HT
+                Kompasssensor Port ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du einen angeschlossenen HT Kompasssensor neu kalibrieren. Dieser Sensor misst
+                das Erdmagnetfeld und berechnet aus dessen Verlauf eine aktuelle Orientierung deines Roboters. Damit
+                diese berechnung möglicht genau funktioniert, musst du den Kompasssensor zu Beginn deines Programms neu
+                kalibrieren, um störende Einflüsse wie z.B. Motoren zu reduzieren.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Port, an dem der Sensor angeschlossen ist.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_compass_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»Gib...HTKompasssensorPort...«[Experten-Block]">»Gib ... HT Kompasssensor Port
+                ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du verschiedene Werte des Kompasssensors abfragen. Der Kompasssensor kann dabei
+                den Winkel und die Kompassorientierung deines Roboters messen. Allerdings solltest du den Sensor neu
+                kalibrieren, bevor du ihn in deinem Programm verwendest.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Eigenschaft, die du messen möchtest.
+                    Entweder der Winkel deines Roboters oder die Kompassorientierung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Port an dem dein Sensor angeschlossen ist.
+                </li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zahl, entweder der Winkel deines Roboters oder die
+                    Kompassorientierung. Zahl zwischen 0 und 359.</li>
+            </ul>
+        </div>
+        <div id="robSensors_irseeker_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»Gib...HTInfrarotsensorPort...«[Experten-Block]">»Gib ... HT Infrarotsensor
+                Port ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du den HT Infrarotsensor deines Roboters abfragen. Dieser Sensor sendet und
+                empfängt Infrarot-Signale und kann so die Distanz zu einem Objekt berechnen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle zwischen einem modulierten oder einem
+                    unmodulierten Signal.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Port deines Sensors.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Entfernung zum nächsten Objekt in Zentimetern.</li>
+            </ul>
+        </div>
+        <div id="robSensors_htcolour_getSample" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»Gibt...HTFarbsensorPort...«[Experten-Block]">»Gibt ... HT Farbsensor Port ...
+                « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du den HT Farbsensor deines Roboters abfragen. Dieser Sensor verwendet mehrere
+                Leuchtdioden um den Untergrund zu beleuchten und misst dann, welche Farbe wie stark reflektiert wird.
+                Aus diesen Werten lassen sich Farben und RGB-Werte berechnen. Der Sensor kann außerdem die Helligkeit
+                des Untergrunds und der Umgebung messen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle welche Eigenschaft du messen möchtest. Du hast
+                    die Wahl zwischen Farbe, Licht, Umgebungslicht und RGB-Aufspaltung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Port deines Sensors aus.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die Farbe des Untergrunds.</li>
+                <li class="typcn typcn-arrow-right">Zahl, die Helligkeit des Untergrunds oder der Umgebung.</li>
+                <li class="typcn typcn-arrow-right">Liste von Zahlen, die Aufspaltung der Farbe des Untergrunds in Rot,
+                    Grün und Blau.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wennmachesonst«">»Wenn mache sonst«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«
+            </h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wiederholenmal«">»Wiederhole n mal«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole
+                solange/bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»FürWertausderListe«[Experten-Block]">»Für Wert aus
+                der Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="ProgrammierBlöckeEV3-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wartems...«">»Warte ms ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wartebis...«.1">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»MathematischeFunktionen«[Experten-Block]">
+                »Mathematische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»TrigonometrischeFunktionen«[Experten-Block]">
+                »Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Konstanten«[Experten-Block]">»Konstanten« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Zahleneigenschaft«[Experten-Block]">
+                »Zahleneigenschaft« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»runden«[Experten-Block]">»runden« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Listeauswerten«[Experten-Block]">»Liste auswerten«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Restvon«[Experten-Block]">»Rest von« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Begrenze«[Experten-Block]">»Begrenze« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»GanzzahligeZufallswerte«[Experten-Block]">
+                »Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Zufallszahl«">»Zufallszahl« </h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeEV3-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette«
+                <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeEV3-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»ErstelleText«[Experten-Block]">»Erstelle Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeEV3-»Textanhängen«[Experten-Block]">»Text anhängen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeEV3-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeEV3-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an
+                Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEV3-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEV3-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEV3-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEV3-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEV3-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEV3-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEV3-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammierBlöckeEV3-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammierBlöckeEV3-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammierBlöckeEV3-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammierBlöckeEV3-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeEV3-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün
+                ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»FarbemitRot...Grün...Blau...«[Experten-Block]">
+                »Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»FarbemitRot...Grün...Blau...«[Experten-Block].1">
+                »Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammierBlöckeEV3-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb
+                einer Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="ProgrammierBlöckeEV3-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="ProgrammierBlöckeEV3-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne
+                Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeEV3-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf
+                mit Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_startConnection" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-VerbindemitRobotername[Experten-Block]">Verbinde mit Robotername <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Verbindungsaufbau wird von einem EV3-Roboter initiiert, wie z.B. ein Telefonanruf von einem Anrufer.
+                Dazu muss bekannt sein, wie der Kommunikationspartner heißt.</p>
+            <p>Die Verbindung zwischen zwei EV3-Robotern wird in einer globalen Variablen vom Typ "Verbindung"
+                gespeichert. Solange diese globale Verbindungsvariable gültig ist, "steht" die Nachrichtenverbindung.
+                Achte darauf, dass die Roboter unterschiedliche Namen haben.</p>
+            <p>Schritt 1: Erzeuge eine globale Variable vom Typ "Verbindung".</p>
+            <p>Schritt 2: Füge einen Verbindungsblock an. Gib als Eingabewert den Namen des EV3-Roboters ein, mit dem
+                die Nachrichtenverbingung aufgebaut werden soll.</p>
+            <p>Beim Kommunikationspartner wird die Verbindungsvariable automatisch über den Experten-Block "Warte auf
+                Verbindung" gesetzt. Die Verbindungsvariable wird gesetzt, wenn der rufende EV3-Roboter den Block
+                "Verbinde mit Robotername" ausgeführt hat.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Name des Roboters, zu dem eine Verbindung aufgebaut werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Verbindungsobjekt, das an eine globale Verbindungsvariable gebunden
+                    werden kann</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_sendBlock" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-SendeNachrichtüberVerbindung[Experten-Block]">Sende Nachricht über Verbindung
+                <span class="typcn typcn-star"></span></h3>
+            <p>Eine Nachricht wird über eine globale Verbindungsvariable übermittelt. Die Nachricht wird über einen
+                Block eingegeben, der dem Nachrichtentyp entspricht (gegenwärtig: Zeichenkette). Damit der Roboter weiß,
+                über welche Verbindung die Kommunikation stattfindet, wird der Wert der globalen Verbindungsvariablen
+                gelesen.</p>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <p>Es können gegenwärtig nur Textnachrichten via Bluetooth verschickt werden.</p>
+                </div>
+            </div>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Nachrichtentyp, »Zeichenkette«.</li>
+                <li class="typcn typcn-arrow-left">Nachricht, Zeichenkette, die übermittelt werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Verbindungsmedium, »Bluetooth«.</li>
+                <li class="typcn typcn-arrow-left">Verbindung, Verbindungsvariable, über die die Kommunikation erfolgt.
+                </li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_receiveBlock" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-EmpfangeNachrichtüberVerbindung[Experten-Block]">Empfange Nachricht über
+                Verbindung <span class="typcn typcn-star"></span></h3>
+            <p>Eine Textnachricht wird über eine globale Verbindungsvariable übermittelt. Die Textnachricht wird an
+                einen Textblock übergeben. Damit der EV3-Roboter weiß, über welche Verbindung die Kommunikation
+                stattfindet, wird der Wert der globalen Verbindungsvariablen gelesen.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Nachrichtentyp, »Zeichenkette«.</li>
+                <li class="typcn typcn-arrow-sorted-down">Verbindungsmedium, »Bluetooth«.</li>
+                <li class="typcn typcn-arrow-left">Verbindung, Verbindungsvariable, über die die Kommunikation erfolgt.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, Inhalt der empfangenen Nachricht.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_waitForConnection" class="help expert">
+            <h3 id="ProgrammierBlöckeEV3-WarteaufVerbindung[Experten-Block]">Warte auf Verbindung <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Verbindungsaufbau wird von einem EV3-Roboter initiiert, wie z.B. ein Telefonanruf von einem Anrufer.
+                Ein angerufener Roboter wartet auf eine Verbindung.</p>
+            <p>Die Verbindung zwischen zwei EV3-Robotern wird in einer globalen Variablen vom Typ "Verbindung"
+                gespeichert. Solange diese globale Verbindungsvariable gültig ist, "steht" die Nachrichtenverbindung.
+            </p>
+            <p>Schritt 1: Erzeuge eine globale Variable vom Typ "Verbindung".</p>
+            <p>Schritt 2: Als Wert der globalen Verbindungsvariablen wird auf den Wert des Experten-Blocks "Warte auf
+                Verbindung" gesetzt.</p>
+            <p>Die Verbindungsvariable wird dann gesetzt, wenn der rufende EV3-Roboter die Verbindung aufgerufen hat
+                (siehe oben: Verbinde mit Robotername).</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Verbindungsobjekt, das an eine Verbindungsvariable gebunden werden
+                    kann.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_ev3_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_ev3_en.html
@@ -1,466 +1,1839 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="ProgrammingBlocksEV3-»Programstart«"><span style="color: rgb(0,0,0);">»Program start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Each program starts with the red »Program start« block.</p><p>This block is always available in the Open Roberta Lab and cannot be deleted. The little triangle below the start block is called  »sequence connector«. The first block you want to use will be connected by using the »sequence connector« at the start block.  The sequence connector color changes to yellow when a suitable block comes into its range.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">create a new global variable</li><li class="typcn typcn-minus">delete the global variable</li><li class="typcn typcn-input-checked">show sensor data - while running a program the current values of connected sensors will be shown on the display</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable</li><li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«, »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li><li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial value of the variable.</li>
-</ul></div><div id="robActions_motor_on" class="help expert"><h3 id="ProgrammingBlocksEV3-»motorport...on«[Expertblock]"><span style="color: rgb(0,0,0);">»motor port ... on</span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span></h3><p>With the »motor port ... on« block you can program the speed (velocity) of the selected motor. Your robot starts the selected motor, until it is stopped or another block specifies new moving parameters.</p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">motor port, choose the port where the motor is connected to.</li><li class="typcn typcn-arrow-left">value, speed between -100 to 100. Negative values let the motor turn backwards.</li>
-</ul></div><div id="robActions_motor_on_for" class="help expert"><h3 id="ProgrammingBlocksEV3-»motorport...on...for«[Expertblock]"><span style="color: rgb(0,0,0);">»motor port ... on ... for</span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span></h3><p>With the »motor port ... rotation« block you can program the speed (velocity) of the selected motor. Your robot starts the selected motor and rotates the motor until the specified number of rotations or degrees is done. </p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">motor port, choose the one where the motor that you want to program is connected to.</li><li class="typcn typcn-arrow-left">number, spped between -100 and 100. 100 is the maximum speed. Negative values lets the motor rotate into the other direction.</li><li class="typcn typcn-arrow-sorted-down">rotation or degree. Choose the one which fits best. 1 rotation is the same than 360 degrees.</li><li class="typcn typcn-arrow-left">number, rotations or degrees, only positive numbers are allowed.</li>
-</ul></div><div id="robActions_motor_getPower" class="help expert"><h3 id="ProgrammingBlocksEV3-»getspeedmotorport«[Expertblock]"><span style="color: rgb(0,0,0);">»get speed motor port</span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span></h3><p>The block »<span style="color: rgb(0,0,0);">get speed motor port</span><span style="color: rgb(0,0,0);"> </span>« reads the speed (velocity) of the selected motor. The motor can have a speed from -100 (rotating backwards) to 100.</p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">motor port, choose the port where the motor is connected to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, the current speed of the motor.</li>
-</ul></div><div id="robActions_motor_setPower" class="help expert"><h3 id="ProgrammingBlocksEV3-»setmotorportspeed«[Expertblock]"><span style="color: rgb(0,0,0);">»set motor port <span>speed</span></span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span></h3><p>The block »s<span style="color: rgb(0,0,0);">et motor port ... </span><span style="color: rgb(0,0,0);">speed</span>« sets the speed (velocity) of one selected motor to a new value. </p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">motor port, choose the port where the motor is connected to.</li><li class="typcn typcn-arrow-left">number, speed between -100 and 100. Negative values let the motor run backwards.</li>
-</ul></div><div id="robActions_motor_stop" class="help expert"><h3 id="ProgrammingBlocksEV3-»stopmotorport«[Expertblock]"><span style="color: rgb(0,0,0);">»stop motor port</span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span></h3><p>Using the block »s<span>top motor port</span><span> </span>« switches off one selected motor. You can decide the motor to run out slowly (float) or to break immediately</p><p>Setting options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">motor port, <span>choose the port where the motor is connected to.</span></li><li class="typcn typcn-arrow-sorted-down">float or brake; make your choice.</li>
-</ul></div><div id="robActions_motorDiff_on" class="help beginner"><h3 id="ProgrammingBlocksEV3-»drive«">»drive«</h3><p>With the »drive« block you can program the direction and also the speed (velocity) of your robot. <span>Your robot moves  until it is stopped or another block specifies new driving parameters. The driving speed can be set in the field  »speed«.</span></p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">direction, forwards or backwards. Choose the direction.</li><li class="typcn typcn-arrow-left"><span>number, speed between -100 to 100. 100 is the maximum speed. Negative values lets the motor rotate into the other direction.</span></li>
-</ul></div><div id="robActions_motorDiff_on_for" class="help beginner"><h3 id="ProgrammingBlocksEV3-»drivedistance«">»drive distance«</h3><p>With the »drive distance« block you can program the direction and the speed of the robot. The speed of your robot is set in the »speed« parameter. Once the block has been executed the motors stop automatically.</p><p>»drive distance« controls both motors of the robot at the same time, meaning that the settings you make here apply to both motors of the robot. If the robot's actions don't correspond with the block's settings when running the program, check the robot configuration settings, especially the wheel diameter and the track width.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Drive, »forwards« or »backwards«. Select a direction.</li><li class="typcn typcn-arrow-left">Number, speed between  -100 and 100. If the number is negative, the motors will rotate backwards.</li><li class="typcn typcn-arrow-left">Number, the distance to drive in cm.</li>
-</ul></div><div id="robActions_motorDiff_stop" class="help beginner"><h3 id="ProgrammingBlocksEV3-»stop«">»stop«</h3><p>The »stop« block stops the motors immediately.</p><p>Settings: none</p></div><div id="robActions_motorDiff_turn" class="help beginner"><h3 id="ProgrammingBlocksEV3-»turn«">»turn«</h3><p>With the »turn« block you set the direction (right/left) which the robot will turn. Your robot turns until it is stopped or another block is used for driving. You can set the speed in the block parameter field »speed«.</p><p>»turn« controls both motors of the robot at the same time, therefore the robot turns on the spot. If the EV3 Robot's actions don't correspond with the block's settings when running the program, check the EV3 robot configuration settings, especially the wheel diameter and the track width.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Turn, »right« or »left«. Select the desired direction for turning.</li><li class="typcn typcn-arrow-left">Number, speed between  -100 and 100. If the number is negative, the motors will rotate backwards.</li>
-</ul><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><p>If your robot turns into the wrong direction, then the motors are connected to the wrong ports. Just swap the ports and your robot will turn into the right way.</p></div></div></div><div id="robActions_motorDiff_turn_for" class="help beginner"><h3 id="ProgrammingBlocksEV3-»turndegree«">»turn degree«</h3><p>With the »turn degree« block you program the direction (right/left) that your robot will turn. In addition to the direction you can also program the »degrees«, allowing you to program how many degrees your robot should rotate (around its axis). This means that you do a complete rotation by setting a 360 degree turn..</p><p>The »turn degree« block controls both motors of the robot in such a way that the robot turns around its own axis. If the robot's actions don't correspond with the block's settings when running the program, check the EV3 robot configuration settings, especially the wheel diameter and the track width.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Turn, »right« or »left«. Select the desired direction for turning.</li><li class="typcn typcn-arrow-left">Number, speed between  -100 and 100. If the number is negative, the motors will rotate backwards.</li><li class="typcn typcn-arrow-left">Number, degrees the robot shall turn. Degree of 360 will perform a full turn around. Negative numbers are not allowed.</li>
-</ul></div><div id="robActions_motorDiff_curve" class="help beginner"><h3 style="text-align: left;" id="ProgrammingBlocksEV3-»steer...speedleft...speedright...«">»steer ... speed left ... speed right ...«</h3><p style="text-align: left;">The block »steer ... speed left ... speed right ...« programs the robot to drive a curve by setting different speeds for the left and right motor. The robot configuration influences the radius of the curve depending from wheel distance and wheel diameter. The turning direction will define the driving direction.</p><p style="text-align: left;">Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Turning direction, »forwards« or »backwards«. Select your desired moving direction.</li><li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number is negative the motor will run backwards.</li><li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number is negative the motor will run backwards.</li>
-</ul><br></div><div id="robActions_motorDiff_curve_for" class="help beginner"><h3 style="text-align: left;" id="ProgrammingBlocksEV3-»steer...speedleft...speedright...distance...«">»steer ... speed left ... speed right ... distance ...«</h3><p style="text-align: left;">The block »steer ... speed left ... speed right ... distance ...« programs the robot to drive a curve by setting different speeds for the left and right motor and also a distance related to the middle between both wheels. The robot configuration influences the radius of the curve depending from wheel distance and wheel diameter. The turning direction will define the driving direction.</p><p style="text-align: left;">Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Turning direction, »forwards« or »backwards«. Select your desired moving direction.</li><li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number is negative the motor will run backwards.</li><li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number is negative the motor will run backwards.</li><li class="typcn typcn-arrow-left">Number, the distance in cm to be driven.</li>
-</ul><br></div><div id="robActions_display_text" class="help beginner"><h3 id="ProgrammingBlocksEV3-»showtext«">»show text«</h3><p>With the »show text« block you can display text and numbers on the display of your robot. You can also specify in which column and row the text or numbers should be displayed on the robot screen.</p><p>The EV3 display contains some rows and columns, counted from 0 in the top left corner. Depending on the system (lejos or EV3dev) there are different numbers of rows and columns available.</p><p>If there was text on the display prior to the show text block then the former text will be overwritten.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, input of a text string to be shown in the display.</li><li class="typcn typcn-arrow-left">Number, column for the text to start.</li><li class="typcn typcn-arrow-left">Number, row for the text to start.</li>
-</ul></div><div id="robActions_display_picture_new" class="help expert"><h3 id="ProgrammingBlocksEV3-»showpicture«[Expertblock]">»show picture« <span class="typcn typcn-star"></span></h3><p>With the »show picture« block you can show one of some stored pictures on the EV3 display of your robot. Avaliable pictures are »glasses«, »eyes open«, »eyes closed«, »flowers«, »tacho«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Picture, select one of the available.</li><li class="typcn typcn-arrow-left">Number for x, column, where the picture shall start.</li><li class="typcn typcn-arrow-left">Number for y, line, where the picture shall start.</li>
-</ul></div><div id="robActions_display_clear" class="help beginner"><h3 id="ProgrammingBlocksEV3-»cleardisplay«">»clear display«</h3><p>With the »clear display« block you can delete text and numbers on the display of your robot, therefore nothing appears on your display.</p><p>Settings: none</p></div><div id="robActions_play_tone" class="help beginner"><h3 id="ProgrammingBlocksEV3-»playfrequency«">»play frequency«</h3><p>With the »play frequency« block you can program the frequency (pitch level) and the time (how long the sound should be played) that a sound is played. The sound is played by the built-in speaker of your LEGO MINDSTORMS EV3 brick for a defined of time. The frequency setting corresponds directly to the frequency in Hertz, for example, setting the frequency to 400 corresponds to 400 Hertz. Example: 261 = C.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p><span>Note that the human ear can perceive frequencies from about 30Hz to about 15,000Hz (15kHz). This can vary depending on the person and their age.</span></p></div></div><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, desired frequency in Hz (Hertz) .</li><li class="typcn typcn-arrow-left">Number, desired duration in milliseconds (ms).</li>
-</ul></div><div id="mbedActions_play_note" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»playnote...«">»play note ... «</h3><p>With this block you can make a robot play a note.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the duration of the note.</li><li class="typcn typcn-arrow-sorted-down">Option, choose the note that the robot should play.</li>
-</ul><br></div><div id="robActions_play_file" class="help expert"><h3 id="ProgrammingBlocksEV3-»playfile«[Expertblock]">»play file« <span class="typcn typcn-star"></span></h3><p>With the »play file« block your robot plays one of five stored sounds.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose between one of the following files:<br>1 = single beep<br>2 = double beep<br>3 = increasing sound of 4 tones<br>4 = decreasing sound of 4 tones<br>5 = single low tone</li>
-</ul></div><div id="robActions_play_setVolume" class="help beginner"><h3 id="ProgrammingBlocksEV3-»setvolume«">»set volume«</h3><p>With the »set volume« block you can program the sound volume played. The volume ranges from 0 (no sound) to 100 (full volume). The volume setting remains unchanged until you change it with another »set volume« block.</p><p>Setting:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, volume for loudness. 0 = no tone, 100 = maximum volume.</li>
-</ul></div><div id="robActions_play_getVolume" class="help expert"><h3 id="ProgrammingBlocksEV3-»getvolume«[Expertblock]">»get volume« <span class="typcn typcn-star"></span></h3><p>With the »get volume« block you can read the currend sound volume level.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, currently adjusted volume. 0 = no tone, 100 = maximum volume</li>
-</ul></div><div id="robActions_setLanguage" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»setlanguage...«[ExpertBlock]">»set language ... «<span class="typcn typcn-star"></span></h3><p>With this block you can control the language of your robot. If you are using C4EV3 as your robot system, you will need to download additional files for the speech. You can find instructions <a href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo/Set+Up+EV3+-+System+C4EV3">here</a>.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the language.</li>
-</ul><br></div><div id="robActions_sayText" class="help beginner "><h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»saytext...«">»say text ... «</h3><p>With this block you can control the voice output of your robot. The robot uses the language you set with the "Set Language..." block. The default language is German.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the text you want your robot to say.</li>
-</ul><br></div><div id="robActions_sayText_parameters" class="help expert"><h3 id="ProgrammingBlocksEV3-»saytext...voicespeed...voicepitch...«[ExpertBlock]"><span style="color: rgb(85,85,85);font-size: 16.0px;letter-spacing: -0.006em;">» say text ... voice speed ... voice pitch ... « <span class="typcn typcn-star"></span></span></h3><p>With this block you can control the voice output of your robot. You can also control your robot's voice pitch and speaking speed.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, text your want your robot to say.</li><li class="typcn typcn-arrow-left">Number, speaking rate in percent, i.e. my number between 1 and 100, the higher the number, the faster the robot speaks.</li><li class="typcn typcn-arrow-left">Number, voice pitch of the robot in percent. Number between 1 and 100, the higher the number, the higher the voice pitch of the robot.</li>
-</ul><br></div><div id="robActions_brickLight_on" class="help beginner"><h3 id="ProgrammingBlocksEV3-»Bricklight«">»Brick light«</h3><p>With the »brick light« block you can program the background light of the EV3 buttons. In addition to color, you can also turn on and off the EV3 brick light. The EV3 brick light stays on until you reprogram it. The following colors are available: »green«, »orange« or »red«.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Colour, select a colour.</li><li class="typcn typcn-arrow-sorted-down">Flash type, »on«, »flashing« or »double flashing«. Select a flash type for the brick light.</li>
-</ul></div><div id="robActions_brickLight_off" class="help beginner"><h3 id="ProgrammingBlocksEV3-»Bricklightoff«">»Brick light off«</h3><p>With the »brick light off« block you can turn off the brick light.</p></div><div id="robActions_brickLight_reset" class="help beginner"><h3 id="ProgrammingBlocksEV3-»resetEV3bricklight«">»reset EV3 brick light«</h3><p>With the »reset EV3 brick light« block you can reset EV3 brick light back to the default settings.</p><p>Settings: none</p></div><div id="robSensors_touch_getSample" class="help beginner"> <h3 id="ProgrammingBlocksEV3-»touchsensor«">»touch sensor«</h3><p>With the block »touch sensor« you can "tell" another block whether the touch sensor is pressed or not. This block returns the logical values <em>true = pressed</em> or <em>false = not pressed</em>. This block can only be used in conjunction with another block which requires a logical value as an input parameter, for example together with the »if then« block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your touch sensor is connected.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value: »true«, if the touch sensor is pressed, otherwise »false«.</li>
-</ul> </div><div id="robSensors_ultrasonic_getSample" class="help beginner"> <h3 id="ProgrammingBlocksEV3-»getdistance/presence«ultrasonicsensor">»get distance/presence« ultrasonic sensor</h3><p>With the block »get distance/presence« you "tell" another block the distance the ultrasonic sensor measures. The distance is transmitted as a number (in cm). In addition, this block can be set to "presence" in the drop down menu. This setting can check whether another ultrasonic sensor is active. This setting specifies the logical values <em>true = another ultrasonic sensor is present </em>or<em> false = no other ultrasonic is present</em> back.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Ultrasound, which was not sent by the own ultrasonic sensor, can result in erroneous measurements.</p></div></div><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Presence or distance; »presence« means that the presence of another ultrasonic sensor will be checked. »Distance« means that the ultrasonic sensor measures the distance to the next obstacle.</li><li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your ultrasonic sensor is connected.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>If »presence« was selected, a boolean value: »true«, if another ultrasonic sensor was detected, otherwise »false«.</p><p>If »distance« was selected, a number, indicating the distance between the ultrasonic sensor and an obstacle in cm.</p></li>
-</ul></div><div id="robSensors_colour_getSample" class="help beginner"> <h3 id="ProgrammingBlocksEV3-»getcolourlightsensor/coloursensorPort...«">»get colour light sensor / colour sensor Port ... «</h3><p>With the block »get colour« you can "tell" another block which color the light sensor measures. The color is transmitted as type »colour« . In addition, this block provides within the drop down menu the settings »light«, »RGB« and »ambient light«. These three additional settings transmit all the same type »number«. The numerical values are between 0 (black) to 100(white). With these various settings this block can be configured according to the specific requirements.</p><p>In mode »colour« the light sensor emits light and detects the basic colour under the sensor. Values for basic colours are BLACK, WHITE, GREY, RED, GREEN, BLUE, YELLOW, BROWN.</p><p>In mode »light« the light sensor emits light with its red LED and measures the light intensity of the reflected light on a scale of 0 to 100.</p><p>In the mode »RGB« the light sensor emits red, green and blue light and measures the reflected light corresponding to the components red, green and blue on a scale from 0 to 100 for each color. A list of three numbers is returned.</p><p>In mode »ambient light« the same scale (0-100) as in the mode light is used. Here, the ambient light inciding the sensor is measured.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of measurement, select the mode of measurement.</li><li class="typcn typcn-arrow-sorted-down"> Port, select the sensor port where your light/colour sensor is connected.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, depending on the selected ode of measurement.</li>
-</ul> </div><div id="robSensors_infrared_getSample" class="help beginner"> <h3 id="ProgrammingBlocksEV3-»givedistance/presence«infraredsensor">»give distance/presence« infrared sensor</h3><p>With the block »give distance/presence« for infrared sensor you can "tell" another block which distance the infrared sensor measures.</p><p>Working in the "distance" mode the distance is transmitted as a number with values between 0 (very close) and 100 (far away). In this mode the sensor detects objects in a distance up to 70 cm.</p><p>In addition, this block can be set to "presence" mode in the drop down menu. With this setting you can check whether an infrared sender/beacon is active. This setting returns a list of 4 pairs of values, i.e. 8 numbers. Each pair of values indicates an <strong>orientation</strong> value and a <strong>distance</strong> value of the infrared sender. The first pair of values is related to channel 1 of the sender, the second pair to channel 2 etc. Orientation values are between -25 and +25. The value of 0 indikates that the infrared signal comes directly from the front. Values out of the -25/+25 range represent angles of 110° to the left or right, respectively. The distance value of the sender is a relative value between 0 (very close) and 100 (far away). Infrared signals may be detected from a maximum distance of 200 cm.</p><p><strong>Example</strong>: Result of an infrared sensor measure is [ 0 0 -10 40 0 0 0 0 ]. This means that on channel 2 the direction of the sender/beacon gives a value of -10, which is about 60 degrees to the left, while the distance value of 35 has been found, which represents nearly 70 cm.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>An exact measurement of distances in cm is not possible with the infrared sonsor.</p></div></div><p>Settins:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»Distance« or »presence«. Select the measuring mode for the infrared sensor.</li><li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your infrared sensor is connected.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>»Distance« mode: number indicating the distance in cm, maximalum distance is 70 cm.</p><p>»Presence« mode: list of numbers.</p></li>
-</ul> </div><div id="robSensors_encoder_reset" class="help beginner"> <h3 id="ProgrammingBlocksEV3-»resetencoder«">»reset encoder«</h3><p>With the block »reset encoder« the internal sensor (motor encoder) of a motor can be reset to 0 .</p><p>Setting:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your motor is connected.</li>
-</ul>     </div><div id="robSensors_encoder_getSample" class="help beginner"> <h3 id="ProgrammingBlocksEV3-»getrotation/degree«rotationsensor">»get rotation/degree« rotation sensor</h3><p>With the block »get rotation/degree« you can "tell" another block the rotation of the motor. The distance is transmitted as a number (in cm). In addition, this block can be set to »degree« in the drop down menu. With this setting the number of degrees is transmitted instead of cm. This block can only be used in conjunction with another block, which requires a number as an input parameter.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Measurement mode, »rotation«, »degree« or»distance«. Select your mode of measurement.</li><li class="typcn typcn-arrow-sorted-down">Encoder port, select the sensor port where your motor/encoder is connected.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, that indicates according to the measurement mode the number of rotations, the degrees, or the distance in cm.</li>
-</ul> </div><div id="robSensors_key_getSample" class="help beginner">  <h3 id="ProgrammingBlocksEV3-»button«EV3buttons">»button« EV3 buttons</h3><p>With the block »button« you can "tell" another block whether the selected button is pressed or not. Available buttons are »enter« / »up« / »down« / »left« / »right« / »escape« / »any«. This block returns logical values <em>true = pressed or false = not pressed</em>.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Button, select the button you want to check.</li>
-</ul><br><p>Return value
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true«, if the selected button has been pressed, »false« otherwise.</li>
-</ul> </div><div id="robSensors_gyro_reset" class="help beginner">  <h3 id="ProgrammingBlocksEV3-»resetgyroscope«">»reset gyroscope«</h3><p>With the block »reset gyroscope« the gyroscope (also called gyro sensor) can be reset to 0.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your gyroscope is connected.</li>
-</ul></div><div id="robSensors_gyro_getSample" class="help beginner"><h3 id="ProgrammingBlocksEV3-»getangle/rate«gyroscope">»get angle/rate« gyroscope</h3><p>With the block »get angle/rate gyroscope« you can "tell" another block the angle in which the gyro sensor was rotated around its vertical axis. The angle is transmitted as a number. Alternatively the return value can be set to »rate« in the drop down menu. This setting allows to send the rotation rate of the sensor in "degrees per second" instead of the angle.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>In mode »rate« a maximum of 440 degrees/second can be captured. In mode »angle« the accuracy of the gyro sensor is +/- 3 degrees.</p></div></div><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Measurement mode: »angle« oder »rate«</li><li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your gyroscope is connected.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, depending from the mode of measurement an angle in degrees or the rate of turns per second.</li>
-</ul> </div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="ProgrammingBlocksEV3-»getvalue«timer">»get value« timer</h3><p>With the block »get value« you can "tell" another block the current time in milliseconds of the internal timer. 5 timers are available.</p><p>Setting:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select the timer you want to read.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, milliseconds since program start or since the last reset of the selected timer.</li>
-</ul> </div><div id="robSensors_timer_reset" class="help beginner"><h3 id="ProgrammingBlocksEV3-»resettimer«">»reset timer«</h3><p>With the block »reset timer« the internal timer (1 to 5) can be reset to the value 0.</p><p>Setting:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Timer number, select the timer you want to reset.</li>
-</ul> </div><div id="robSensors_sound_getSample" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»getsound%soundsensorport...«[Expert-Block]">»get sound % sound sensor port ... « <span class="typcn typcn-star"></span></h3><p>This block allows you to query the volume that the sound sensor measures.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option. choose the Port the sensor is connected to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the volume of the robots surroundings in percent.</li>
-</ul><br> </div><div id="robSensors_compass_calibrate" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»calibrateHTcompasssensorport...«[Expert-Block]">»calibrate HT compass sensor port... « <span class="typcn typcn-star"></span></h3><p>Use this block to recalibrate a connected HT compass sensor. This sensor measures the earth's magnetic field and calculates a current orientation of your robot from its course. In order for this calculation to be as accurate as possible, you must recalibrate the compass sensor at the beginning of your program to reduce disturbing influences such as motors.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the port your sensor is connected to.</li>
-</ul><br> </div><div id="robSensors_compass_getSample" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»get...HTcompasssensorport...«[Expert-Block]">»get ... HT compass sensor port ... « <span class="typcn typcn-star"></span></h3><p>With this block you can request different values of the compass sensor. The compass sensor can measure the angle and compass orientation of your robot. However, you should recalibrate the sensor before using it in your program.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select the property you want to measure. Either the angle of your robot or the compass orientation.</li><li class="typcn typcn-arrow-sorted-down">Option, choose the port your sensor is connected to.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, either the angle of your robot or the compass orientation. Number between 0 and 359.</li>
-</ul> </div><div id="robSensors_irseeker_getSample" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»get...HTinfraredsensorport...«[Expert-Block]">»get ... HT infrared sensor port ... « <span class="typcn typcn-star"></span></h3><p>With this block you can poll the HT infrared sensor of your robot. This sensor sends and receives infrared signals and can calculate the distance to an object.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose between a modulated or an unmodulated signal.</li><li class="typcn typcn-arrow-sorted-down">Option, choose the port your sensor is connected to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, distance to the nearest object in centimeters.</li>
-</ul><br> </div><div id="robSensors_htcolour_getSample" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»get...HTcoloursensorport...«[Expert-Block]">»get ... HT colour sensor port ... « <span class="typcn typcn-star"></span></h3><p>With this block you can query the HT color sensor of your robot. This sensor uses several light emitting diodes to illuminate the background and then measures which color is reflected how much. From these values you can calculate colors and RGB values. The sensor can also measure the brightness of the background and the environment.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select which property you want to measure. You have the choice between color, light, ambient light and RGB splitting.</li><li class="typcn typcn-arrow-sorted-down">Option, choose the port your sensor is connected to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Colour, the colour of the underground.</p><p>Number, the brightness of the underground or surroundings.</p><p>List of numbers, splitting the color of the background into red, green and blue.</p></li>
-</ul><br> </div><div id="robControls_if" class="help beginner"><h3 id="ProgrammingBlocksEV3-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="ProgrammingBlocksEV3-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="ProgrammingBlocksEV3-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="ProgrammingBlocksEV3-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="ProgrammingBlocksEV3-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="ProgrammingBlocksEV3-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="ProgrammingBlocksEV3-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="ProgrammingBlocksEV3-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="ProgrammingBlocksEV3-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="ProgrammingBlocksEV3-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="ProgrammingBlocksEV3-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="ProgrammingBlocksEV3-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="ProgrammingBlocksEV3-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="ProgrammingBlocksEV3-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="ProgrammingBlocksEV3-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="ProgrammingBlocksEV3-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="ProgrammingBlocksEV3-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="ProgrammingBlocksEV3-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="ProgrammingBlocksEV3-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="ProgrammingBlocksEV3-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="ProgrammingBlocksEV3-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="ProgrammingBlocksEV3-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="ProgrammingBlocksEV3-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="ProgrammingBlocksEV3-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="ProgrammingBlocksEV3-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEV3-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="ProgrammingBlocksEV3-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="ProgrammingBlocksEV3-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="ProgrammingBlocksEV3-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="ProgrammingBlocksEV3-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksEV3-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksEV3-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="ProgrammingBlocksEV3-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="ProgrammingBlocksEV3-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEV3-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksEV3-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksEV3-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEV3-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEV3-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEV3-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEV3-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEV3-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEV3-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEV3-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksEV3-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingBlocksEV3-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammingBlocksEV3-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammingBlocksEV3-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingBlocksEV3-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="ProgrammingBlocksEV3-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="ProgrammingBlocksEV3-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammingBlocksEV3-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="ProgrammingBlocksEV3-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammingBlocksEV3-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammingBlocksEV3-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammingBlocksEV3-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="ProgrammingBlocksEV3-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="ProgrammingBlocksEV3-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammingBlocksEV3-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div><div id="robCommunication_startConnection" class="help expert"><h3 id="ProgrammingBlocksEV3-Connecttorobotname[Expertblock]">Connect to robot name <span class="typcn typcn-star"></span></h3><p>A message interchange connection is initiated by an EV3 robot, like a telephone call that is initiated by the caller. You need to know the name of the communication partner.</p><p>The connection between two EV3 robots is stored in a global variable of type "connection". As long as this global variable is valid the message connection is available.</p><p>Step 1: Create a global variable of type "connection".</p><p>Step 2: Enter the name of an EV3 robot that is partner of the message exchange.</p><p>The connection variable of the communication partner will automatically be initiated by using the expert block "wait for connection" (see below). The connection variable will be initiated when the calling EV3 robot has established the connection by using the block "connect to robot name".</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, name of a robot to which a connection shall be started.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Connection object, bound to a global variable.</li>
-</ul><br></div><div id="robCommunication_sendBlock" class="help expert"><h3 id="ProgrammingBlocksEV3-Datatosendviaconnection[Expertblock]">Data to send via connection <span class="typcn typcn-star"></span></h3><p>A text message will be transferred using a global connection variable. The text message will be entered in a text block. To give the connection information to the EV3 robot the value of the global connection variable will be read.</p><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><p>Currently only strings can be sent via bluetooth.</p></div></div><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Message data type, »String«.</li><li class="typcn typcn-arrow-left">String, message to be sent.</li><li class="typcn typcn-arrow-sorted-down">Connection type, »Bluetooth«.</li><li class="typcn typcn-arrow-left">Connection variable, established for the connection.</li>
-</ul><br></div><div id="robCommunication_receiveBlock" class="help expert"><h3 id="ProgrammingBlocksEV3-Datareceivedviaconnection[Expertblock]">Data received via connection <span class="typcn typcn-star"></span></h3><p>A text message will be transferred using a global connection variable. The text message will be transferred into a text block. To give the connection information to the EV3 robot the value of the global connection variable will be read.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Message data type, »String«.</li><li class="typcn typcn-arrow-sorted-down">Connection type, »Bluetooth«.</li><li class="typcn typcn-arrow-left">Connection variable, established for the connection.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, content of the received message.</li>
-</ul><br></div><div id="robCommunication_waitForConnection" class="help expert"><h3 id="ProgrammingBlocksEV3-Waitforconnection[Expertblock]">Wait for connection <span class="typcn typcn-star"></span></h3><p>A message interchange connection is initiated by an EV3 robot, like a telephone call that is initiated by the caller. A robot that is called is waiting for a connection.</p><p>The connection between two EV3 robots is stored in a global variable of type "connection". As long as this global variable is valid the message connection is available.</p><p>Step 1: Create a global variable of type "connection".</p><p>Step 2: The value of the connection variable is set to the expert block "wait for connection".</p><p>The connection variable will be set when the calling EV3 robot has initiated the connection (see above: connect to robot name).</p><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Connection object that may be stored in a connection variable.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»Programstart«"><span style="color: rgb(0,0,0);">»Program start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Each program starts with the red »Program start« block.</p>
+            <p>This block is always available in the Open Roberta Lab and cannot be deleted. The little triangle below
+                the start block is called »sequence connector«. The first block you want to use will be connected by
+                using the »sequence connector« at the start block. The sequence connector color changes to yellow when a
+                suitable block comes into its range.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">create a new global variable</li>
+                <li class="typcn typcn-minus">delete the global variable</li>
+                <li class="typcn typcn-input-checked">show sensor data - while running a program the current values of
+                    connected sensors will be shown on the display</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«,
+                    »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li>
+                <li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial
+                    value of the variable.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»motorport...on«[Expertblock]"><span style="color: rgb(0,0,0);">»motor port ...
+                    on</span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span></h3>
+            <p>With the »motor port ... on« block you can program the speed (velocity) of the selected motor. Your robot
+                starts the selected motor, until it is stopped or another block specifies new moving parameters.</p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">motor port, choose the port where the motor is connected to.
+                </li>
+                <li class="typcn typcn-arrow-left">value, speed between -100 to 100. Negative values let the motor turn
+                    backwards.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on_for" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»motorport...on...for«[Expertblock]"><span style="color: rgb(0,0,0);">»motor
+                    port ... on ... for</span><span style="color: rgb(0,0,0);">« <span
+                        class="typcn typcn-star"></span></span></h3>
+            <p>With the »motor port ... rotation« block you can program the speed (velocity) of the selected motor. Your
+                robot starts the selected motor and rotates the motor until the specified number of rotations or degrees
+                is done. </p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">motor port, choose the one where the motor that you want to
+                    program is connected to.</li>
+                <li class="typcn typcn-arrow-left">number, spped between -100 and 100. 100 is the maximum speed.
+                    Negative values lets the motor rotate into the other direction.</li>
+                <li class="typcn typcn-arrow-sorted-down">rotation or degree. Choose the one which fits best. 1 rotation
+                    is the same than 360 degrees.</li>
+                <li class="typcn typcn-arrow-left">number, rotations or degrees, only positive numbers are allowed.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_getPower" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»getspeedmotorport«[Expertblock]"><span style="color: rgb(0,0,0);">»get speed
+                    motor port</span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span>
+            </h3>
+            <p>The block »<span style="color: rgb(0,0,0);">get speed motor port</span><span style="color: rgb(0,0,0);">
+                </span>« reads the speed (velocity) of the selected motor. The motor can have a speed from -100
+                (rotating backwards) to 100.</p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">motor port, choose the port where the motor is connected to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, the current speed of the motor.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_setPower" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»setmotorportspeed«[Expertblock]"><span style="color: rgb(0,0,0);">»set motor
+                    port <span>speed</span></span><span style="color: rgb(0,0,0);">« <span
+                        class="typcn typcn-star"></span></span></h3>
+            <p>The block »s<span style="color: rgb(0,0,0);">et motor port ... </span><span
+                    style="color: rgb(0,0,0);">speed</span>« sets the speed (velocity) of one selected motor to a new
+                value. </p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">motor port, choose the port where the motor is connected to.
+                </li>
+                <li class="typcn typcn-arrow-left">number, speed between -100 and 100. Negative values let the motor run
+                    backwards.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_stop" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»stopmotorport«[Expertblock]"><span style="color: rgb(0,0,0);">»stop motor
+                    port</span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span></h3>
+            <p>Using the block »s<span>top motor port</span><span> </span>« switches off one selected motor. You can
+                decide the motor to run out slowly (float) or to break immediately</p>
+            <p>Setting options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">motor port, <span>choose the port where the motor is connected
+                        to.</span></li>
+                <li class="typcn typcn-arrow-sorted-down">float or brake; make your choice.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_on" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»drive«">»drive«</h3>
+            <p>With the »drive« block you can program the direction and also the speed (velocity) of your robot.
+                <span>Your robot moves until it is stopped or another block specifies new driving parameters. The
+                    driving speed can be set in the field »speed«.</span></p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">direction, forwards or backwards. Choose the direction.</li>
+                <li class="typcn typcn-arrow-left"><span>number, speed between -100 to 100. 100 is the maximum speed.
+                        Negative values lets the motor rotate into the other direction.</span></li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_on_for" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»drivedistance«">»drive distance«</h3>
+            <p>With the »drive distance« block you can program the direction and the speed of the robot. The speed of
+                your robot is set in the »speed« parameter. Once the block has been executed the motors stop
+                automatically.</p>
+            <p>»drive distance« controls both motors of the robot at the same time, meaning that the settings you make
+                here apply to both motors of the robot. If the robot's actions don't correspond with the block's
+                settings when running the program, check the robot configuration settings, especially the wheel diameter
+                and the track width.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Drive, »forwards« or »backwards«. Select a direction.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100. If the number is negative, the
+                    motors will rotate backwards.</li>
+                <li class="typcn typcn-arrow-left">Number, the distance to drive in cm.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_stop" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»stop«">»stop«</h3>
+            <p>The »stop« block stops the motors immediately.</p>
+            <p>Settings: none</p>
+        </div>
+        <div id="robActions_motorDiff_turn" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»turn«">»turn«</h3>
+            <p>With the »turn« block you set the direction (right/left) which the robot will turn. Your robot turns
+                until it is stopped or another block is used for driving. You can set the speed in the block parameter
+                field »speed«.</p>
+            <p>»turn« controls both motors of the robot at the same time, therefore the robot turns on the spot. If the
+                EV3 Robot's actions don't correspond with the block's settings when running the program, check the EV3
+                robot configuration settings, especially the wheel diameter and the track width.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Turn, »right« or »left«. Select the desired direction for
+                    turning.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100. If the number is negative, the
+                    motors will rotate backwards.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <p>If your robot turns into the wrong direction, then the motors are connected to the wrong ports.
+                        Just swap the ports and your robot will turn into the right way.</p>
+                </div>
+            </div>
+        </div>
+        <div id="robActions_motorDiff_turn_for" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»turndegree«">»turn degree«</h3>
+            <p>With the »turn degree« block you program the direction (right/left) that your robot will turn. In
+                addition to the direction you can also program the »degrees«, allowing you to program how many degrees
+                your robot should rotate (around its axis). This means that you do a complete rotation by setting a 360
+                degree turn..</p>
+            <p>The »turn degree« block controls both motors of the robot in such a way that the robot turns around its
+                own axis. If the robot's actions don't correspond with the block's settings when running the program,
+                check the EV3 robot configuration settings, especially the wheel diameter and the track width.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Turn, »right« or »left«. Select the desired direction for
+                    turning.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100. If the number is negative, the
+                    motors will rotate backwards.</li>
+                <li class="typcn typcn-arrow-left">Number, degrees the robot shall turn. Degree of 360 will perform a
+                    full turn around. Negative numbers are not allowed.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_curve" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammingBlocksEV3-»steer...speedleft...speedright...«">»steer ... speed
+                left ... speed right ...«</h3>
+            <p style="text-align: left;">The block »steer ... speed left ... speed right ...« programs the robot to
+                drive a curve by setting different speeds for the left and right motor. The robot configuration
+                influences the radius of the curve depending from wheel distance and wheel diameter. The turning
+                direction will define the driving direction.</p>
+            <p style="text-align: left;">Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Turning direction, »forwards« or »backwards«. Select your
+                    desired moving direction.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
+                    is negative the motor will run backwards.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
+                    is negative the motor will run backwards.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_curve_for" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammingBlocksEV3-»steer...speedleft...speedright...distance...«">
+                »steer ... speed left ... speed right ... distance ...«</h3>
+            <p style="text-align: left;">The block »steer ... speed left ... speed right ... distance ...« programs the
+                robot to drive a curve by setting different speeds for the left and right motor and also a distance
+                related to the middle between both wheels. The robot configuration influences the radius of the curve
+                depending from wheel distance and wheel diameter. The turning direction will define the driving
+                direction.</p>
+            <p style="text-align: left;">Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Turning direction, »forwards« or »backwards«. Select your
+                    desired moving direction.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
+                    is negative the motor will run backwards.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
+                    is negative the motor will run backwards.</li>
+                <li class="typcn typcn-arrow-left">Number, the distance in cm to be driven.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_display_text" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»showtext«">»show text«</h3>
+            <p>With the »show text« block you can display text and numbers on the display of your robot. You can also
+                specify in which column and row the text or numbers should be displayed on the robot screen.</p>
+            <p>The EV3 display contains some rows and columns, counted from 0 in the top left corner. Depending on the
+                system (lejos or EV3dev) there are different numbers of rows and columns available.</p>
+            <p>If there was text on the display prior to the show text block then the former text will be overwritten.
+            </p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, input of a text string to be shown in the display.</li>
+                <li class="typcn typcn-arrow-left">Number, column for the text to start.</li>
+                <li class="typcn typcn-arrow-left">Number, row for the text to start.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_picture_new" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»showpicture«[Expertblock]">»show picture« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the »show picture« block you can show one of some stored pictures on the EV3 display of your robot.
+                Avaliable pictures are »glasses«, »eyes open«, »eyes closed«, »flowers«, »tacho«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Picture, select one of the available.</li>
+                <li class="typcn typcn-arrow-left">Number for x, column, where the picture shall start.</li>
+                <li class="typcn typcn-arrow-left">Number for y, line, where the picture shall start.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»cleardisplay«">»clear display«</h3>
+            <p>With the »clear display« block you can delete text and numbers on the display of your robot, therefore
+                nothing appears on your display.</p>
+            <p>Settings: none</p>
+        </div>
+        <div id="robActions_play_tone" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»playfrequency«">»play frequency«</h3>
+            <p>With the »play frequency« block you can program the frequency (pitch level) and the time (how long the
+                sound should be played) that a sound is played. The sound is played by the built-in speaker of your LEGO
+                MINDSTORMS EV3 brick for a defined of time. The frequency setting corresponds directly to the frequency
+                in Hertz, for example, setting the frequency to 400 corresponds to 400 Hertz. Example: 261 = C.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p><span>Note that the human ear can perceive frequencies from about 30Hz to about 15,000Hz (15kHz).
+                            This can vary depending on the person and their age.</span></p>
+                </div>
+            </div>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, desired frequency in Hz (Hertz) .</li>
+                <li class="typcn typcn-arrow-left">Number, desired duration in milliseconds (ms).</li>
+            </ul>
+        </div>
+        <div id="mbedActions_play_note" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»playnote...«">»play note ... «</h3>
+            <p>With this block you can make a robot play a note.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the duration of the note.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the note that the robot should play.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_play_file" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»playfile«[Expertblock]">»play file« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>With the »play file« block your robot plays one of five stored sounds.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose between one of the following files:<br>1 =
+                    single beep<br>2 = double beep<br>3 = increasing sound of 4 tones<br>4 = decreasing sound of 4
+                    tones<br>5 = single low tone</li>
+            </ul>
+        </div>
+        <div id="robActions_play_setVolume" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»setvolume«">»set volume«</h3>
+            <p>With the »set volume« block you can program the sound volume played. The volume ranges from 0 (no sound)
+                to 100 (full volume). The volume setting remains unchanged until you change it with another »set volume«
+                block.</p>
+            <p>Setting:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, volume for loudness. 0 = no tone, 100 = maximum volume.</li>
+            </ul>
+        </div>
+        <div id="robActions_play_getVolume" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»getvolume«[Expertblock]">»get volume« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>With the »get volume« block you can read the currend sound volume level.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, currently adjusted volume. 0 = no tone, 100 = maximum volume
+                </li>
+            </ul>
+        </div>
+        <div id="robActions_setLanguage" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»setlanguage...«[ExpertBlock]">»set language ...
+                «<span class="typcn typcn-star"></span></h3>
+            <p>With this block you can control the language of your robot. If you are using C4EV3 as your robot system,
+                you will need to download additional files for the speech. You can find instructions <a
+                    href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo/Set+Up+EV3+-+System+C4EV3">here</a>.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the language.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_sayText" class="help beginner ">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»saytext...«">»say text ... «</h3>
+            <p>With this block you can control the voice output of your robot. The robot uses the language you set with
+                the "Set Language..." block. The default language is German.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the text you want your robot to say.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_sayText_parameters" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»saytext...voicespeed...voicepitch...«[ExpertBlock]"><span
+                    style="color: rgb(85,85,85);font-size: 16.0px;letter-spacing: -0.006em;">» say text ... voice speed
+                    ... voice pitch ... « <span class="typcn typcn-star"></span></span></h3>
+            <p>With this block you can control the voice output of your robot. You can also control your robot's voice
+                pitch and speaking speed.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, text your want your robot to say.</li>
+                <li class="typcn typcn-arrow-left">Number, speaking rate in percent, i.e. my number between 1 and 100,
+                    the higher the number, the faster the robot speaks.</li>
+                <li class="typcn typcn-arrow-left">Number, voice pitch of the robot in percent. Number between 1 and
+                    100, the higher the number, the higher the voice pitch of the robot.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_brickLight_on" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»Bricklight«">»Brick light«</h3>
+            <p>With the »brick light« block you can program the background light of the EV3 buttons. In addition to
+                color, you can also turn on and off the EV3 brick light. The EV3 brick light stays on until you
+                reprogram it. The following colors are available: »green«, »orange« or »red«.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Colour, select a colour.</li>
+                <li class="typcn typcn-arrow-sorted-down">Flash type, »on«, »flashing« or »double flashing«. Select a
+                    flash type for the brick light.</li>
+            </ul>
+        </div>
+        <div id="robActions_brickLight_off" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»Bricklightoff«">»Brick light off«</h3>
+            <p>With the »brick light off« block you can turn off the brick light.</p>
+        </div>
+        <div id="robActions_brickLight_reset" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»resetEV3bricklight«">»reset EV3 brick light«</h3>
+            <p>With the »reset EV3 brick light« block you can reset EV3 brick light back to the default settings.</p>
+            <p>Settings: none</p>
+        </div>
+        <div id="robSensors_touch_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»touchsensor«">»touch sensor«</h3>
+            <p>With the block »touch sensor« you can "tell" another block whether the touch sensor is pressed or not.
+                This block returns the logical values <em>true = pressed</em> or <em>false = not pressed</em>. This
+                block can only be used in conjunction with another block which requires a logical value as an input
+                parameter, for example together with the »if then« block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your touch sensor is
+                    connected.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value: »true«, if the touch sensor is pressed, otherwise
+                    »false«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»getdistance/presence«ultrasonicsensor">»get distance/presence« ultrasonic
+                sensor</h3>
+            <p>With the block »get distance/presence« you "tell" another block the distance the ultrasonic sensor
+                measures. The distance is transmitted as a number (in cm). In addition, this block can be set to
+                "presence" in the drop down menu. This setting can check whether another ultrasonic sensor is active.
+                This setting specifies the logical values <em>true = another ultrasonic sensor is present </em>or<em>
+                    false = no other ultrasonic is present</em> back.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Ultrasound, which was not sent by the own ultrasonic sensor, can result in erroneous
+                        measurements.</p>
+                </div>
+            </div>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Presence or distance; »presence« means that the presence of
+                    another ultrasonic sensor will be checked. »Distance« means that the ultrasonic sensor measures the
+                    distance to the next obstacle.</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your ultrasonic sensor is
+                    connected.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>If »presence« was selected, a boolean value: »true«, if another ultrasonic sensor was detected,
+                        otherwise »false«.</p>
+                    <p>If »distance« was selected, a number, indicating the distance between the ultrasonic sensor and
+                        an obstacle in cm.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_colour_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»getcolourlightsensor/coloursensorPort...«">»get colour light sensor / colour
+                sensor Port ... «</h3>
+            <p>With the block »get colour« you can "tell" another block which color the light sensor measures. The color
+                is transmitted as type »colour« . In addition, this block provides within the drop down menu the
+                settings »light«, »RGB« and »ambient light«. These three additional settings transmit all the same type
+                »number«. The numerical values are between 0 (black) to 100(white). With these various settings this
+                block can be configured according to the specific requirements.</p>
+            <p>In mode »colour« the light sensor emits light and detects the basic colour under the sensor. Values for
+                basic colours are BLACK, WHITE, GREY, RED, GREEN, BLUE, YELLOW, BROWN.</p>
+            <p>In mode »light« the light sensor emits light with its red LED and measures the light intensity of the
+                reflected light on a scale of 0 to 100.</p>
+            <p>In the mode »RGB« the light sensor emits red, green and blue light and measures the reflected light
+                corresponding to the components red, green and blue on a scale from 0 to 100 for each color. A list of
+                three numbers is returned.</p>
+            <p>In mode »ambient light« the same scale (0-100) as in the mode light is used. Here, the ambient light
+                inciding the sensor is measured.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of measurement, select the mode of measurement.</li>
+                <li class="typcn typcn-arrow-sorted-down"> Port, select the sensor port where your light/colour sensor
+                    is connected.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, depending on the selected ode of measurement.</li>
+            </ul>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»givedistance/presence«infraredsensor">»give distance/presence« infrared sensor
+            </h3>
+            <p>With the block »give distance/presence« for infrared sensor you can "tell" another block which distance
+                the infrared sensor measures.</p>
+            <p>Working in the "distance" mode the distance is transmitted as a number with values between 0 (very close)
+                and 100 (far away). In this mode the sensor detects objects in a distance up to 70 cm.</p>
+            <p>In addition, this block can be set to "presence" mode in the drop down menu. With this setting you can
+                check whether an infrared sender/beacon is active. This setting returns a list of 4 pairs of values,
+                i.e. 8 numbers. Each pair of values indicates an <strong>orientation</strong> value and a
+                <strong>distance</strong> value of the infrared sender. The first pair of values is related to channel 1
+                of the sender, the second pair to channel 2 etc. Orientation values are between -25 and +25. The value
+                of 0 indikates that the infrared signal comes directly from the front. Values out of the -25/+25 range
+                represent angles of 110° to the left or right, respectively. The distance value of the sender is a
+                relative value between 0 (very close) and 100 (far away). Infrared signals may be detected from a
+                maximum distance of 200 cm.</p>
+            <p><strong>Example</strong>: Result of an infrared sensor measure is [ 0 0 -10 40 0 0 0 0 ]. This means that
+                on channel 2 the direction of the sender/beacon gives a value of -10, which is about 60 degrees to the
+                left, while the distance value of 35 has been found, which represents nearly 70 cm.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>An exact measurement of distances in cm is not possible with the infrared sonsor.</p>
+                </div>
+            </div>
+            <p>Settins:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»Distance« or »presence«. Select the measuring mode for the
+                    infrared sensor.</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your infrared sensor is
+                    connected.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>»Distance« mode: number indicating the distance in cm, maximalum distance is 70 cm.</p>
+                    <p>»Presence« mode: list of numbers.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_encoder_reset" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»resetencoder«">»reset encoder«</h3>
+            <p>With the block »reset encoder« the internal sensor (motor encoder) of a motor can be reset to 0 .</p>
+            <p>Setting:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your motor is connected.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_encoder_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»getrotation/degree«rotationsensor">»get rotation/degree« rotation sensor</h3>
+            <p>With the block »get rotation/degree« you can "tell" another block the rotation of the motor. The distance
+                is transmitted as a number (in cm). In addition, this block can be set to »degree« in the drop down
+                menu. With this setting the number of degrees is transmitted instead of cm. This block can only be used
+                in conjunction with another block, which requires a number as an input parameter.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Measurement mode, »rotation«, »degree« or»distance«. Select
+                    your mode of measurement.</li>
+                <li class="typcn typcn-arrow-sorted-down">Encoder port, select the sensor port where your motor/encoder
+                    is connected.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, that indicates according to the measurement mode the number
+                    of rotations, the degrees, or the distance in cm.</li>
+            </ul>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»button«EV3buttons">»button« EV3 buttons</h3>
+            <p>With the block »button« you can "tell" another block whether the selected button is pressed or not.
+                Available buttons are »enter« / »up« / »down« / »left« / »right« / »escape« / »any«. This block returns
+                logical values <em>true = pressed or false = not pressed</em>.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Button, select the button you want to check.</li>
+            </ul><br>
+            <p>Return value
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true«, if the selected button has been pressed,
+                    »false« otherwise.</li>
+            </ul>
+        </div>
+        <div id="robSensors_gyro_reset" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»resetgyroscope«">»reset gyroscope«</h3>
+            <p>With the block »reset gyroscope« the gyroscope (also called gyro sensor) can be reset to 0.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your gyroscope is
+                    connected.</li>
+            </ul>
+        </div>
+        <div id="robSensors_gyro_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»getangle/rate«gyroscope">»get angle/rate« gyroscope</h3>
+            <p>With the block »get angle/rate gyroscope« you can "tell" another block the angle in which the gyro sensor
+                was rotated around its vertical axis. The angle is transmitted as a number. Alternatively the return
+                value can be set to »rate« in the drop down menu. This setting allows to send the rotation rate of the
+                sensor in "degrees per second" instead of the angle.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>In mode »rate« a maximum of 440 degrees/second can be captured. In mode »angle« the accuracy of
+                        the gyro sensor is +/- 3 degrees.</p>
+                </div>
+            </div>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Measurement mode: »angle« oder »rate«</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your gyroscope is
+                    connected.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, depending from the mode of measurement an angle in degrees
+                    or the rate of turns per second.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»getvalue«timer">»get value« timer</h3>
+            <p>With the block »get value« you can "tell" another block the current time in milliseconds of the internal
+                timer. 5 timers are available.</p>
+            <p>Setting:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select the timer you want to read.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, milliseconds since program start or since the last reset of
+                    the selected timer.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»resettimer«">»reset timer«</h3>
+            <p>With the block »reset timer« the internal timer (1 to 5) can be reset to the value 0.</p>
+            <p>Setting:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Timer number, select the timer you want to reset.</li>
+            </ul>
+        </div>
+        <div id="robSensors_sound_getSample" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»getsound%soundsensorport...«[Expert-Block]">»get
+                sound % sound sensor port ... « <span class="typcn typcn-star"></span></h3>
+            <p>This block allows you to query the volume that the sound sensor measures.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option. choose the Port the sensor is connected to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the volume of the robots surroundings in percent.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_compass_calibrate" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»calibrateHTcompasssensorport...«[Expert-Block]">
+                »calibrate HT compass sensor port... « <span class="typcn typcn-star"></span></h3>
+            <p>Use this block to recalibrate a connected HT compass sensor. This sensor measures the earth's magnetic
+                field and calculates a current orientation of your robot from its course. In order for this calculation
+                to be as accurate as possible, you must recalibrate the compass sensor at the beginning of your program
+                to reduce disturbing influences such as motors.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the port your sensor is connected to.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_compass_getSample" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»get...HTcompasssensorport...«[Expert-Block]">»get
+                ... HT compass sensor port ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can request different values of the compass sensor. The compass sensor can measure
+                the angle and compass orientation of your robot. However, you should recalibrate the sensor before using
+                it in your program.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select the property you want to measure. Either the
+                    angle of your robot or the compass orientation.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the port your sensor is connected to.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, either the angle of your robot or the compass orientation.
+                    Number between 0 and 359.</li>
+            </ul>
+        </div>
+        <div id="robSensors_irseeker_getSample" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»get...HTinfraredsensorport...«[Expert-Block]">»get
+                ... HT infrared sensor port ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can poll the HT infrared sensor of your robot. This sensor sends and receives
+                infrared signals and can calculate the distance to an object.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose between a modulated or an unmodulated signal.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the port your sensor is connected to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, distance to the nearest object in centimeters.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_htcolour_getSample" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»get...HTcoloursensorport...«[Expert-Block]">»get
+                ... HT colour sensor port ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can query the HT color sensor of your robot. This sensor uses several light emitting
+                diodes to illuminate the background and then measures which color is reflected how much. From these
+                values you can calculate colors and RGB values. The sensor can also measure the brightness of the
+                background and the environment.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select which property you want to measure. You have
+                    the choice between color, light, ambient light and RGB splitting.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the port your sensor is connected to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Colour, the colour of the underground.</p>
+                    <p>Number, the brightness of the underground or surroundings.</p>
+                    <p>List of numbers, splitting the color of the background into red, green and blue.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="ProgrammingBlocksEV3-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue
+                with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammingBlocksEV3-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="ProgrammingBlocksEV3-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»mathematicalfunction«[Expert-block]">»mathematical function« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEV3-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksEV3-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksEV3-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="ProgrammingBlocksEV3-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="ProgrammingBlocksEV3-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEV3-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksEV3-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksEV3-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number«
+                <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEV3-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEV3-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEV3-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEV3-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEV3-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEV3-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEV3-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksEV3-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingBlocksEV3-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingBlocksEV3-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammingBlocksEV3-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingBlocksEV3-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ...
+                green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="ProgrammingBlocksEV3-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ...
+                blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingBlocksEV3-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green
+                ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammingBlocksEV3-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function
+                blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function
+                blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="ProgrammingBlocksEV3-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with
+                return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="ProgrammingBlocksEV3-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function
+                with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-»functioncallwithoutreturnvalue«">»function call without return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksEV3-»functioncallwithreturnvalue«">»function call with
+                return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul>
+        </div>
+        <div id="robCommunication_startConnection" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-Connecttorobotname[Expertblock]">Connect to robot name <span
+                    class="typcn typcn-star"></span></h3>
+            <p>A message interchange connection is initiated by an EV3 robot, like a telephone call that is initiated by
+                the caller. You need to know the name of the communication partner.</p>
+            <p>The connection between two EV3 robots is stored in a global variable of type "connection". As long as
+                this global variable is valid the message connection is available.</p>
+            <p>Step 1: Create a global variable of type "connection".</p>
+            <p>Step 2: Enter the name of an EV3 robot that is partner of the message exchange.</p>
+            <p>The connection variable of the communication partner will automatically be initiated by using the expert
+                block "wait for connection" (see below). The connection variable will be initiated when the calling EV3
+                robot has established the connection by using the block "connect to robot name".</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, name of a robot to which a connection shall be started.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Connection object, bound to a global variable.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_sendBlock" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-Datatosendviaconnection[Expertblock]">Data to send via connection <span
+                    class="typcn typcn-star"></span></h3>
+            <p>A text message will be transferred using a global connection variable. The text message will be entered
+                in a text block. To give the connection information to the EV3 robot the value of the global connection
+                variable will be read.</p>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <p>Currently only strings can be sent via bluetooth.</p>
+                </div>
+            </div>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Message data type, »String«.</li>
+                <li class="typcn typcn-arrow-left">String, message to be sent.</li>
+                <li class="typcn typcn-arrow-sorted-down">Connection type, »Bluetooth«.</li>
+                <li class="typcn typcn-arrow-left">Connection variable, established for the connection.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_receiveBlock" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-Datareceivedviaconnection[Expertblock]">Data received via connection <span
+                    class="typcn typcn-star"></span></h3>
+            <p>A text message will be transferred using a global connection variable. The text message will be
+                transferred into a text block. To give the connection information to the EV3 robot the value of the
+                global connection variable will be read.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Message data type, »String«.</li>
+                <li class="typcn typcn-arrow-sorted-down">Connection type, »Bluetooth«.</li>
+                <li class="typcn typcn-arrow-left">Connection variable, established for the connection.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, content of the received message.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_waitForConnection" class="help expert">
+            <h3 id="ProgrammingBlocksEV3-Waitforconnection[Expertblock]">Wait for connection <span
+                    class="typcn typcn-star"></span></h3>
+            <p>A message interchange connection is initiated by an EV3 robot, like a telephone call that is initiated by
+                the caller. A robot that is called is waiting for a connection.</p>
+            <p>The connection between two EV3 robots is stored in a global variable of type "connection". As long as
+                this global variable is valid the message connection is available.</p>
+            <p>Step 1: Create a global variable of type "connection".</p>
+            <p>Step 2: The value of the connection variable is set to the expert block "wait for connection".</p>
+            <p>The connection variable will be set when the calling EV3 robot has initiated the connection (see above:
+                connect to robot name).</p>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Connection object that may be stored in a connection variable.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_festobionic_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_festobionic_de.html
@@ -1,295 +1,1136 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start_ardu" class="help beginner"><h3 id="BlockbeschreibungBionics4Education-»Programmstart«"><span style="color: rgb(0,0,0);">»Programmstart«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Jedes Programm beginnt mit dem »Programmstart-Block«, welcher nicht gelöscht werden kann. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am Programmstart-Block. </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
-</ul><br><p>Wenn globale Variablen erzeugt wurden:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variablen.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
-</ul></div><div id="robActions_serial_print" class="help beginner"><h3 id="BlockbeschreibungBionics4Education-»ZeigeaufSerialMonitor...«">»Zeige auf Serial Monitor ...«</h3><p>Mit diesem Block kannst du einen Text über die serielle Schnittstelle an deinen Computer übertragen und dort mit einem seriellen Monitor auslesen. Dazu kannst du den eingebauten Seriellen Monitor des Open Roberta Connectors verwenden.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, den text den du auf deinen Computer übertragen möchtest.</li>
-</ul></div><div id="robActions_motor_on_for_ardu" class="help beginner"><h3 id="BlockbeschreibungBionics4Education-»SetzeServomotor...auf°...«">»Setze Servomotor ... auf ° ... «</h3><p>Mit diesem Block kannst du den angeschlossenen Servomotor steuern und seine Postion einstellen. Die Position wird als Winke beschrieben, wobei 360° eine ganze Umdrehung ist.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den Servomotor aus, den du angeschlossen hat.</li><li class="typcn typcn-arrow-right">Zahl, neue Position für den Servomotor, </li>
-</ul></div><div id="robActions_brickLight_on" class="help beginner"><h3 id="BlockbeschreibungBionics4Education-»SchalteLEDan/aus«">»Schalte LED an/aus «</h3><p>Mit diesem Block kannst du eine angeschlossene LED steuern und an- bzw. ausschalten.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du steuern möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option,  wähle  ob du die LED an- oder ausschalten möchtest.</li>
-</ul></div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="BlockbeschreibungBionics4Education-»GibWertZeitgeber...zurück«">»Gib Wert Zeitgeber ... zurück«</h3><p>Mit diesem Block  kannst du den Wert eines Zeitgebers abfragen. Diese geben die Zeit seit dem Start in Millisekunden zurück.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Wähle den Zeitgeber zurück, den du abfragen möchtest. Zeitgeber 1 wird bei Start des Programms automatisch gestartet, alle anderen müssen zunächst durch den Block »Setze Zeitgeber  ... zurück« gestartet werden,</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Zeit seit des Starts oder dem letzten Zurücksetzen in Millisekunden.</li>
-</ul><br></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="BlockbeschreibungBionics4Education-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück«</h3><p>Mit diesem Block kannst du einen der eingebauten Zeitgeber auf Null zurücksetzen. Zudem kannst du einen neuen Zeitgeber starten.
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den Zeitgeber den du zurücksetzen oder  starten möchtest. Es stehen 5 Zeitgeber zur Verfügung.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 class="auto-cursor-target" id="BlockbeschreibungBionics4Education-»Wartebis...«">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wartems...«">»Warte ms ... «</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wartebis...«.1">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Zufallszahl«[Experten-Block]">»Zufallszahl« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBionics4Education-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBionics4Education-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBionics4Education-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBionics4Education-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBionics4Education-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBionics4Education-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungBionics4Education-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="BlockbeschreibungBionics4Education-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockbeschreibungBionics4Education-»Farbwahl«">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="BlockbeschreibungBionics4Education-»Farbwahl«.1">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="BlockbeschreibungBionics4Education-»Farbwahl«.2">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 class="auto-cursor-target" id="BlockbeschreibungBionics4Education-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, die  Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 class="auto-cursor-target" id="BlockbeschreibungBionics4Education-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 class="auto-cursor-target" id="BlockbeschreibungBionics4Education-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="BlockbeschreibungBionics4Education-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="BlockbeschreibungBionics4Education-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="BlockbeschreibungBionics4Education-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="BlockbeschreibungBionics4Education-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="BlockbeschreibungBionics4Education-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="BlockbeschreibungBionics4Education-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="BlockbeschreibungBionics4Education-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="BlockbeschreibungBionics4Education-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen Wert zurück.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="BlockbeschreibungBionics4Education-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit Rückgabewert «</h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start_ardu" class="help beginner">
+            <h3 id="BlockbeschreibungBionics4Education-»Programmstart«"><span
+                    style="color: rgb(0,0,0);">»Programmstart«</span><span style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Programmstart-Block«, welcher nicht gelöscht werden kann. Den ersten
+                Block, den man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am
+                Programmstart-Block. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
+            </ul><br>
+            <p>Wenn globale Variablen erzeugt wurden:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variablen.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
+            </ul>
+        </div>
+        <div id="robActions_serial_print" class="help beginner">
+            <h3 id="BlockbeschreibungBionics4Education-»ZeigeaufSerialMonitor...«">»Zeige auf Serial Monitor ...«</h3>
+            <p>Mit diesem Block kannst du einen Text über die serielle Schnittstelle an deinen Computer übertragen und
+                dort mit einem seriellen Monitor auslesen. Dazu kannst du den eingebauten Seriellen Monitor des Open
+                Roberta Connectors verwenden.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, den text den du auf deinen Computer übertragen möchtest.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on_for_ardu" class="help beginner">
+            <h3 id="BlockbeschreibungBionics4Education-»SetzeServomotor...auf°...«">»Setze Servomotor ... auf ° ... «
+            </h3>
+            <p>Mit diesem Block kannst du den angeschlossenen Servomotor steuern und seine Postion einstellen. Die
+                Position wird als Winke beschrieben, wobei 360° eine ganze Umdrehung ist.</p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Servomotor aus, den du angeschlossen hat.
+                </li>
+                <li class="typcn typcn-arrow-right">Zahl, neue Position für den Servomotor, </li>
+            </ul>
+        </div>
+        <div id="robActions_brickLight_on" class="help beginner">
+            <h3 id="BlockbeschreibungBionics4Education-»SchalteLEDan/aus«">»Schalte LED an/aus «</h3>
+            <p>Mit diesem Block kannst du eine angeschlossene LED steuern und an- bzw. ausschalten.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du steuern möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob du die LED an- oder ausschalten möchtest.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungBionics4Education-»GibWertZeitgeber...zurück«">»Gib Wert Zeitgeber ... zurück«</h3>
+            <p>Mit diesem Block kannst du den Wert eines Zeitgebers abfragen. Diese geben die Zeit seit dem Start in
+                Millisekunden zurück.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Wähle den Zeitgeber zurück, den du abfragen möchtest.
+                    Zeitgeber 1 wird bei Start des Programms automatisch gestartet, alle anderen müssen zunächst durch
+                    den Block »Setze Zeitgeber ... zurück« gestartet werden,</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Zeit seit des Starts oder dem letzten Zurücksetzen in
+                    Millisekunden.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="BlockbeschreibungBionics4Education-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück«</h3>
+            <p>Mit diesem Block kannst du einen der eingebauten Zeitgeber auf Null zurücksetzen. Zudem kannst du einen
+                neuen Zeitgeber starten.
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Zeitgeber den du zurücksetzen oder starten
+                    möchtest. Es stehen 5 Zeitgeber zur Verfügung.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wennmachesonst«">»Wenn mache sonst«
+            </h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wiederholeunendlichoft«">»Wiederhole
+                unendlich oft«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wiederholenmal«">»Wiederhole n mal«
+            </h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungBionics4Education-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»FürWertausderListe«[Experten-Block]">
+                »Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Zählevonbis«[Experten-Block]">»Zähle
+                von bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungBionics4Education-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungBionics4Education-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wartems...«">»Warte ms ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wartebis...«.1">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungBionics4Education-»MathematischeFunktionen«[Experten-Block]">»Mathematische
+                Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungBionics4Education-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische
+                Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Konstanten«[Experten-Block]">
+                »Konstanten« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Zahleneigenschaft«[Experten-Block]">
+                »Zahleneigenschaft« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Erhöheumx«[Experten-Block]">»Erhöhe um
+                x« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»runden«[Experten-Block]">»runden«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Listeauswerten«[Experten-Block]">
+                »Liste auswerten« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Restvon«[Experten-Block]">»Rest von«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Begrenze«[Experten-Block]">»Begrenze«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungBionics4Education-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige
+                Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Zufallszahl«[Experten-Block]">
+                »Zufallszahl« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»ErstelleText«[Experten-Block]">
+                »Erstelle Text« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Textanhängen«[Experten-Block]">»Text
+                anhängen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBionics4Education-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBionics4Education-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element
+                in Liste« <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBionics4Education-»Länge«[Experten-Block]">»Länge« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBionics4Education-»istleer?«[Experten-Block]">»ist leer?« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBionics4Education-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBionics4Education-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungBionics4Education-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="BlockbeschreibungBionics4Education-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockbeschreibungBionics4Education-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="BlockbeschreibungBionics4Education-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="BlockbeschreibungBionics4Education-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungBionics4Education-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit
+                Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungBionics4Education-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot
+                ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungBionics4Education-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot
+                ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="BlockbeschreibungBionics4Education-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="BlockbeschreibungBionics4Education-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3
+                id="BlockbeschreibungBionics4Education-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3
+                id="BlockbeschreibungBionics4Education-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="BlockbeschreibungBionics4Education-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage
+                innerhalb einer Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="BlockbeschreibungBionics4Education-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage
+                innerhalb einer Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="BlockbeschreibungBionics4Education-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage
+                innerhalb einer Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="BlockbeschreibungBionics4Education-»FunktionsaufrufohneRückgabewert«[Experten-Block]">
+                »Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungBionics4Education-»FunktionsaufrufmitRückgabewert«">
+                »Funktionsaufruf mit Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_festobionic_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_festobionic_en.html
@@ -1,313 +1,1146 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start_ardu" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»Programstart«"><span style="color: rgb(0,0,0);">»Program start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Each program starts with the »Start« block, which cannot be deleted. The first block you want to use is connected directly to the »Sequence connection« on the »Repeat indefinitely« block.</p><p>For systems based on an Arduino or similar microcontroller, there is always a »repeat indefinitely« loop connected to the start block, which also cannot be removed. This is due to the fact that such microcontrollers are usually programmed for exactly one task, which then has to be executed again and again. If you only want one run of the program, you can simply make the robot wait at the end of the loop for a very long time.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">create a new global variable</li><li class="typcn typcn-minus">delete the global variable</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable</li><li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«, »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li><li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial value of the variable.</li>
-</ul></div><div id="robActions_serial_print" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»showonSerialMonitor...«">»show on Serial Monitor ... «</h3><p>With this block you can transfer a text via the serial interface to your computer and read it out with a serial monitor. For this you can use the built-in serial monitor of the Open Roberta Connector.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, text you want to transfer to your computer.</li>
-</ul><br></div><div id="robActions_motor_on_for_ardu" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»setservomotor...to°...«">»set servo motor ... to ° ... «</h3><p>With this block you can control the connected servo motor and adjust its position. The position is described as an angle, where 360° is a full rotation.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the connected servo motor that you want to control.</li><li class="typcn typcn-arrow-left">Number, the new angle for the servo motor.</li>
-</ul><br></div><div id="robActions_brickLight_on" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»turnLEDon...«">»turn LED on ... «</h3><p>With this block you can either switch a connected LED on or off.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose which LED to control.</li><li class="typcn typcn-arrow-sorted-down">Option, choose whether to turn the LED on or off.</li>
-</ul><br></div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»getvaluemstimer...«">»get value ms timer ...« </h3><p>With this block you can query the value of one of the build-in timers of your robot. The first timer is automatically started at program start and all other timers can be started by the »reset timer ... « block.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the timer which value want to query.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, time since program start or last reset in milliseconds.</li>
-</ul><br></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»resettimer...«">»reset timer ... «</h3><p>With this block you can reset the value of one of the build-in timers of your robot. The first timer is automatically started at program start and all other timers can be started by this block.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the timer which you want to reset.</li>
-</ul><br></div><div id="robControls_if" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="BlockdescriptionBionics4Education-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="BlockdescriptionBionics4Education-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="BlockdescriptionBionics4Education-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="BlockdescriptionBionics4Education-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="BlockdescriptionBionics4Education-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="BlockdescriptionBionics4Education-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="BlockdescriptionBionics4Education-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="BlockdescriptionBionics4Education-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="BlockdescriptionBionics4Education-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="BlockdescriptionBionics4Education-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="BlockdescriptionBionics4Education-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="BlockdescriptionBionics4Education-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="BlockdescriptionBionics4Education-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="BlockdescriptionBionics4Education-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBionics4Education-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="BlockdescriptionBionics4Education-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="BlockdescriptionBionics4Education-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="BlockdescriptionBionics4Education-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="BlockdescriptionBionics4Education-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionBionics4Education-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionBionics4Education-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="BlockdescriptionBionics4Education-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="BlockdescriptionBionics4Education-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="BlockdescriptionBionics4Education-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBionics4Education-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionBionics4Education-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionBionics4Education-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBionics4Education-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBionics4Education-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBionics4Education-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBionics4Education-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBionics4Education-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBionics4Education-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBionics4Education-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="BlockdescriptionBionics4Education-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockdescriptionBionics4Education-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="BlockdescriptionBionics4Education-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="BlockdescriptionBionics4Education-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockdescriptionBionics4Education-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="BlockdescriptionBionics4Education-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="BlockdescriptionBionics4Education-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="BlockdescriptionBionics4Education-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="BlockdescriptionBionics4Education-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="BlockdescriptionBionics4Education-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="BlockdescriptionBionics4Education-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="BlockdescriptionBionics4Education-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="BlockdescriptionBionics4Education-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="BlockdescriptionBionics4Education-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="BlockdescriptionBionics4Education-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start_ardu" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»Programstart«"><span style="color: rgb(0,0,0);">»Program
+                    start«</span><span style="color: rgb(0,0,0);"> </span></h3>
+            <p>Each program starts with the »Start« block, which cannot be deleted. The first block you want to use is
+                connected directly to the »Sequence connection« on the »Repeat indefinitely« block.</p>
+            <p>For systems based on an Arduino or similar microcontroller, there is always a »repeat indefinitely« loop
+                connected to the start block, which also cannot be removed. This is due to the fact that such
+                microcontrollers are usually programmed for exactly one task, which then has to be executed again and
+                again. If you only want one run of the program, you can simply make the robot wait at the end of the
+                loop for a very long time.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">create a new global variable</li>
+                <li class="typcn typcn-minus">delete the global variable</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«,
+                    »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li>
+                <li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial
+                    value of the variable.</li>
+            </ul>
+        </div>
+        <div id="robActions_serial_print" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»showonSerialMonitor...«">»show on Serial Monitor ... «</h3>
+            <p>With this block you can transfer a text via the serial interface to your computer and read it out with a
+                serial monitor. For this you can use the built-in serial monitor of the Open Roberta Connector.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, text you want to transfer to your computer.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on_for_ardu" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»setservomotor...to°...«">»set servo motor ... to ° ... «</h3>
+            <p>With this block you can control the connected servo motor and adjust its position. The position is
+                described as an angle, where 360° is a full rotation.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the connected servo motor that you want to
+                    control.</li>
+                <li class="typcn typcn-arrow-left">Number, the new angle for the servo motor.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_brickLight_on" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»turnLEDon...«">»turn LED on ... «</h3>
+            <p>With this block you can either switch a connected LED on or off.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose which LED to control.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose whether to turn the LED on or off.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»getvaluemstimer...«">»get value ms timer ...« </h3>
+            <p>With this block you can query the value of one of the build-in timers of your robot. The first timer is
+                automatically started at program start and all other timers can be started by the »reset timer ... «
+                block.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the timer which value want to query.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, time since program start or last reset in milliseconds.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»resettimer...«">»reset timer ... «</h3>
+            <p>With this block you can reset the value of one of the build-in timers of your robot. The first timer is
+                automatically started at program start and all other timers can be started by this block.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the timer which you want to reset.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="BlockdescriptionBionics4Education-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»breakout/continuewithnextiterationofloop«[Expert-block]">»break
+                out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="BlockdescriptionBionics4Education-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="BlockdescriptionBionics4Education-»test«[Expert-block]">»test« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»null«[Expert-block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»mathematicalfunction«[Expert-block]">»mathematical function«
+                <span class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»trigonometricfunctions«[Expert-block]">»trigonometric functions«
+                <span class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»constant«[Expert-block]">»constant« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»round«[Expert-block]">»round« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBionics4Education-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»constrain«[Expert-block]">»constrain« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionBionics4Education-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionBionics4Education-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="BlockdescriptionBionics4Education-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockdescriptionBionics4Education-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="BlockdescriptionBionics4Education-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBionics4Education-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionBionics4Education-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionBionics4Education-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index
+                ... to Number« <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBionics4Education-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBionics4Education-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBionics4Education-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBionics4Education-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBionics4Education-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBionics4Education-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBionics4Education-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionBionics4Education-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockdescriptionBionics4Education-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="BlockdescriptionBionics4Education-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="BlockdescriptionBionics4Education-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockdescriptionBionics4Education-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour
+                with red ... green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="BlockdescriptionBionics4Education-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red
+                ... green ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="BlockdescriptionBionics4Education-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red
+                ... green ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="BlockdescriptionBionics4Education-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»Functionblockswith/withoutinputparametersandnoreturnstatement«">
+                »Function blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»Functionblockswith/withoutinputparameterswithreturnstatements«">
+                »Function blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»ifblocktobeusedwithinafunction«">»if block to be used within a
+                function«</h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="BlockdescriptionBionics4Education-Ifstatementwithinafunctionwithreturnvalue:">If statement within a
+                function with return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="BlockdescriptionBionics4Education-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within
+                a function with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="BlockdescriptionBionics4Education-»functioncallwithoutreturnvalue«">»function call without return
+                value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockdescriptionBionics4Education-»functioncallwithreturnvalue«">
+                »function call with return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_mbot_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_mbot_de.html
@@ -1,391 +1,1494 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start_ardu" class="help beginner"><h3 id="BlockbeschreibungmBot-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am »Wiederhole unendlich oft«-Block.</p><p>Für Systeme, die auf einem Arduino oder einem ähnlichen Mikrocontroller basieren, ist hier immer eine »Wiederhole unendlich oft«-Schleife mit dem Start-Block verbunden, die ebenfalls nicht entfernt werden kann. Dies liegt daran, dass solche Mikrocontroller meistens für genau eine Aufgabe programmiert werden, die dann immer wieder ausgeführt werden soll. Wenn du nur einen Durchlauf des Programm möchtest, kannst du den Roboter am Ende der Schleife einfach für eine sehr lange Zeit warten lassen.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
-</ul><br><p>Wenn globale Variablen erzeugt wurden:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variablen.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
-</ul><br></div><div id="robActions_motorDiff_on_for" class="help beginner"><h3 id="BlockbeschreibungmBot-»Fahre...Tempo%...Zeitms...«"><br>»Fahre ... Tempo % ... Zeit ms ... «</h3><p>Mit diesem Block kannst du deinen mBot in Bewegung setzten. Der mBot fährt dann mit der eingegebenen Geschwindigkeit für die angegebene Zeit.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die dein mBot fahren soll, entweder vorwärts oder rückwärts.</li><li class="typcn typcn-arrow-sorted-down">Zahl, Tempo, mit dem sich dein mBot bewegen soll, zwischen 1 und 100, wobei 1 langsam ist und 100 schnell.</li><li class="typcn typcn-arrow-sorted-down">Zahl, Zeit, für die sich dein mBot bewegen soll, in Millisekunden.</li>
-</ul></div><div id="robActions_motorDiff_on" class="help beginner"><h3 id="BlockbeschreibungmBot-»Fahre...Tempo%...«"><br>»Fahre ... Tempo % ... «</h3><p>Mit diesem Block lässt du deinen mBot in die gewünschte Richtung mit der vorgegebenen Geschwindigkeit fahren, ohne die zu fahrende Zeit vorzugeben. Der Roboter fährt also immer weiter, wenn du ihn nicht stoppst.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die dein Roboter fahren soll.</li><li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter bewegen soll, zwischen 1 und 100, wobei 1 langsam ist und 100 schnell.</li>
-</ul></div><div id="robActions_motorDiff_turn_for" class="help beginner"><h3 id="BlockbeschreibungmBot-»Drehe...Tempo%...Zeitms...«">»Drehe ... Tempo % ... Zeit ms ... «</h3><p>Mit diesem Block lässt sich dein Roboter in die gewünschte Richtung drehen. Dabei dreht sich der Roboter mit der vorgegebenen Geschwindigkeit für die vorgegebene Zeit.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die sich dein Roboter drehen soll.</li><li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter drehen soll, zwischen 1 und 100, wobei 1 langsam ist und 100 schnell.</li><li class="typcn typcn-arrow-left">Zahl, Zeit, für die sich dein Roboter drehen soll, in Millisekunden.</li>
-</ul><br></div><div id="robActions_motorDiff_turn" class="help beginner"><h3 id="BlockbeschreibungmBot-»Drehe...Tempo%...«">»Drehe ... Tempo % ... «</h3><p>Mit diesem Block lässt sich dein Roboter in die gewünschte Richtung drehen. Dabei dreht sich der Roboter mit der vorgegebenen Geschwindigkeit, solange bis du ihn wieder stoppst.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die sich dein Roboter drehen soll.</li><li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter drehen soll, zwischen 1 und 100, wobei 1 langsam ist und 100 schnell.</li>
-</ul></div><div id="robActions_motorDiff_curve_for" class="help beginner"><h3 id="BlockbeschreibungmBot-»Steure...Tempo%links...Tempo%rechts...Zeitms...«">»Steure ... Tempo % links ... Tempo % rechts ... Zeit ms ... «</h3><p>Mit diesem Block kannst du deinen Roboter eine Kurve fahren lassen, indem du die Geschwindigkeit der beiden Motoren unabhängig voneinander einstellen kannst. Zudem kannst du steuern, für wie lange dein Roboter diese Kurve fahren soll.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die dein Roboter fahren soll.</li><li class="typcn typcn-arrow-left">Zahl, Tempo des linken Motors, zwischen 1 und 100.</li><li class="typcn typcn-arrow-left">Zahl, Tempo des rechten Motors, zwischen 1 und 100, wobei 1 langsam ist und 100 schnell.</li><li class="typcn typcn-arrow-left">Zahl, Zeit, für die dein Roboter die Kurve fahren soll, in Millisekunden.</li>
-</ul></div><div id="robActions_motorDiff_curve" class="help beginner"><h3 id="BlockbeschreibungmBot-»Steure...Tempo%links...Tempo%rechts...«">»Steure ... Tempo % links ... Tempo % rechts ... «</h3><p>Mit diesem Block kannst du deinen Roboter eine Kurve fahren lassen, indem du die Geschwindigkeit der beiden Motoren unabhängig voneinander einstellen kannst. Dein Roboter wird diese Kurve immer weiter fahren, bis du ihn stoppst.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die dein Roboter fahren soll.</li><li class="typcn typcn-arrow-left">Zahl, Tempo des linken Motors, zwischen 1 und 100, wobei 1 langsam ist und 100 schnell.</li><li class="typcn typcn-arrow-left">Zahl, Tempo des rechten Motors, zwischen 1 und 100, wobei 1 langsam ist und 100 schnell.</li>
-</ul></div><div id="robActions_motorDiff_stop" class="help beginner"><h3 id="BlockbeschreibungmBot-»Stoppe«">»Stoppe «</h3><p>Dieser Block stoppt deinen Roboter sofort.</p></div><div id="robActions_motor_on_for" class="help expert"><h3 id="BlockbeschreibungmBot-»Motor...anTempo%...Zeitms...«[Experten-Block]">»Motor ... an Tempo % ... Zeit ms ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du einen Motor, der an deinem Roboter angeschlossen ist, steuern. Zudem kannst du die Geschwindigkeit des Motors und die Zeit, für die der Motor laufen soll, steuern.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Motor, den du steuern möchtest.</li><li class="typcn typcn-arrow-left">Zahl, Tempo des Motors, zwischen -100 und 100. Dabei läuft der Motor rückwärts, wenn das Tempo eine negative Zahl ist.</li><li class="typcn typcn-arrow-left">Zahl, Zeit, für die der Motor laufen soll.</li>
-</ul></div><div id="robActions_motor_on" class="help expert"><h3 id="BlockbeschreibungmBot-»Motor...anTempo%...«[Experten-Block]">»Motor ... an Tempo % ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du einen Motor deines Roboters steuern, indem du seine Geschwindigkeit kontrollierst. Der Motor wird mit der angegebenen Geschwindigkeit weiterlaufen, bis du ihn stoppst oder seine Geschwindigkeit änderst.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Motor, den du steuern möchtest.</li><li class="typcn typcn-arrow-left">Zahl, Tempo des Motors, zwischen -100 und 100. Dabei läuft der Motor rückwärts, wenn das Tempo eine negative Zahl ist.</li>
-</ul></div><div id="robActions_motor_stop" class="help expert"><h3 id="BlockbeschreibungmBot-»StoppeMotorPort...«[Experten-Block]">»Stoppe Motor Port ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du einen Motor deines Roboters stoppen.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Motor, den du stoppen möchtest.</li>
-</ul></div><div id="robActions_serial_print" class="help beginner"><h3 id="BlockbeschreibungmBot-»ZeigeaufSerialMonitor«">»Zeige auf Serial Monitor «</h3><p>Mit diesem Block kann dein Roboter eine Zeichenkette über den Serial Bus ausgeben. Um diese Nachrichten empfangen zu können, musst du deinen Roboter per USB mit deinem Computer verbinden.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zeichenkette, Nachricht, die auf dem Serial Monitor ausgegeben werden soll.</li>
-</ul></div><div id="mBotActions_display_text" class="help beginner"><h3 id="BlockbeschreibungmBot-»ZeigeTextLEDMatrixPort...«">»Zeige Text LED Matrix Port ... «</h3><p>Mit diesem Block kannst du einen Text deiner Wahl auf der LED Matrix anzeigen lassen. Der Text wird dabei als Lauftext auf der LED Matrix dargestellt und läuft einmal durch.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den Port aus, an dem die LED Matrix angeschlossen ist.</li><li class="typcn typcn-arrow-left">Zeichenkette, der Text den du anzeigen möchtest.</li>
-</ul></div><div id="mBotActions_display_image" class="help beginner"><h3 id="BlockbeschreibungmBot-»Zeige...LEDMatrixPort...«">»Zeige ... LED Matrix Port ... «</h3><p>Mit diesem Block kannst du entweder ein einzelnes Bild oder eine Abfolge von Bildern auf deiner LED Matrix anzeigen lassen. </p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle ob du ein einzelnes Bild oder eine Abfolge von Bilder anzeigen möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle den Port an dem die LED Matrix angeschlossen ist.</li><li class="typcn typcn-arrow-left">Bild oder Liste von Bildern, das Bild oder die Abfolge von Bildern die du anzeigen möchtest.</li>
-</ul></div><div id="mBotActions_display_clear" class="help beginner"><h3 id="BlockbeschreibungmBot-»LöscheLEDMatrixPort...«">»Lösche LED Matrix Port ... «</h3><p>Mit diesem Block kannst du die LED Matrix zurücksetzen, dabei werden alle LEDs ausgeschaltet.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Port an dem die LED Matrix angeschlossen ist.</li>
-</ul></div><div id="mBotActions_display_setBrightness" class="help expert"><h3 id="BlockbeschreibungmBot-»SetzeHelligkeitLEDMatrixPort...«[Experten-Block]">»Setze Helligkeit LED Matrix Port ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du die Helligkeit der LED Matrix steuern. </p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Port an dem die LED Matrix angeschlossen ist.</li><li class="typcn typcn-arrow-left">Zahl, Helligkeit der LED Matrix, Zahl zwischen 0 und 9, wobei 0 aus bedeutet und 9 die maximale Helligkeit ist.</li>
-</ul></div><div id="robActions_play_tone" class="help expert"><h3 id="BlockbeschreibungmBot-»SpieleFrequenzHz...Dauerms...«[Experten-Block]">»Spiele Frequenz Hz ... Dauer ms ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Roboter kannst du deinen Roboter dazu bringen, einen Ton aus seinem Lautsprecher abzuspielen. Dabei kannst du die Frequenz und die Dauer des Tons steuern.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zahl, Frequenz des Tons, Töne sind nur hörbar zwischen 20 und 20000 Hz.</li><li class="typcn typcn-arrow-sorted-down">Zahl, Dauer, für die der Ton gespielt werden soll.</li>
-</ul></div><div id="mbedActions_play_note" class="help beginner"><h3 id="BlockbeschreibungmBot-»Spiele..Note...«">»Spiele .. Note ... «</h3><p>Mit diesem Block lässt du deinen Roboter eine Note für eine gewisse Zeit spielen.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Spieldauer der Note.</li><li class="typcn typcn-arrow-sorted-down">Option, Note die gespielt werden soll.</li>
-</ul><br></div><div id="robActions_led_on" class="help beginner"><h3 id="BlockbeschreibungmBot-»SchalteLEDan...Farbe...«">»Schalte LED an ... Farbe ... «</h3><p>Mit diesem Block kannst du eine der RGB-LEDs deines Roboters steuern und die LED in einer Farbe leuchten lassen.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Position der LED, die du einschalten möchtest.</li><li class="typcn typcn-arrow-left">Farbe, Farbe, in der die LED leuchten soll.</li>
-</ul></div><div id="robActions_led_off" class="help beginner"><h3 id="BlockbeschreibungmBot-»SchalteLEDaus...«">»Schalte LED aus ...«</h3><p>Mit diesem Block kannst du eine der LEDs deines Roboters ausschalten.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Position der LED, die du ausschalten möchtest.</li>
-</ul></div><div id="robSensors_key_getSample" class="help beginner"><h3 id="BlockbeschreibungmBot-»Tastegedrückt?«">»Taste gedrückt? «</h3><p>Mit diesem Block kannst du den Status der Taste deines mBots abfragen.</p><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr«, wenn die Taste gedrückt ist, sonst »falsch«.</li>
-</ul></div><div id="robSensors_ultrasonic_getSample" class="help beginner"><h3 id="BlockbeschreibungmBot-»GibAbstandcmUltraschallsensorPort...«">»Gib Abstand cm Ultraschallsensor Port ... «</h3><p>Mit diesem Block kannst du deinen Abstandsensor abfragen. Dieser misst den Abstand zum nächsten Hindernis vor dem Roboter, indem er Ultraschallwellen aussendet und misst, wie lange diese brauchen, um zurückzukehren.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Port, an dem der Ultraschallsensor angeschlossen ist.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Abstand zum nächsten Hindernis, in Zentimetern.</li>
-</ul></div><div id="robSensors_infrared_getSample" class="help beginner"><h3 id="BlockbeschreibungmBot-»GibLinieInfrarotsensorPort......«">»Gib Linie Infrarotsensor Port ... ... «</h3><p>Mit diesem Block kannst du den Zustand des Infrarotsensors abfragen. Dieser Sensor misst die Schattierung des Untergrunds durch Infrarot-Licht.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Port, an dem der Sensor angeschlossen ist.</li><li class="typcn typcn-arrow-sorted-down">Option, Position des Sensors, der abgefragt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr«, wenn der Untergrund dunkel ist, sonst »falsch«.</li>
-</ul></div><div id="robSensors_light_getSample" class="help beginner"><h3 id="BlockbeschreibungmBot-»GibLicht%LichtsensorPort...«">»Gib Licht % Lichtsensor Port ... «</h3><p>Mit diesem Block kannst du den Zustand des Lichtsensors abfragen. Dieser Sensor kann die Helligkeit der Umgebung messen.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Port, an dem der Lichtsensor angeschlossen ist.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Helligkeit des Umgebungslicht, zwischen 1 und 100, wobei 1 dunkel und 100 hell ist.</li>
-</ul></div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="BlockbeschreibungmBot-»GibWertmsZeitgeber...«">»Gib Wert ms Zeitgeber ... «</h3><p>Mit diesem Block kannst du den Wert eines Zeitgebers ausgeben.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Nummer des Zeitnehmers, den du abfragen möchtest</li>
-</ul><p class="auto-cursor-target"> Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zahl, Zeit seit dem letzten Zurücksetzen oder Programmstart, in Millisekunden.</li>
-</ul><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Der Zeitgeber 1 wird bei Programmstart automatisch gestartet, er muss zu Beginn nicht manuell zurückgesetzt werden.</p></div></div></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="BlockbeschreibungmBot-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück «</h3><p>Mit diesem Block kannst du einen Zeitgeber zurücksetzen bzw. eine neuen starten, wenn die gewählte Nummer vorher noch keine Zeit gemessen hat.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Nummer des Zeitnehmers, der zurückgesetzt oder gestartet werden soll.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 class="auto-cursor-target" id="BlockbeschreibungmBot-»Wartebis...«">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wartems...«">»Warte ms ... «</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wartebis...«.1">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Zufallszahl«">»Zufallszahl« </h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungmBot-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungmBot-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt werden soll. Zahl zwischen 0 und 255.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungmBot-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungmBot-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von der verwendeten Programmiersprache des Roboters abhängt. </span><span style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt, sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der Zeichenkette »52abcd« die Zahl 52.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungmBot-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li><li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte das die Nummerierung bei 0 anfängt.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungmBot-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungmBot-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungmBot-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungmBot-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungmBot-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungmBot-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungmBot-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="BlockbeschreibungmBot-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockbeschreibungmBot-»Farbwahl«">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="BlockbeschreibungmBot-»Farbwahl«.1">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="BlockbeschreibungmBot-»Farbwahl«.2">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 class="auto-cursor-target" id="BlockbeschreibungmBot-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, die  Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 class="auto-cursor-target" id="BlockbeschreibungmBot-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 class="auto-cursor-target" id="BlockbeschreibungmBot-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="BlockbeschreibungmBot-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="BlockbeschreibungmBot-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="BlockbeschreibungmBot-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="BlockbeschreibungmBot-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="BlockbeschreibungmBot-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="BlockbeschreibungmBot-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="BlockbeschreibungmBot-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="BlockbeschreibungmBot-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen Wert zurück.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="BlockbeschreibungmBot-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit Rückgabewert «</h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
-</ul><br></div><div id="robCommunication_ir_sendBlock" class="help expert"><h3 id="BlockbeschreibungmBot-»SendeNachricht...«">»Sende Nachricht ... «</h3><p>Mit diesem Block kann dein mBot eine Nachricht an alle anderen mBots in der Nähe verschicken.</p><p>Eingabeoption:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, Nachricht, die du versenden möchtest.</li>
-</ul></div><div id="robCommunication_ir_receiveBlock" class="help expert"><h3 id="BlockbeschreibungmBot-»EmpfangeNachricht«">»Empfange Nachricht «</h3><p>Mit diesem Block kann dein mBot Nachrichten von anderen mBots in der Umgebung empfangen.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zeichenkette, empfangene Nachricht von anderen mBots in der Umgebung.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start_ardu" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den
+                man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am »Wiederhole unendlich
+                oft«-Block.</p>
+            <p>Für Systeme, die auf einem Arduino oder einem ähnlichen Mikrocontroller basieren, ist hier immer eine
+                »Wiederhole unendlich oft«-Schleife mit dem Start-Block verbunden, die ebenfalls nicht entfernt werden
+                kann. Dies liegt daran, dass solche Mikrocontroller meistens für genau eine Aufgabe programmiert werden,
+                die dann immer wieder ausgeführt werden soll. Wenn du nur einen Durchlauf des Programm möchtest, kannst
+                du den Roboter am Ende der Schleife einfach für eine sehr lange Zeit warten lassen.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
+            </ul><br>
+            <p>Wenn globale Variablen erzeugt wurden:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variablen.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_on_for" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»Fahre...Tempo%...Zeitms...«"><br>»Fahre ... Tempo % ... Zeit ms ... «</h3>
+            <p>Mit diesem Block kannst du deinen mBot in Bewegung setzten. Der mBot fährt dann mit der eingegebenen
+                Geschwindigkeit für die angegebene Zeit.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die dein mBot fahren soll, entweder
+                    vorwärts oder rückwärts.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahl, Tempo, mit dem sich dein mBot bewegen soll, zwischen 1
+                    und 100, wobei 1 langsam ist und 100 schnell.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahl, Zeit, für die sich dein mBot bewegen soll, in
+                    Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_on" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»Fahre...Tempo%...«"><br>»Fahre ... Tempo % ... «</h3>
+            <p>Mit diesem Block lässt du deinen mBot in die gewünschte Richtung mit der vorgegebenen Geschwindigkeit
+                fahren, ohne die zu fahrende Zeit vorzugeben. Der Roboter fährt also immer weiter, wenn du ihn nicht
+                stoppst.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die dein Roboter fahren soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter bewegen soll, zwischen 1 und
+                    100, wobei 1 langsam ist und 100 schnell.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_turn_for" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»Drehe...Tempo%...Zeitms...«">»Drehe ... Tempo % ... Zeit ms ... «</h3>
+            <p>Mit diesem Block lässt sich dein Roboter in die gewünschte Richtung drehen. Dabei dreht sich der Roboter
+                mit der vorgegebenen Geschwindigkeit für die vorgegebene Zeit.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die sich dein Roboter drehen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter drehen soll, zwischen 1 und
+                    100, wobei 1 langsam ist und 100 schnell.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeit, für die sich dein Roboter drehen soll, in Millisekunden.
+                </li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_turn" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»Drehe...Tempo%...«">»Drehe ... Tempo % ... «</h3>
+            <p>Mit diesem Block lässt sich dein Roboter in die gewünschte Richtung drehen. Dabei dreht sich der Roboter
+                mit der vorgegebenen Geschwindigkeit, solange bis du ihn wieder stoppst.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die sich dein Roboter drehen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter drehen soll, zwischen 1 und
+                    100, wobei 1 langsam ist und 100 schnell.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_curve_for" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»Steure...Tempo%links...Tempo%rechts...Zeitms...«">»Steure ... Tempo % links
+                ... Tempo % rechts ... Zeit ms ... «</h3>
+            <p>Mit diesem Block kannst du deinen Roboter eine Kurve fahren lassen, indem du die Geschwindigkeit der
+                beiden Motoren unabhängig voneinander einstellen kannst. Zudem kannst du steuern, für wie lange dein
+                Roboter diese Kurve fahren soll.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die dein Roboter fahren soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo des linken Motors, zwischen 1 und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo des rechten Motors, zwischen 1 und 100, wobei 1 langsam
+                    ist und 100 schnell.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeit, für die dein Roboter die Kurve fahren soll, in
+                    Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_curve" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»Steure...Tempo%links...Tempo%rechts...«">»Steure ... Tempo % links ... Tempo
+                % rechts ... «</h3>
+            <p>Mit diesem Block kannst du deinen Roboter eine Kurve fahren lassen, indem du die Geschwindigkeit der
+                beiden Motoren unabhängig voneinander einstellen kannst. Dein Roboter wird diese Kurve immer weiter
+                fahren, bis du ihn stoppst.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die dein Roboter fahren soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo des linken Motors, zwischen 1 und 100, wobei 1 langsam
+                    ist und 100 schnell.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo des rechten Motors, zwischen 1 und 100, wobei 1 langsam
+                    ist und 100 schnell.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_stop" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»Stoppe«">»Stoppe «</h3>
+            <p>Dieser Block stoppt deinen Roboter sofort.</p>
+        </div>
+        <div id="robActions_motor_on_for" class="help expert">
+            <h3 id="BlockbeschreibungmBot-»Motor...anTempo%...Zeitms...«[Experten-Block]">»Motor ... an Tempo % ... Zeit
+                ms ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du einen Motor, der an deinem Roboter angeschlossen ist, steuern. Zudem kannst du
+                die Geschwindigkeit des Motors und die Zeit, für die der Motor laufen soll, steuern.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Motor, den du steuern möchtest.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo des Motors, zwischen -100 und 100. Dabei läuft der Motor
+                    rückwärts, wenn das Tempo eine negative Zahl ist.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeit, für die der Motor laufen soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on" class="help expert">
+            <h3 id="BlockbeschreibungmBot-»Motor...anTempo%...«[Experten-Block]">»Motor ... an Tempo % ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du einen Motor deines Roboters steuern, indem du seine Geschwindigkeit
+                kontrollierst. Der Motor wird mit der angegebenen Geschwindigkeit weiterlaufen, bis du ihn stoppst oder
+                seine Geschwindigkeit änderst.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Motor, den du steuern möchtest.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo des Motors, zwischen -100 und 100. Dabei läuft der Motor
+                    rückwärts, wenn das Tempo eine negative Zahl ist.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_stop" class="help expert">
+            <h3 id="BlockbeschreibungmBot-»StoppeMotorPort...«[Experten-Block]">»Stoppe Motor Port ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du einen Motor deines Roboters stoppen.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Motor, den du stoppen möchtest.</li>
+            </ul>
+        </div>
+        <div id="robActions_serial_print" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»ZeigeaufSerialMonitor«">»Zeige auf Serial Monitor «</h3>
+            <p>Mit diesem Block kann dein Roboter eine Zeichenkette über den Serial Bus ausgeben. Um diese Nachrichten
+                empfangen zu können, musst du deinen Roboter per USB mit deinem Computer verbinden.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zeichenkette, Nachricht, die auf dem Serial Monitor ausgegeben
+                    werden soll.</li>
+            </ul>
+        </div>
+        <div id="mBotActions_display_text" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»ZeigeTextLEDMatrixPort...«">»Zeige Text LED Matrix Port ... «</h3>
+            <p>Mit diesem Block kannst du einen Text deiner Wahl auf der LED Matrix anzeigen lassen. Der Text wird dabei
+                als Lauftext auf der LED Matrix dargestellt und läuft einmal durch.</p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Port aus, an dem die LED Matrix
+                    angeschlossen ist.</li>
+                <li class="typcn typcn-arrow-left">Zeichenkette, der Text den du anzeigen möchtest.</li>
+            </ul>
+        </div>
+        <div id="mBotActions_display_image" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»Zeige...LEDMatrixPort...«">»Zeige ... LED Matrix Port ... «</h3>
+            <p>Mit diesem Block kannst du entweder ein einzelnes Bild oder eine Abfolge von Bildern auf deiner LED
+                Matrix anzeigen lassen. </p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob du ein einzelnes Bild oder eine Abfolge von
+                    Bilder anzeigen möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Port an dem die LED Matrix angeschlossen
+                    ist.</li>
+                <li class="typcn typcn-arrow-left">Bild oder Liste von Bildern, das Bild oder die Abfolge von Bildern
+                    die du anzeigen möchtest.</li>
+            </ul>
+        </div>
+        <div id="mBotActions_display_clear" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»LöscheLEDMatrixPort...«">»Lösche LED Matrix Port ... «</h3>
+            <p>Mit diesem Block kannst du die LED Matrix zurücksetzen, dabei werden alle LEDs ausgeschaltet.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Port an dem die LED Matrix angeschlossen ist.</li>
+            </ul>
+        </div>
+        <div id="mBotActions_display_setBrightness" class="help expert">
+            <h3 id="BlockbeschreibungmBot-»SetzeHelligkeitLEDMatrixPort...«[Experten-Block]">»Setze Helligkeit LED
+                Matrix Port ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du die Helligkeit der LED Matrix steuern. </p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Port an dem die LED Matrix angeschlossen ist.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Helligkeit der LED Matrix, Zahl zwischen 0 und 9, wobei 0 aus
+                    bedeutet und 9 die maximale Helligkeit ist.</li>
+            </ul>
+        </div>
+        <div id="robActions_play_tone" class="help expert">
+            <h3 id="BlockbeschreibungmBot-»SpieleFrequenzHz...Dauerms...«[Experten-Block]">»Spiele Frequenz Hz ... Dauer
+                ms ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Roboter kannst du deinen Roboter dazu bringen, einen Ton aus seinem Lautsprecher abzuspielen.
+                Dabei kannst du die Frequenz und die Dauer des Tons steuern.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zahl, Frequenz des Tons, Töne sind nur hörbar zwischen 20 und
+                    20000 Hz.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahl, Dauer, für die der Ton gespielt werden soll.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_play_note" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»Spiele..Note...«">»Spiele .. Note ... «</h3>
+            <p>Mit diesem Block lässt du deinen Roboter eine Note für eine gewisse Zeit spielen.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Spieldauer der Note.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, Note die gespielt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_led_on" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»SchalteLEDan...Farbe...«">»Schalte LED an ... Farbe ... «</h3>
+            <p>Mit diesem Block kannst du eine der RGB-LEDs deines Roboters steuern und die LED in einer Farbe leuchten
+                lassen.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Position der LED, die du einschalten möchtest.</li>
+                <li class="typcn typcn-arrow-left">Farbe, Farbe, in der die LED leuchten soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_off" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»SchalteLEDaus...«">»Schalte LED aus ...«</h3>
+            <p>Mit diesem Block kannst du eine der LEDs deines Roboters ausschalten.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Position der LED, die du ausschalten möchtest.</li>
+            </ul>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»Tastegedrückt?«">»Taste gedrückt? «</h3>
+            <p>Mit diesem Block kannst du den Status der Taste deines mBots abfragen.</p>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr«, wenn die Taste gedrückt ist, sonst »falsch«.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»GibAbstandcmUltraschallsensorPort...«">»Gib Abstand cm Ultraschallsensor Port
+                ... «</h3>
+            <p>Mit diesem Block kannst du deinen Abstandsensor abfragen. Dieser misst den Abstand zum nächsten Hindernis
+                vor dem Roboter, indem er Ultraschallwellen aussendet und misst, wie lange diese brauchen, um
+                zurückzukehren.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Port, an dem der Ultraschallsensor angeschlossen ist.
+                </li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Abstand zum nächsten Hindernis, in Zentimetern.</li>
+            </ul>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»GibLinieInfrarotsensorPort......«">»Gib Linie Infrarotsensor Port ... ... «
+            </h3>
+            <p>Mit diesem Block kannst du den Zustand des Infrarotsensors abfragen. Dieser Sensor misst die Schattierung
+                des Untergrunds durch Infrarot-Licht.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Port, an dem der Sensor angeschlossen ist.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, Position des Sensors, der abgefragt werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr«, wenn der Untergrund dunkel ist, sonst
+                    »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»GibLicht%LichtsensorPort...«">»Gib Licht % Lichtsensor Port ... «</h3>
+            <p>Mit diesem Block kannst du den Zustand des Lichtsensors abfragen. Dieser Sensor kann die Helligkeit der
+                Umgebung messen.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Port, an dem der Lichtsensor angeschlossen ist.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Helligkeit des Umgebungslicht, zwischen 1 und 100, wobei 1
+                    dunkel und 100 hell ist.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»GibWertmsZeitgeber...«">»Gib Wert ms Zeitgeber ... «</h3>
+            <p>Mit diesem Block kannst du den Wert eines Zeitgebers ausgeben.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Nummer des Zeitnehmers, den du abfragen möchtest</li>
+            </ul>
+            <p class="auto-cursor-target"> Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zahl, Zeit seit dem letzten Zurücksetzen oder Programmstart,
+                    in Millisekunden.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Der Zeitgeber 1 wird bei Programmstart automatisch gestartet, er muss zu Beginn nicht manuell
+                        zurückgesetzt werden.</p>
+                </div>
+            </div>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück «</h3>
+            <p>Mit diesem Block kannst du einen Zeitgeber zurücksetzen bzw. eine neuen starten, wenn die gewählte Nummer
+                vorher noch keine Zeit gemessen hat.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Nummer des Zeitnehmers, der zurückgesetzt oder
+                    gestartet werden soll.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wennmachesonst«">»Wenn mache sonst«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«
+            </h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wiederholenmal«">»Wiederhole n mal«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole
+                solange/bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»FürWertausderListe«[Experten-Block]">»Für Wert aus
+                der Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungmBot-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungmBot-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wartems...«">»Warte ms ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wartebis...«.1">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»MathematischeFunktionen«[Experten-Block]">
+                »Mathematische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»TrigonometrischeFunktionen«[Experten-Block]">
+                »Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Konstanten«[Experten-Block]">»Konstanten« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Zahleneigenschaft«[Experten-Block]">
+                »Zahleneigenschaft« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»runden«[Experten-Block]">»runden« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Listeauswerten«[Experten-Block]">»Liste auswerten«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Restvon«[Experten-Block]">»Rest von« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Begrenze«[Experten-Block]">»Begrenze« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»GanzzahligeZufallswerte«[Experten-Block]">
+                »Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Zufallszahl«">»Zufallszahl« </h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungmBot-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette«
+                <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungmBot-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»ErstelleText«[Experten-Block]">»Erstelle Text«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungmBot-»Textanhängen«[Experten-Block]">»Text anhängen«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungmBot-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungmBot-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an
+                Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungmBot-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungmBot-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste«
+                <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungmBot-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungmBot-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungmBot-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungmBot-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungmBot-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="BlockbeschreibungmBot-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockbeschreibungmBot-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="BlockbeschreibungmBot-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="BlockbeschreibungmBot-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungmBot-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün
+                ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungmBot-»FarbemitRot...Grün...Blau...«[Experten-Block]">
+                »Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungmBot-»FarbemitRot...Grün...Blau...«[Experten-Block].1">
+                »Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="BlockbeschreibungmBot-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="BlockbeschreibungmBot-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="BlockbeschreibungmBot-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="BlockbeschreibungmBot-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb
+                einer Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="BlockbeschreibungmBot-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="BlockbeschreibungmBot-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="BlockbeschreibungmBot-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne
+                Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungmBot-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf
+                mit Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_ir_sendBlock" class="help expert">
+            <h3 id="BlockbeschreibungmBot-»SendeNachricht...«">»Sende Nachricht ... «</h3>
+            <p>Mit diesem Block kann dein mBot eine Nachricht an alle anderen mBots in der Nähe verschicken.</p>
+            <p>Eingabeoption:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, Nachricht, die du versenden möchtest.</li>
+            </ul>
+        </div>
+        <div id="robCommunication_ir_receiveBlock" class="help expert">
+            <h3 id="BlockbeschreibungmBot-»EmpfangeNachricht«">»Empfange Nachricht «</h3>
+            <p>Mit diesem Block kann dein mBot Nachrichten von anderen mBots in der Umgebung empfangen.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zeichenkette, empfangene Nachricht von anderen mBots in der
+                    Umgebung.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_mbot_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_mbot_en.html
@@ -1,385 +1,1412 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start_ardu" class="help beginner"><h3 id="BlockdescriptionsmBot-»Programstart«"><span style="color: rgb(0,0,0);">»Program start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Each program starts with the »Start« block, which cannot be deleted. The first block you want to use is connected directly to the »Sequence connection« on the »Repeat indefinitely« block.</p><p>For systems based on an Arduino or similar microcontroller, there is always a »repeat indefinitely« loop connected to the start block, which also cannot be removed. This is due to the fact that such microcontrollers are usually programmed for exactly one task, which then has to be executed again and again. If you only want one run of the program, you can simply make the robot wait at the end of the loop for a very long time.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">create a new global variable</li><li class="typcn typcn-minus">delete the global variable</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable</li><li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«, »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li><li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial value of the variable.</li>
-</ul></div><div id="robActions_motorDiff_on_for" class="help beginner"><h3 id="BlockdescriptionsmBot-»Drive...speed%...timems...«">»Drive ... speed % ... time ms ... «</h3><p>With this block you can move your mBot. The mBot then moves at the entered speed for the specified time.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, direction in which your mBot should move, either forward or backward.</li><li class="typcn typcn-arrow-left">Number, tempo with which your mBot should move. Between 1 and 100, where 1 means »very slow« and 100 »very fast«.</li><li class="typcn typcn-arrow-left">Number, time your mBot should move for, in milliseconds.</li>
-</ul><br></div><div id="robActions_motorDiff_on" class="help beginner"><h3 id="BlockdescriptionsmBot-»Drive...speed%...«">»Drive ... speed % ... «</h3><p>With this block you let your mBot drive in the desired direction with the given speed without setting a time. So the robot will keep going if you don't stop it.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should move.</li><li class="typcn typcn-arrow-left">Number, speed at which your robot should move, between 1 and 100, where 1 means »very slow« and 100 »very fast«.</li>
-</ul></div><div id="robActions_motorDiff_turn_for" class="help beginner"><h3 id="BlockdescriptionsmBot-»Turn...speed%...timems...«">»Turn ... speed % ... time ms ... «</h3><p>With this block you can rotate your robot in the desired direction. The robot rotates at the specified speed for the specified time.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should rotate.</li><li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and 100, where 1 means »very slow« and 100 »very fast«.</li><li class="typcn typcn-arrow-left">Number, time your robot should spin for, in milliseconds.</li>
-</ul></div><div id="robActions_motorDiff_turn" class="help beginner"><h3 id="BlockdescriptionsmBot-»Turn...speed%...«">»Turn ... speed % ... «</h3><p>With this block you can rotate your robot in the desired direction. The robot rotates at the given speed until you stop it again.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should rotate.</li><li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and 100, where 1 means »very slow« and 100 »very fast«.</li>
-</ul></div><div id="robActions_motorDiff_curve_for" class="help beginner"><h3 id="BlockdescriptionsmBot-»Steer...speed%left...speed%right...time...«">»Steer ... speed % left ... speed % right ... time ... «</h3><p>With this block you can let your robot take a curve by setting the speed of the two motors independently of each other. You can also control how long you want your robot to take this turn.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should move.</li><li class="typcn typcn-arrow-left">Number, speed of the left motor, between 1 and 100, where 1 means »very slow« and 100 »very fast«.</li><li class="typcn typcn-arrow-left">Number, speed of the right engine, between 1 and 100, where 1 means »very slow« and 100 »very fast«.</li><li class="typcn typcn-arrow-left">Number, time in milliseconds your robot should take the curve for.</li>
-</ul></div><div id="robActions_motorDiff_curve" class="help beginner"><h3 id="BlockdescriptionsmBot-»Steer...speed%left...speed%right...«">»Steer ... speed % left ... speed % right ... «</h3><p>With this block you can let your robot take a curve by setting the speed of the two motors independently of each other. Your robot will keep driving this curve until you stop it.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should move.</li><li class="typcn typcn-arrow-left">Number, speed of the left motor, between 1 and 100, where 1 means »very slow« and 100 »very fast«.</li><li class="typcn typcn-arrow-left">Number, speed of the right engine, between 1 and 100, where 1 means »very slow« and 100 »very fast«.</li>
-</ul><br></div><div id="robActions_motorDiff_stop" class="help beginner"><h3 id="BlockdescriptionsmBot-»Stop«">»Stop«</h3><p>This block stops your robot immediately.</p></div><div id="robActions_motor_on_for" class="help expert"><h3 id="BlockdescriptionsmBot-»Motor...onspeed%...timems...«[Expert-Block]">»Motor ... on speed % ... time ms ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control a motor connected to your robot. You can also control the speed of the motor and the time the motor should run for.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, motor you want to control.</li><li class="typcn typcn-arrow-left">Number, speed of the motor, between -100 and 100. The motor runs backwards if the speed is a negative number.</li><li class="typcn typcn-arrow-left">Number, time for which the motor should run.</li>
-</ul></div><div id="robActions_motor_on" class="help expert"><h3 id="BlockdescriptionsmBot-»Motor...onspeed%...«[Expert-Block]">»Motor ... on speed % ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control a motor of your robot by controlling its speed. The motor will continue to run at the specified speed until you stop it or change its speed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, motor you want to control.</li><li class="typcn typcn-arrow-left">Number, speed of the motor, between -100 and 100. The motor runs backwards if the speed is a negative number.</li>
-</ul></div><div id="robActions_motor_stop" class="help expert"><h3 id="BlockdescriptionsmBot-»Stopmotorport...«[Expert-Block]">»Stop motor port ... « <span class="typcn typcn-star"></span></h3><p>With this block you can stop an engine of your robot.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, motor you want to stop.</li>
-</ul><br></div><div id="robActions_serial_print" class="help beginner"><h3 id="BlockdescriptionsmBot-»ShowonSerialMonitor«">»Show on Serial Monitor «</h3><p>With this block your robot can output a string via the serial bus. To receive these messages, you need to connect your robot to your computer via USB.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, message to be displayed on the Serial Monitor.</li>
-</ul></div><div id="mBotActions_display_text" class="help beginner"><h3 id="BlockdescriptionsmBot-»showtextLEDmatrixPort...«">»show text LED matrix Port ... «</h3><p>With this block you can display a text of your choice on the LED Matrix. The text is displayed as scrolling text on the LED Matrix and cycles once.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the port your LED matrix is connected to.</li><li class="typcn typcn-arrow-left">string, the string you want to display.</li>
-</ul></div><div id="mBotActions_display_image" class="help beginner"><h3 id="BlockdescriptionsmBot-»show...LEDmatrixPort...«">»show ... LED matrix Port ... «</h3><p>With this block you can display either a single image or a sequence of images on your LED Matrix. </p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose between displaying a single image or a sequence of images as  an  animation.</li><li class="typcn typcn-arrow-sorted-down">option, choose the port the LED matrix is connected to.</li><li class="typcn typcn-arrow-left">image  or list of images, the image  or animation you want to display.</li>
-</ul></div><div id="mBotActions_display_clear" class="help beginner"><h3 id="BlockdescriptionsmBot-»clearLEDmatrixPort...«">»clear LED matrix Port ... «</h3><p>With this block you  can clear the screen of your LED matrix, which will turn off all LEDs.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the port the LED matrix is connected to.</li>
-</ul></div><div id="mBotActions_display_setBrightness" class="help expert"><h3 id="BlockdescriptionsmBot-»setbrightnessLEDmatrixPort...«[Expertblock]">»set brightness LED matrix Port ... «  <span class="typcn typcn-star"></span></h3><p>With this block you can control the brightness of the LED Matrix. </p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the port the LED matrix is connected to.</li><li class="typcn typcn-arrow-left">Number, brightness of the LED matrix, number between 0 and 9, where 0 means off and 9 is the maximum brightness</li>
-</ul></div><div id="robActions_play_tone" class="help expert"><h3 id="BlockdescriptionsmBot-»PlayfrequencyHz...durationms...«[Expert-Block]">»Play frequency Hz ... duration ms ... « <span class="typcn typcn-star"></span></h3><p>With this block you can get your robot to play a sound from its speaker. You can control the frequency and duration of the sound.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, frequency of the tone, tones are only audible between 20 and 20000 Hz.</li><li class="typcn typcn-arrow-left">Number, duration for which the sound is to be played.</li>
-</ul></div><div id="mbedActions_play_note" class="help beginner"><h3 id="BlockdescriptionsmBot-»Play...note...«">»Play ... note ... «</h3><p>With this block you let your robot play a note for a certain time.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, playing time of the note.</li><li class="typcn typcn-arrow-sorted-down">Option, note to be played.</li>
-</ul></div><div id="robActions_led_on" class="help beginner"><h3 id="BlockdescriptionsmBot-»TurnLEDon...colour...«">»Turn LED on ... colour ... «</h3><p>With this block you can control one of the RGB-LEDs of your robot and let the LED light up in one color.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, position of the LED you want to turn on.</li><li class="typcn typcn-arrow-left">Colour, the color in which the LED should light.</li>
-</ul></div><div id="robActions_led_off" class="help beginner"><h3 id="BlockdescriptionsmBot-»TurnLEDoff...«">»Turn LED off ... «</h3><p>With this block you can switch off one of the LEDs of your robot.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, position of the LED you want to turn off.</li>
-</ul></div><div id="robSensors_key_getSample" class="help beginner"><h3 id="BlockdescriptionsmBot-»Buttonpressed?«">»Button pressed? «</h3><p>With this block you can check the status of the button of your mBot.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logical value, »true« if the key is pressed, otherwise »false«.</li>
-</ul></div><div id="robSensors_ultrasonic_getSample" class="help beginner"><h3 id="BlockdescriptionsmBot-»GetdistancecmultrasonicsensorPort...«">»Get distance cm ultrasonic sensor Port ... «</h3><p>With this block you can check your distance sensor. It measures the distance to the next obstacle in front of the robot by emitting ultrasonic waves and measures how long they take to return.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, port to which the ultrasonic sensor is connected.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, distance to the next obstacle, in centimeters.</li>
-</ul><br></div><div id="robSensors_infrared_getSample" class="help beginner"><h3 id="BlockdescriptionsmBot-»GetLineinfraredsensorPort......«">»Get Line infrared sensor Port ... ...«</h3><p>With this block you can query the state of the infrared sensor. This sensor measures the shading of the background by infrared light.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, port to which the sensor is connected.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the sensor to be checked.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logical value, "true" if the background is dark, otherwise "false".</li>
-</ul></div><div id="robSensors_light_getSample" class="help beginner"><h3 id="BlockdescriptionsmBot-»Getlight%lightsensorPort...«">»Get light % light sensor Port ... «</h3><p>With this block you can check the state of the light sensor. This sensor can measure the brightness of the environment.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, port to which the light sensor is connected.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, brightness of the ambient light, between 1 and 100, where 1 means »dark« and 100 »bright«.</li>
-</ul><br></div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="BlockdescriptionsmBot-»Getvaluemstimer...«">»Get value ms timer ... «</h3><p>With this block you can display the value of a timer.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, number of the timekeeper you want to query</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, time since last reset or program start, in milliseconds.</li>
-</ul><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Timer 1 is started automatically at program start, it does not have to be started manually at the beginning.</p></div></div></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="BlockdescriptionsmBot-»Resettimer...«">»Reset timer ... «</h3><p>With this block you can reset a timer or start a new one if the selected number has not measured any time before.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, number of the timekeeper to be reset or started.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 id="BlockdescriptionsmBot-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="BlockdescriptionsmBot-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="BlockdescriptionsmBot-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="BlockdescriptionsmBot-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="BlockdescriptionsmBot-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="BlockdescriptionsmBot-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="BlockdescriptionsmBot-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="BlockdescriptionsmBot-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="BlockdescriptionsmBot-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="BlockdescriptionsmBot-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="BlockdescriptionsmBot-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="BlockdescriptionsmBot-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="BlockdescriptionsmBot-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="BlockdescriptionsmBot-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="BlockdescriptionsmBot-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="BlockdescriptionsmBot-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="BlockdescriptionsmBot-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="BlockdescriptionsmBot-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="BlockdescriptionsmBot-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="BlockdescriptionsmBot-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="BlockdescriptionsmBot-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="BlockdescriptionsmBot-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="BlockdescriptionsmBot-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="BlockdescriptionsmBot-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="BlockdescriptionsmBot-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsmBot-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="BlockdescriptionsmBot-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="BlockdescriptionsmBot-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="BlockdescriptionsmBot-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="BlockdescriptionsmBot-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionsmBot-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionsmBot-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="BlockdescriptionsmBot-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="BlockdescriptionsmBot-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="BlockdescriptionsmBot-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsmBot-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionsmBot-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionsmBot-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsmBot-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsmBot-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsmBot-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsmBot-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsmBot-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsmBot-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsmBot-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsmBot-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockdescriptionsmBot-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="BlockdescriptionsmBot-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="BlockdescriptionsmBot-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockdescriptionsmBot-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="BlockdescriptionsmBot-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="BlockdescriptionsmBot-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="BlockdescriptionsmBot-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="BlockdescriptionsmBot-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="BlockdescriptionsmBot-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="BlockdescriptionsmBot-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="BlockdescriptionsmBot-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="BlockdescriptionsmBot-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="BlockdescriptionsmBot-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="BlockdescriptionsmBot-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="BlockdescriptionsmBot-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div><div id="robCommunication_ir_sendBlock" class="help expert"><h3 id="BlockdescriptionsmBot-»Sendmessage...«">»Send message ... «</h3><p>With this block your mBot can send a message to all other mBots nearby.</p><p>Input option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, message you want to send.</li>
-</ul></div><div id="robCommunication_ir_receiveBlock" class="help expert"><h3 id="BlockdescriptionsmBot-»Receivemessage«">»Receive message«</h3><p>With this block your mBot can receive messages from other mBots in the area.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, received message from other mBots in the environment.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start_ardu" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Programstart«"><span style="color: rgb(0,0,0);">»Program start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Each program starts with the »Start« block, which cannot be deleted. The first block you want to use is
+                connected directly to the »Sequence connection« on the »Repeat indefinitely« block.</p>
+            <p>For systems based on an Arduino or similar microcontroller, there is always a »repeat indefinitely« loop
+                connected to the start block, which also cannot be removed. This is due to the fact that such
+                microcontrollers are usually programmed for exactly one task, which then has to be executed again and
+                again. If you only want one run of the program, you can simply make the robot wait at the end of the
+                loop for a very long time.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">create a new global variable</li>
+                <li class="typcn typcn-minus">delete the global variable</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«,
+                    »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li>
+                <li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial
+                    value of the variable.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_on_for" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Drive...speed%...timems...«">»Drive ... speed % ... time ms ... «</h3>
+            <p>With this block you can move your mBot. The mBot then moves at the entered speed for the specified time.
+            </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, direction in which your mBot should move, either
+                    forward or backward.</li>
+                <li class="typcn typcn-arrow-left">Number, tempo with which your mBot should move. Between 1 and 100,
+                    where 1 means »very slow« and 100 »very fast«.</li>
+                <li class="typcn typcn-arrow-left">Number, time your mBot should move for, in milliseconds.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_on" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Drive...speed%...«">»Drive ... speed % ... «</h3>
+            <p>With this block you let your mBot drive in the desired direction with the given speed without setting a
+                time. So the robot will keep going if you don't stop it.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should move.</li>
+                <li class="typcn typcn-arrow-left">Number, speed at which your robot should move, between 1 and 100,
+                    where 1 means »very slow« and 100 »very fast«.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_turn_for" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Turn...speed%...timems...«">»Turn ... speed % ... time ms ... «</h3>
+            <p>With this block you can rotate your robot in the desired direction. The robot rotates at the specified
+                speed for the specified time.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should rotate.</li>
+                <li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and 100,
+                    where 1 means »very slow« and 100 »very fast«.</li>
+                <li class="typcn typcn-arrow-left">Number, time your robot should spin for, in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_turn" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Turn...speed%...«">»Turn ... speed % ... «</h3>
+            <p>With this block you can rotate your robot in the desired direction. The robot rotates at the given speed
+                until you stop it again.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should rotate.</li>
+                <li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and 100,
+                    where 1 means »very slow« and 100 »very fast«.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_curve_for" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Steer...speed%left...speed%right...time...«">»Steer ... speed % left ...
+                speed % right ... time ... «</h3>
+            <p>With this block you can let your robot take a curve by setting the speed of the two motors independently
+                of each other. You can also control how long you want your robot to take this turn.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should move.</li>
+                <li class="typcn typcn-arrow-left">Number, speed of the left motor, between 1 and 100, where 1 means
+                    »very slow« and 100 »very fast«.</li>
+                <li class="typcn typcn-arrow-left">Number, speed of the right engine, between 1 and 100, where 1 means
+                    »very slow« and 100 »very fast«.</li>
+                <li class="typcn typcn-arrow-left">Number, time in milliseconds your robot should take the curve for.
+                </li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_curve" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Steer...speed%left...speed%right...«">»Steer ... speed % left ... speed %
+                right ... «</h3>
+            <p>With this block you can let your robot take a curve by setting the speed of the two motors independently
+                of each other. Your robot will keep driving this curve until you stop it.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should move.</li>
+                <li class="typcn typcn-arrow-left">Number, speed of the left motor, between 1 and 100, where 1 means
+                    »very slow« and 100 »very fast«.</li>
+                <li class="typcn typcn-arrow-left">Number, speed of the right engine, between 1 and 100, where 1 means
+                    »very slow« and 100 »very fast«.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_stop" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Stop«">»Stop«</h3>
+            <p>This block stops your robot immediately.</p>
+        </div>
+        <div id="robActions_motor_on_for" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»Motor...onspeed%...timems...«[Expert-Block]">»Motor ... on speed % ... time
+                ms ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can control a motor connected to your robot. You can also control the speed of the
+                motor and the time the motor should run for.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, motor you want to control.</li>
+                <li class="typcn typcn-arrow-left">Number, speed of the motor, between -100 and 100. The motor runs
+                    backwards if the speed is a negative number.</li>
+                <li class="typcn typcn-arrow-left">Number, time for which the motor should run.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»Motor...onspeed%...«[Expert-Block]">»Motor ... on speed % ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can control a motor of your robot by controlling its speed. The motor will continue
+                to run at the specified speed until you stop it or change its speed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, motor you want to control.</li>
+                <li class="typcn typcn-arrow-left">Number, speed of the motor, between -100 and 100. The motor runs
+                    backwards if the speed is a negative number.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_stop" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»Stopmotorport...«[Expert-Block]">»Stop motor port ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can stop an engine of your robot.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, motor you want to stop.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_serial_print" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»ShowonSerialMonitor«">»Show on Serial Monitor «</h3>
+            <p>With this block your robot can output a string via the serial bus. To receive these messages, you need to
+                connect your robot to your computer via USB.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, message to be displayed on the Serial Monitor.</li>
+            </ul>
+        </div>
+        <div id="mBotActions_display_text" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»showtextLEDmatrixPort...«">»show text LED matrix Port ... «</h3>
+            <p>With this block you can display a text of your choice on the LED Matrix. The text is displayed as
+                scrolling text on the LED Matrix and cycles once.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the port your LED matrix is connected to.</li>
+                <li class="typcn typcn-arrow-left">string, the string you want to display.</li>
+            </ul>
+        </div>
+        <div id="mBotActions_display_image" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»show...LEDmatrixPort...«">»show ... LED matrix Port ... «</h3>
+            <p>With this block you can display either a single image or a sequence of images on your LED Matrix. </p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose between displaying a single image or a sequence
+                    of images as an animation.</li>
+                <li class="typcn typcn-arrow-sorted-down">option, choose the port the LED matrix is connected to.</li>
+                <li class="typcn typcn-arrow-left">image or list of images, the image or animation you want to display.
+                </li>
+            </ul>
+        </div>
+        <div id="mBotActions_display_clear" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»clearLEDmatrixPort...«">»clear LED matrix Port ... «</h3>
+            <p>With this block you can clear the screen of your LED matrix, which will turn off all LEDs.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the port the LED matrix is connected to.</li>
+            </ul>
+        </div>
+        <div id="mBotActions_display_setBrightness" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»setbrightnessLEDmatrixPort...«[Expertblock]">»set brightness LED matrix Port
+                ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can control the brightness of the LED Matrix. </p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the port the LED matrix is connected to.</li>
+                <li class="typcn typcn-arrow-left">Number, brightness of the LED matrix, number between 0 and 9, where 0
+                    means off and 9 is the maximum brightness</li>
+            </ul>
+        </div>
+        <div id="robActions_play_tone" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»PlayfrequencyHz...durationms...«[Expert-Block]">»Play frequency Hz ...
+                duration ms ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can get your robot to play a sound from its speaker. You can control the frequency
+                and duration of the sound.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, frequency of the tone, tones are only audible between 20 and
+                    20000 Hz.</li>
+                <li class="typcn typcn-arrow-left">Number, duration for which the sound is to be played.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_play_note" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Play...note...«">»Play ... note ... «</h3>
+            <p>With this block you let your robot play a note for a certain time.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, playing time of the note.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, note to be played.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_on" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»TurnLEDon...colour...«">»Turn LED on ... colour ... «</h3>
+            <p>With this block you can control one of the RGB-LEDs of your robot and let the LED light up in one color.
+            </p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the LED you want to turn on.</li>
+                <li class="typcn typcn-arrow-left">Colour, the color in which the LED should light.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_off" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»TurnLEDoff...«">»Turn LED off ... «</h3>
+            <p>With this block you can switch off one of the LEDs of your robot.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the LED you want to turn off.</li>
+            </ul>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Buttonpressed?«">»Button pressed? «</h3>
+            <p>With this block you can check the status of the button of your mBot.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logical value, »true« if the key is pressed, otherwise »false«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»GetdistancecmultrasonicsensorPort...«">»Get distance cm ultrasonic sensor
+                Port ... «</h3>
+            <p>With this block you can check your distance sensor. It measures the distance to the next obstacle in
+                front of the robot by emitting ultrasonic waves and measures how long they take to return.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, port to which the ultrasonic sensor is connected.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, distance to the next obstacle, in centimeters.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»GetLineinfraredsensorPort......«">»Get Line infrared sensor Port ... ...«
+            </h3>
+            <p>With this block you can query the state of the infrared sensor. This sensor measures the shading of the
+                background by infrared light.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, port to which the sensor is connected.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the sensor to be checked.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logical value, "true" if the background is dark, otherwise "false".
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Getlight%lightsensorPort...«">»Get light % light sensor Port ... «</h3>
+            <p>With this block you can check the state of the light sensor. This sensor can measure the brightness of
+                the environment.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, port to which the light sensor is connected.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, brightness of the ambient light, between 1 and 100, where 1
+                    means »dark« and 100 »bright«.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Getvaluemstimer...«">»Get value ms timer ... «</h3>
+            <p>With this block you can display the value of a timer.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, number of the timekeeper you want to query</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, time since last reset or program start, in milliseconds.
+                </li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Timer 1 is started automatically at program start, it does not have to be started manually at the
+                        beginning.</p>
+                </div>
+            </div>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»Resettimer...«">»Reset timer ... «</h3>
+            <p>With this block you can reset a timer or start a new one if the selected number has not measured any time
+                before.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, number of the timekeeper to be reset or started.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="BlockdescriptionsmBot-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue
+                with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="BlockdescriptionsmBot-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="BlockdescriptionsmBot-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»mathematicalfunction«[Expert-block]">»mathematical function« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsmBot-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionsmBot-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionsmBot-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="BlockdescriptionsmBot-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockdescriptionsmBot-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="BlockdescriptionsmBot-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsmBot-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionsmBot-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionsmBot-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number«
+                <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsmBot-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsmBot-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsmBot-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsmBot-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsmBot-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsmBot-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsmBot-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsmBot-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockdescriptionsmBot-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="BlockdescriptionsmBot-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="BlockdescriptionsmBot-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockdescriptionsmBot-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ...
+                green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="BlockdescriptionsmBot-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ...
+                blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="BlockdescriptionsmBot-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green
+                ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="BlockdescriptionsmBot-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function
+                blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function
+                blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="BlockdescriptionsmBot-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function
+                with return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="BlockdescriptionsmBot-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function
+                with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»functioncallwithoutreturnvalue«">»function call without return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockdescriptionsmBot-»functioncallwithreturnvalue«">»function call with
+                return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul>
+        </div>
+        <div id="robCommunication_ir_sendBlock" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»Sendmessage...«">»Send message ... «</h3>
+            <p>With this block your mBot can send a message to all other mBots nearby.</p>
+            <p>Input option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, message you want to send.</li>
+            </ul>
+        </div>
+        <div id="robCommunication_ir_receiveBlock" class="help expert">
+            <h3 id="BlockdescriptionsmBot-»Receivemessage«">»Receive message«</h3>
+            <p>With this block your mBot can receive messages from other mBots in the area.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, received message from other mBots in the environment.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_microbit_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_microbit_de.html
@@ -1,376 +1,1439 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am »Start«-Block.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
-</ul><p class="auto-cursor-target">Wenn globale Variablen erzeugt wurden:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variablen.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
-</ul></div><div id="mbedActions_display_text" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»ZeigeText...«">»Zeige Text ... «</h3><p>Mit diesem Block kannst du einen Text auf dem Bildschirm des micro:bits ausgeben.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Art und Weise wie du den Text auf dem Display darstellen möchtest. Bei »Text« wird der Text als Fließtext von rechts nach links wiedergegeben, bei »Zeichen« werden alle Zeichen nacheinander auf dem Bildschirm wiedergegeben.</li><li class="typcn typcn-arrow-left">Zeichenkette, Text den du auf dem Display darstellen möchtest.</li>
-</ul></div><div id="mbedActions_display_image" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»ZeigeBild...«">»Zeige Bild ... «</h3><p>Mit diesem Block kannst du ein Bild oder eine Animation auf dem Bildschirm des micro:bits darstellen.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Art und Weise wie das Bild dargestellt werden soll. Bei »Bild« wird nur ein einzelnes Bild dargestellt, bei »Animation« wird eine Liste von Bilder hintereinander dargestellt.</li><li class="typcn typcn-arrow-left">Bild oder Liste von Bildern, Das Bild oder die Liste von Bildern, die dargestellt werden sollen.</li>
-</ul></div><div id="mbedActions_display_clear" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»LöscheBildschirm«">»Lösche Bildschirm«</h3><p>Mit diesem Block kannst du den Bildschirm deines micro:bits zurücksetzen. Dabei werden alle LEDs des Bildschirms ausgeschaltet.</p></div><div id="mbedActions_display_setpixel" class="help expert"><h3 id="BlockbeschreibungenMicro:bit-»SetzeLEDx...y...Helligkeit...«[Experten-Block]">»Setze LED x ... y ... Helligkeit ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du die Helligkeit einer einzelnen LED des Bildschirms deines micro:bits steuern.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, x-Koordinate der LED. Die x-Achse läuft parallel zu den langen Seiten des micro:bits. Hier sind ganze Zahlen zwischen 0 und 4 möglich.</li><li class="typcn typcn-arrow-left">Zahl, y-Koordinate der LED. Die y-Achse läuft parallel zu den kurzen Seiten des micro:bits. Hier sind ganze Zahlen zwischen 0 und 4 möglich.</li><li class="typcn typcn-arrow-left">Zahl, gewünschte Helligkeit der LED. je höher die Zahl, desto heller leuchtet die LED; bei 0 wird die LED ausgeschaltet. Hier sind ganze Zahlen zwischen 0 und 9 möglich.</li>
-</ul></div><div id="mbedActions_display_getPixel" class="help expert"><h3 id="BlockbeschreibungenMicro:bit-»GibHelligkeitx...y...«[Experten-Block]">»Gib Helligkeit x ... y ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du die Helligkeit einer LED des Bildschirms deines micro:bits abfragen. Dieser Block gibt die Helligkeit an den verbundenen Block zurück.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, x-Koordinate der LED. Die x-Achse läuft parallel zu den langen Seiten des micro:bits. Hier sind ganze Zahlen zwischen 0 und 4 möglich.</li><li class="typcn typcn-arrow-left">Zahl, y-Koordinate der LED. Die y-Achse läuft parallel zu den kurzen Seiten des micro:bits. Hier sind ganze Zahlen zwischen 0 und 4 möglich.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Helligkeit der LED, je höher die Zahl desto heller leuchtet die LED. Dieser Block gibt eine ganze Zahl zwischen 0 und 9 zurück. 0 bedeutet dabei, dass die LED aus ist.</li>
-</ul></div><div id="robActions_serial_print" class="help expert"><h3 class="auto-cursor-target" id="BlockbeschreibungenMicro:bit-»ZeigeaufSerialMonitor...«[Experten-Block]"><span style="color: rgb(85,85,85);font-size: 16.0px;letter-spacing: -0.006em;">»Zei</span><span style="color: rgb(85,85,85);font-size: 16.0px;letter-spacing: -0.006em;">ge</span><span style="color: rgb(85,85,85);font-size: 16.0px;letter-spacing: -0.006em;"> auf Serial Monitor ... « </span><span class="typcn typcn-star"></span></h3><p class="auto-cursor-target">Mit diesem Block kannst du einen Text auf deinem Computer ausgeben. Dieser Text wird per Serial Port auf deinen Computer übertragen. Wie du einen Serial Monitor einrichtest, kannst du <a href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo/Open+Roberta+Connector">hier </a><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;letter-spacing: 0.0px;">nachlesen.</span></p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, Text den du auf deinem Computer ausgeben möchtest.</li>
-</ul></div><div id="mbedActions_write_to_pin" class="help expert"><h3 id="BlockbeschreibungenMicro:bit-»Schreibe...WertaufPin...«[Experten-Block]">»Schreibe ... Wert auf Pin ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du entweder einen digitalen oder analogen Wert auf einem der Pins deines micro:bits ausgeben.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle aus, ob du einen »digitalen« oder »analogen« Wert auf deinem Pin ausgeben möchtest. Dabei bedeutet »digital« entweder 0 oder 1, »analog« heißt eine Zahl zwischen 0 und 1, also eine Prozentzahl der Gesamtspannung von 3,3,V.</li><li class="typcn typcn-arrow-sorted-down">Option, Pin auf dem du diesen Wert ausgeben möchtest. beachte dabei, dass nicht alle Pins einen »analogen« Wert ausgeben können.</li><li class="typcn typcn-arrow-left">Zahl, Wert den du auf dem Pin ausgeben möchtest. Bei »digital« entweder 0 oder 1, bei »analog« zwischen 0 und 1.</li>
-</ul></div><div id="robSensors_key_getSample" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»Taste...gedrückt?«">»Taste ... gedrückt? «</h3><p>Mit diesem Block kannst du abfragen, ob ein Knopf gerade gedrückt wird oder nicht.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Taste die du abfragen möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Wahrheitswert, »wahr«, wenn die Taste gedrückt wird, sonst »falsch«</li>
-</ul></div><div id="robSensors_gesture_getSample" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»Gib...Lage«">»Gib ... Lage «</h3><p>Mit diesem Block kannst du den Lagesensor deines micro:bits abfragen. Dieser Sensor misst, in welcher Lage sich dein micro.bit befindet.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Lage die du abfragen möchtest. Zur Auswahl stehen folgende Lagen: aufrecht; kopfüber; auf der Vorderseite; auf der Rückseite; geschüttelt; frei fallend.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wahrheitswert, »wahr«, wenn sich der micro:bit in dieser Lage befindet, sonst falsch.</li>
-</ul><br></div><div id="robSensors_compass_getSample" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»GibWinkelKompasssensor«">»Gib Winkel Kompasssensor «</h3><p>Mit diesem Block kannst du den Kompasssensor deines micro:bits abfragen. Dieser Sensor kann den Winkel messen, um den sich dein micro.bit gedreht hat.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Winkel um den dein micro.bit gedreht worden ist. Eine zahl zwischen 0 und 360. Diese zahl steht für den gedrehten Winkel.</li>
-</ul></div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»GibWertmsZeitgeber...«">»Gib Wert ms Zeitgeber ... «</h3><p>Mit diesem Block kannst du den Wert eines Zeitgebers abfragen. Der erste Zeitgeber wird beim Start des Programms automatisch gestartet, alle andren müssen erst mit dem »Setze Zeitgeber ... zurück « gestartet werden.</p><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Zeit seit dem der Zeitgeber gestartet oder zurück gesetzt worden ist. Die Zeit wird in Millisekunden angegeben.</li>
-</ul></div><div id="mbedSensors_timer_reset" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück «</h3><p>Mit diesem Block kannst du den Zeitgeber zurücksetzen.</p></div><div id="robSensors_temperature_getSample" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»GibWertTemperatursensor«">»Gib Wert Temperatursensor «</h3><p>Mit diesem Block kannst du den Temperatursensor des micro:bits abfragen. Dieser kann die Umgebungstemperatur messen.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Umgebungstemperatur gemessen in Grad Celsius.</li>
-</ul></div><div id="robSensors_pintouch_getSample" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»Pin...gedrückt?«">»Pin ... gedrückt? «</h3><p>Mit diesem Block kannst du abfragen, ob gerade einer der großen Pins des micro.bits gedrückt wird. nur die großen Pins mit Nummer 0 bis 2 haben die Sensoren, um eine Berührung zu registrieren.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Nummer des Pins, der abgefragt werden soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Wahrheitswert. »wahr« wenn der Pin gedrückt wird, sonst »falsch«.</li>
-</ul></div><div id="robSensors_pin_getSample" class="help expert"><h3 id="BlockbeschreibungenMicro:bit-»Gib...WertPin...«[Experten-Block]">»Gib ... Wert Pin ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du einen Wert an einem der Pins der micro:bits auslesen. Dieser Wert kann entweder »digital« sein, das bedeutet eine 1 oder eine 0 sein, oder der Wert ist »analog«, kann also zwischen 0 und 1 liegen. Du kannst zudem die Zeit messen, wie lange entweder eine hohe, »Pulszeit HIGH«, oder eine niedrige, »Pulszeit LOW«, an dem Pin registriert wurde.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle aus, ob du einen »digitalen« oder »analogen« Wert oder eine Pulszeit auslesen möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle den Pin aus, an dem du messen möchtest. beachte dabei, dass nicht alle Pins einen analogen Wert messen können. Du kannst sehen, welcher Pin einen analogen Wert messen kann, indem du den analogen Wert auswählst und dann auf die Liste der Pins klickst.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Wert der gemessen wurde. Bei einem digitalen Wert ist diese zahl entweder 0 oder 1, bei einem analogen Wert ist diese Zahl zwischen 0 und 1 und bei einer Pulszeit ist es die gemessene Zeit in Millisekunden.</li>
-</ul></div><div id="robSensors_accelerometer_getSample" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»GibWertmilli-gBeschleunigungssensor...«">»Gib Wert milli-g Beschleunigungssensor ... «</h3><p>Mit diesem Sensor kannst du eine Beschleunigung messen, die auf deinem micro:bit wirkt. Eine Beschleunigung äußert sich immer durch eine wirkende Kraft. Wenn du also z.B. deinen micro:bit in eine Richtung schiebst, übst du eine kraft auf ihn aus und damit eine Beschleunigung. Diese beschleunigung kann der Sensor messen und ihr Wert wird in Einheiten der Erdbeschleunigung gemessen. Dabei gilt 1000 milli-g = 1 g = 9,81 m/s²</p><p><span style="letter-spacing: 0.0px;">Optionen:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Richtung in die du eine Beschleunigung messen möchtest. Dabei ist x die links-rechts-Richtung, y die vorne-hinten-Richtung und z die oben-unten-Richtung. »Stärke« ist zudem die gesamte gemessene Beschleunigung aller Achsen zusammen.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gemessene Beschleunigung als milli-g, also als tausendstel der Erdbeschleunigung.</li>
-</ul></div><div id="robSensors_light_getSample" class="help beginner"><h3 class="auto-cursor-target" id="BlockbeschreibungenMicro:bit-»gibWert%Lichtsensor«">»gib Wert % Lichtsensor «</h3><p>Mit diesem Block kannst du den Lichtsensor deines micro:bits abfragen.</p><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, relative Helligkeit der Umgebung in %.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 class="auto-cursor-target" id="BlockbeschreibungenMicro:bit-»Wartebis...«">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wartems...«">»Warte ms ... «</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wartebis...«.1">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Zufallszahl«">»Zufallszahl« </h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungenMicro:bit-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungenMicro:bit-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt werden soll. Zahl zwischen 0 und 255.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungenMicro:bit-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von der verwendeten Programmiersprache des Roboters abhängt. </span><span style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt, sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der Zeichenkette »52abcd« die Zahl 52.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungenMicro:bit-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li><li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte das die Nummerierung bei 0 anfängt.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungenMicro:bit-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungenMicro:bit-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungenMicro:bit-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungenMicro:bit-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungenMicro:bit-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungenMicro:bit-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungenMicro:bit-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="BlockbeschreibungenMicro:bit-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockbeschreibungenMicro:bit-»Farbwahl«">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="BlockbeschreibungenMicro:bit-»Farbwahl«.1">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="BlockbeschreibungenMicro:bit-»Farbwahl«.2">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 class="auto-cursor-target" id="BlockbeschreibungenMicro:bit-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, die  Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 class="auto-cursor-target" id="BlockbeschreibungenMicro:bit-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 class="auto-cursor-target" id="BlockbeschreibungenMicro:bit-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="BlockbeschreibungenMicro:bit-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="BlockbeschreibungenMicro:bit-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="BlockbeschreibungenMicro:bit-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="BlockbeschreibungenMicro:bit-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="BlockbeschreibungenMicro:bit-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="BlockbeschreibungenMicro:bit-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="BlockbeschreibungenMicro:bit-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen Wert zurück.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="BlockbeschreibungenMicro:bit-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit Rückgabewert «</h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
-</ul><br></div><div id="mbedCommunication_sendBlock" class="help expert"><h3 id="BlockbeschreibungenMicro:bit-»SendeNachricht...mitStärke...«[Experten-Block]">»Sende Nachricht ... mit Stärke ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine Nachricht an andere Roboter in deiner Umgebung senden. Die Nachricht kann dabei entweder eine zahl, ein logischer Wert oder eine Zeichenkette sein.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den Datentyp aus, aus dem deine Nachricht bestehen soll.</li><li class="typcn typcn-arrow-left">Element von gewählten Datentyp, die Nachricht die du verschicken möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, Stärke mit dem du deine Nachricht senden möchtest. Je höher die Stärke ist, desto weiter wird deine Nachricht gesendet.</li>
-</ul><br></div><div id="mbedCommunication_receiveBlock" class="help expert"><h3 id="BlockbeschreibungenMicro:bit-»EmpfangeNachricht...«[Experten-Block]">»Empfange Nachricht ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du Nachrichten von anderen Robotern empfangen. Du kannst dabei einstellen, welche Daten die Nachricht enthalten soll.</span></p><p><span style="letter-spacing: -0.006em;">Optionen:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Datentyp der Nachricht.</li>
-</ul><br><p><span class="auto-cursor-target" style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Element des gewählten Datentyps.</li>
-</ul><br></div><div id="mbedCommunication_setChannel" class="help expert"><h3 id="BlockbeschreibungenMicro:bit-»setzeKanalauf...«[Experten-Block]">»setze Kanal auf ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du den Kanal ändern, auf dem dein Roboter seine Nachrichten sendet und empfängt. Du kannst nur mit anderen Robotern kommunizieren, die auf dem gleichen Kanal senden und empfangen.</span></p><p><span style="letter-spacing: -0.006em;">Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Kanal auf dem du kommunizieren möchtest.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den
+                man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am »Start«-Block.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
+            </ul>
+            <p class="auto-cursor-target">Wenn globale Variablen erzeugt wurden:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variablen.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_text" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»ZeigeText...«">»Zeige Text ... «</h3>
+            <p>Mit diesem Block kannst du einen Text auf dem Bildschirm des micro:bits ausgeben.</p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Art und Weise wie du den Text auf dem Display
+                    darstellen möchtest. Bei »Text« wird der Text als Fließtext von rechts nach links wiedergegeben, bei
+                    »Zeichen« werden alle Zeichen nacheinander auf dem Bildschirm wiedergegeben.</li>
+                <li class="typcn typcn-arrow-left">Zeichenkette, Text den du auf dem Display darstellen möchtest.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_image" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»ZeigeBild...«">»Zeige Bild ... «</h3>
+            <p>Mit diesem Block kannst du ein Bild oder eine Animation auf dem Bildschirm des micro:bits darstellen.</p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Art und Weise wie das Bild dargestellt werden soll.
+                    Bei »Bild« wird nur ein einzelnes Bild dargestellt, bei »Animation« wird eine Liste von Bilder
+                    hintereinander dargestellt.</li>
+                <li class="typcn typcn-arrow-left">Bild oder Liste von Bildern, Das Bild oder die Liste von Bildern, die
+                    dargestellt werden sollen.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_clear" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»LöscheBildschirm«">»Lösche Bildschirm«</h3>
+            <p>Mit diesem Block kannst du den Bildschirm deines micro:bits zurücksetzen. Dabei werden alle LEDs des
+                Bildschirms ausgeschaltet.</p>
+        </div>
+        <div id="mbedActions_display_setpixel" class="help expert">
+            <h3 id="BlockbeschreibungenMicro:bit-»SetzeLEDx...y...Helligkeit...«[Experten-Block]">»Setze LED x ... y ...
+                Helligkeit ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du die Helligkeit einer einzelnen LED des Bildschirms deines micro:bits steuern.
+            </p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, x-Koordinate der LED. Die x-Achse läuft parallel zu den langen
+                    Seiten des micro:bits. Hier sind ganze Zahlen zwischen 0 und 4 möglich.</li>
+                <li class="typcn typcn-arrow-left">Zahl, y-Koordinate der LED. Die y-Achse läuft parallel zu den kurzen
+                    Seiten des micro:bits. Hier sind ganze Zahlen zwischen 0 und 4 möglich.</li>
+                <li class="typcn typcn-arrow-left">Zahl, gewünschte Helligkeit der LED. je höher die Zahl, desto heller
+                    leuchtet die LED; bei 0 wird die LED ausgeschaltet. Hier sind ganze Zahlen zwischen 0 und 9 möglich.
+                </li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_getPixel" class="help expert">
+            <h3 id="BlockbeschreibungenMicro:bit-»GibHelligkeitx...y...«[Experten-Block]">»Gib Helligkeit x ... y ... «
+                <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du die Helligkeit einer LED des Bildschirms deines micro:bits abfragen. Dieser
+                Block gibt die Helligkeit an den verbundenen Block zurück.</p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, x-Koordinate der LED. Die x-Achse läuft parallel zu den langen
+                    Seiten des micro:bits. Hier sind ganze Zahlen zwischen 0 und 4 möglich.</li>
+                <li class="typcn typcn-arrow-left">Zahl, y-Koordinate der LED. Die y-Achse läuft parallel zu den kurzen
+                    Seiten des micro:bits. Hier sind ganze Zahlen zwischen 0 und 4 möglich.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Helligkeit der LED, je höher die Zahl desto heller leuchtet
+                    die LED. Dieser Block gibt eine ganze Zahl zwischen 0 und 9 zurück. 0 bedeutet dabei, dass die LED
+                    aus ist.</li>
+            </ul>
+        </div>
+        <div id="robActions_serial_print" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungenMicro:bit-»ZeigeaufSerialMonitor...«[Experten-Block]">
+                <span style="color: rgb(85,85,85);font-size: 16.0px;letter-spacing: -0.006em;">»Zei</span><span
+                    style="color: rgb(85,85,85);font-size: 16.0px;letter-spacing: -0.006em;">ge</span><span
+                    style="color: rgb(85,85,85);font-size: 16.0px;letter-spacing: -0.006em;"> auf Serial Monitor ... «
+                </span><span class="typcn typcn-star"></span></h3>
+            <p class="auto-cursor-target">Mit diesem Block kannst du einen Text auf deinem Computer ausgeben. Dieser
+                Text wird per Serial Port auf deinen Computer übertragen. Wie du einen Serial Monitor einrichtest,
+                kannst du <a href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo/Open+Roberta+Connector">hier
+                </a><span
+                    style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;letter-spacing: 0.0px;">nachlesen.</span>
+            </p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, Text den du auf deinem Computer ausgeben möchtest.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_write_to_pin" class="help expert">
+            <h3 id="BlockbeschreibungenMicro:bit-»Schreibe...WertaufPin...«[Experten-Block]">»Schreibe ... Wert auf Pin
+                ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du entweder einen digitalen oder analogen Wert auf einem der Pins deines
+                micro:bits ausgeben.</p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle aus, ob du einen »digitalen« oder »analogen«
+                    Wert auf deinem Pin ausgeben möchtest. Dabei bedeutet »digital« entweder 0 oder 1, »analog« heißt
+                    eine Zahl zwischen 0 und 1, also eine Prozentzahl der Gesamtspannung von 3,3,V.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, Pin auf dem du diesen Wert ausgeben möchtest. beachte
+                    dabei, dass nicht alle Pins einen »analogen« Wert ausgeben können.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert den du auf dem Pin ausgeben möchtest. Bei »digital«
+                    entweder 0 oder 1, bei »analog« zwischen 0 und 1.</li>
+            </ul>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»Taste...gedrückt?«">»Taste ... gedrückt? «</h3>
+            <p>Mit diesem Block kannst du abfragen, ob ein Knopf gerade gedrückt wird oder nicht.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Taste die du abfragen möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Wahrheitswert, »wahr«, wenn die Taste gedrückt wird, sonst
+                    »falsch«</li>
+            </ul>
+        </div>
+        <div id="robSensors_gesture_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»Gib...Lage«">»Gib ... Lage «</h3>
+            <p>Mit diesem Block kannst du den Lagesensor deines micro:bits abfragen. Dieser Sensor misst, in welcher
+                Lage sich dein micro.bit befindet.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Lage die du abfragen möchtest. Zur Auswahl stehen
+                    folgende Lagen: aufrecht; kopfüber; auf der Vorderseite; auf der Rückseite; geschüttelt; frei
+                    fallend.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wahrheitswert, »wahr«, wenn sich der micro:bit in dieser Lage
+                    befindet, sonst falsch.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_compass_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»GibWinkelKompasssensor«">»Gib Winkel Kompasssensor «</h3>
+            <p>Mit diesem Block kannst du den Kompasssensor deines micro:bits abfragen. Dieser Sensor kann den Winkel
+                messen, um den sich dein micro.bit gedreht hat.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Winkel um den dein micro.bit gedreht worden ist. Eine zahl
+                    zwischen 0 und 360. Diese zahl steht für den gedrehten Winkel.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»GibWertmsZeitgeber...«">»Gib Wert ms Zeitgeber ... «</h3>
+            <p>Mit diesem Block kannst du den Wert eines Zeitgebers abfragen. Der erste Zeitgeber wird beim Start des
+                Programms automatisch gestartet, alle andren müssen erst mit dem »Setze Zeitgeber ... zurück « gestartet
+                werden.</p>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Zeit seit dem der Zeitgeber gestartet oder zurück gesetzt
+                    worden ist. Die Zeit wird in Millisekunden angegeben.</li>
+            </ul>
+        </div>
+        <div id="mbedSensors_timer_reset" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück «</h3>
+            <p>Mit diesem Block kannst du den Zeitgeber zurücksetzen.</p>
+        </div>
+        <div id="robSensors_temperature_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»GibWertTemperatursensor«">»Gib Wert Temperatursensor «</h3>
+            <p>Mit diesem Block kannst du den Temperatursensor des micro:bits abfragen. Dieser kann die
+                Umgebungstemperatur messen.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Umgebungstemperatur gemessen in Grad Celsius.</li>
+            </ul>
+        </div>
+        <div id="robSensors_pintouch_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»Pin...gedrückt?«">»Pin ... gedrückt? «</h3>
+            <p>Mit diesem Block kannst du abfragen, ob gerade einer der großen Pins des micro.bits gedrückt wird. nur
+                die großen Pins mit Nummer 0 bis 2 haben die Sensoren, um eine Berührung zu registrieren.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Nummer des Pins, der abgefragt werden soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Wahrheitswert. »wahr« wenn der Pin gedrückt wird, sonst
+                    »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_pin_getSample" class="help expert">
+            <h3 id="BlockbeschreibungenMicro:bit-»Gib...WertPin...«[Experten-Block]">»Gib ... Wert Pin ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du einen Wert an einem der Pins der micro:bits auslesen. Dieser Wert kann
+                entweder »digital« sein, das bedeutet eine 1 oder eine 0 sein, oder der Wert ist »analog«, kann also
+                zwischen 0 und 1 liegen. Du kannst zudem die Zeit messen, wie lange entweder eine hohe, »Pulszeit HIGH«,
+                oder eine niedrige, »Pulszeit LOW«, an dem Pin registriert wurde.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle aus, ob du einen »digitalen« oder »analogen«
+                    Wert oder eine Pulszeit auslesen möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Pin aus, an dem du messen möchtest. beachte
+                    dabei, dass nicht alle Pins einen analogen Wert messen können. Du kannst sehen, welcher Pin einen
+                    analogen Wert messen kann, indem du den analogen Wert auswählst und dann auf die Liste der Pins
+                    klickst.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Wert der gemessen wurde. Bei einem digitalen Wert ist diese
+                    zahl entweder 0 oder 1, bei einem analogen Wert ist diese Zahl zwischen 0 und 1 und bei einer
+                    Pulszeit ist es die gemessene Zeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robSensors_accelerometer_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»GibWertmilli-gBeschleunigungssensor...«">»Gib Wert milli-g
+                Beschleunigungssensor ... «</h3>
+            <p>Mit diesem Sensor kannst du eine Beschleunigung messen, die auf deinem micro:bit wirkt. Eine
+                Beschleunigung äußert sich immer durch eine wirkende Kraft. Wenn du also z.B. deinen micro:bit in eine
+                Richtung schiebst, übst du eine kraft auf ihn aus und damit eine Beschleunigung. Diese beschleunigung
+                kann der Sensor messen und ihr Wert wird in Einheiten der Erdbeschleunigung gemessen. Dabei gilt 1000
+                milli-g = 1 g = 9,81 m/s²</p>
+            <p><span style="letter-spacing: 0.0px;">Optionen:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Richtung in die du eine Beschleunigung messen
+                    möchtest. Dabei ist x die links-rechts-Richtung, y die vorne-hinten-Richtung und z die
+                    oben-unten-Richtung. »Stärke« ist zudem die gesamte gemessene Beschleunigung aller Achsen zusammen.
+                </li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gemessene Beschleunigung als milli-g, also als tausendstel der
+                    Erdbeschleunigung.</li>
+            </ul>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungenMicro:bit-»gibWert%Lichtsensor«">»gib Wert %
+                Lichtsensor «</h3>
+            <p>Mit diesem Block kannst du den Lichtsensor deines micro:bits abfragen.</p>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, relative Helligkeit der Umgebung in %.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wennmachesonst«">»Wenn mache sonst«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wiederholeunendlichoft«">»Wiederhole
+                unendlich oft«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wiederholenmal«">»Wiederhole n mal«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wiederholesolange/bis«[Experten-Block]">
+                »Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»FürWertausderListe«[Experten-Block]">»Für
+                Wert aus der Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Zählevonbis«[Experten-Block]">»Zähle von
+                bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungenMicro:bit-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungenMicro:bit-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wartems...«">»Warte ms ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wartebis...«.1">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»MathematischeFunktionen«[Experten-Block]">
+                »Mathematische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungenMicro:bit-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische
+                Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Konstanten«[Experten-Block]">»Konstanten«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Zahleneigenschaft«[Experten-Block]">
+                »Zahleneigenschaft« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Erhöheumx«[Experten-Block]">»Erhöhe um x«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»runden«[Experten-Block]">»runden« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Listeauswerten«[Experten-Block]">»Liste
+                auswerten« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Restvon«[Experten-Block]">»Rest von« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Begrenze«[Experten-Block]">»Begrenze« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»GanzzahligeZufallswerte«[Experten-Block]">
+                »Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Zufallszahl«">»Zufallszahl« </h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungenMicro:bit-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in
+                Zeichenkette« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungenMicro:bit-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen«
+                <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»ErstelleText«[Experten-Block]">»Erstelle
+                Text« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungenMicro:bit-»Textanhängen«[Experten-Block]">»Text
+                anhängen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungenMicro:bit-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungenMicro:bit-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen
+                ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungenMicro:bit-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungenMicro:bit-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in
+                Liste« <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungenMicro:bit-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungenMicro:bit-»istleer?«[Experten-Block]">»ist leer?« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungenMicro:bit-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungenMicro:bit-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungenMicro:bit-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="BlockbeschreibungenMicro:bit-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockbeschreibungenMicro:bit-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="BlockbeschreibungenMicro:bit-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="BlockbeschreibungenMicro:bit-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungenMicro:bit-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot
+                ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungenMicro:bit-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün
+                ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungenMicro:bit-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ...
+                Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="BlockbeschreibungenMicro:bit-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="BlockbeschreibungenMicro:bit-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="BlockbeschreibungenMicro:bit-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="BlockbeschreibungenMicro:bit-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage
+                innerhalb einer Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="BlockbeschreibungenMicro:bit-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage
+                innerhalb einer Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="BlockbeschreibungenMicro:bit-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage
+                innerhalb einer Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="BlockbeschreibungenMicro:bit-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf
+                ohne Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungenMicro:bit-»FunktionsaufrufmitRückgabewert«">
+                »Funktionsaufruf mit Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="mbedCommunication_sendBlock" class="help expert">
+            <h3 id="BlockbeschreibungenMicro:bit-»SendeNachricht...mitStärke...«[Experten-Block]">»Sende Nachricht ...
+                mit Stärke ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine Nachricht an andere Roboter in deiner Umgebung senden. Die Nachricht kann
+                dabei entweder eine zahl, ein logischer Wert oder eine Zeichenkette sein.</p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Datentyp aus, aus dem deine Nachricht
+                    bestehen soll.</li>
+                <li class="typcn typcn-arrow-left">Element von gewählten Datentyp, die Nachricht die du verschicken
+                    möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, Stärke mit dem du deine Nachricht senden möchtest. Je
+                    höher die Stärke ist, desto weiter wird deine Nachricht gesendet.</li>
+            </ul><br>
+        </div>
+        <div id="mbedCommunication_receiveBlock" class="help expert">
+            <h3 id="BlockbeschreibungenMicro:bit-»EmpfangeNachricht...«[Experten-Block]">»Empfange Nachricht ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du Nachrichten von anderen Robotern
+                    empfangen. Du kannst dabei einstellen, welche Daten die Nachricht enthalten soll.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Datentyp der Nachricht.</li>
+            </ul><br>
+            <p><span class="auto-cursor-target" style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Element des gewählten Datentyps.</li>
+            </ul><br>
+        </div>
+        <div id="mbedCommunication_setChannel" class="help expert">
+            <h3 id="BlockbeschreibungenMicro:bit-»setzeKanalauf...«[Experten-Block]">»setze Kanal auf ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du den Kanal ändern, auf dem dein Roboter
+                    seine Nachrichten sendet und empfängt. Du kannst nur mit anderen Robotern kommunizieren, die auf dem
+                    gleichen Kanal senden und empfangen.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Kanal auf dem du kommunizieren möchtest.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_microbit_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_microbit_en.html
@@ -1,373 +1,1355 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»Programstart«">»Program start «</h3><p>Each program starts with the »Program start block«, which cannot be deleted. The first block to be used is connected directly to the »Sequence connection« on the program start block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Create a new global variable.</li><li class="typcn typcn-minus">Remove the global variable.</li>
-</ul><p class="auto-cursor-target">If global variables have been created:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable.</li><li class="typcn typcn-arrow-sorted-down">Type of the variable.</li><li class="typcn typcn-arrow-left">Value, initial value of the variable.</li>
-</ul><br></div><div id="mbedActions_display_text" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»Showtext...«">»Show text ... «</h3><p>With this block you can output a text on the screen of the micro:bit.</p><p>Options and Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, the way you want the text to appear on the display. With »text« the text is displayed as a scrolling text from right to left, with »character« all characters are displayed one after the other on the screen.</li><li class="typcn typcn-arrow-left">String, text that you want to display on your micro:bit.</li>
-</ul></div><div id="mbedActions_display_image" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»Showimage...«">»Show image ... «</h3><p>With this block you can display an image or animation on the micro:bit screen.</p><p>Options and Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, the way the image is to be displayed. With »image« only a single image is displayed, with »animation« a list of images is displayed one after the other.</li><li class="typcn typcn-arrow-left">Image or list of images, the image or the list of images you want to be displayed on your micro:bit.</li>
-</ul></div><div id="mbedActions_display_clear" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»Cleardisplay«">»Clear display«</h3><p>With this block you can clear the display of your micro:bit, that means that all LEDs are turned off.</p></div><div id="mbedActions_display_setpixel" class="help expert"><h3 id="Blockdescriptionmicro:bit-»SetLEDx...y...brightness...«[Expert-block]">»Set LED x ... y ... brightness ... « <span class="typcn typcn-star"></span></h3><p>With this block you can set the brightness of one specific LED to a desired value between 0 and 9, where 0 is off and 9 is the maximum brightness.</p><p>Options and input values
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, x coordinate of the LED you want to control. The x-axis runs parallel to the long side ouf your micro:bit. Possible inputs are integers between 0 and 4.</li><li class="typcn typcn-arrow-left">Number, y coordinate of the LED you want to control. The y-axis runs parallel to the short side of your micro:bit. Possible inputs are integers between 0 and 4.</li><li class="typcn typcn-arrow-left">Number, desired brightness of the LED. 0 means off and 9 is the maximum brightness.</li>
-</ul></div><div id="mbedActions_display_getPixel" class="help expert"><h3 id="Blockdescriptionmicro:bit-»GetLEDbrightnessx...y...«[Expert-block]">»Get LED brightness x ... y ... « <span class="typcn typcn-star"></span></h3><p>With this block you can querry the brightness of on of your micro:bits LEDs.</p><p>Options ans input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, x coordinate of the LED you want to control. The x-axis runs parallel to the long side ouf your micro:bit. Possible inputs are integers between 0 and 4.</li><li class="typcn typcn-arrow-left">Number, y coordinate of the LED you want to control. The y-axis runs parallel to the short side of your micro:bit. Possible inputs are integers between 0 and 4.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, brightness of the chosen LED. This number can be an integer between 0 for off and 9 for maximum brightness.</li>
-</ul></div><div id="robActions_serial_print" class="help expert"><h3 id="Blockdescriptionmicro:bit-»ShowonSerialMonitor...«[Expert-block]">»Show on Serial Monitor ... « <span class="typcn typcn-star"></span></h3><p>With this block you can display a text on your computer. This text is transferred to your computer via serial port. You can read how to set up a Serial Monitor <a href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo/Set+Up+Calliope+mini">here</a>.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the String that you want to display on the connected computer.</li>
-</ul></div><div id="mbedActions_write_to_pin" class="help expert"><h3 id="Blockdescriptionmicro:bit-»Write...valuetopin...«[Expert-block]">»Write ... value to pin ... « <span class="typcn typcn-star"></span></h3><p>With this block you can output either a digital or analog value on one of the pins of your micro:bit.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select whether you want to output a »digital« or »analog« value on your pin. »Digital« means either 0 or 1, »analog« means a number between 0 and 1, i.e. a percentage of the total voltage of 3,3,V.</li><li class="typcn typcn-arrow-sorted-down">Option, pin on which you want to output this value. Note that not all pins can output an "analog" value.</li><li class="typcn typcn-arrow-left">Number, the value that you want to write to the pin. With »digital« this means either 0 or 1 and with »analog« this means a number between 0 and 1.</li>
-</ul></div><div id="robSensors_key_getSample" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»Button..pressed?«">»Button .. pressed?«</h3><p>With this button you can check whether a button is currently being pressed.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, the button that you want to check.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, »true« if the button is being pressed, otherwise »false«</li>
-</ul></div><div id="robSensors_gesture_getSample" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»Get...gesture«">»Get ... gesture «</h3><p>With this block you can check whether your micro.bit is in a certain position or certain gesture is being done.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, gesture or position that you want to check for.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, »true« if the micro:bit is in that position, »false« otherwise.</li>
-</ul></div><div id="robSensors_compass_getSample" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»getangle°compasssensor«">»get angle ° compass sensor «</h3><p>With this block you can check the compass sensor of your micro:bits. This sensor can measure the angle by which your micro.bit has rotated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, angle by which your micro.bit has rotated. This value can be any number between 0 and 360 for a full rotation.</li>
-</ul></div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»getvaluetimer...«">»get value timer ... «</h3><p>With this block you can query the value of a timer. The first timer is started automatically at the start of the program, all other timers have to be set first with the "Set timer ..." button. back " can be started.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the timer you want to check.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, time since the start or the last reset of the timer in millesconds.</li>
-</ul></div><div id="mbedSensors_timer_reset" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»resettimer...«">»reset timer ... «</h3><p>With this block you can reset  the timer of your micro:bit.</p></div><div id="robSensors_temperature_getSample" class="help beginner"><br><h3 id="Blockdescriptionmicro:bit-»getvalue°temperaturesensor«">»get value ° temperature sensor «</h3><p>With this block you can check the temperature sensor for the ambient temperature.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, ambient temperature in degrees Celsius.</li>
-</ul></div><div id="robSensors_pintouch_getSample" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»pin..pressed?«">»pin .. pressed? «</h3><p>With this block you can check whether the chosen pin is pressed by a person. But be aware that not all pins can check whether they are being pressed.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, pin that you want to check.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolena, »true« if the pin is pressed, »false« otherwise.</li>
-</ul></div><div id="robSensors_pin_getSample" class="help expert"><h3 id="Blockdescriptionmicro:bit-»get...valuepin...«[Expert-block]">»get ... value pin ... « <span class="typcn typcn-star"></span></h3><p>With this block you can read a value at one of the pins of the micro:bit. This value can be either »digital«, meaning 1 or 0, or the value can be »analog«, meaning between 0 and 1. You can also measure the time how long either a high, »pulse time HIGH«, or a low, »pulse time LOW«, was registered at the pin.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the type of value or which pulse time you want to check.</li><li class="typcn typcn-arrow-sorted-down">option, select the pin you want to measure against. Note that not all pins can measure an analog value. You can see which pin can measure an analog value by selecting the analog value and then clicking on the list of pins.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, value measured. With a digital value this number is either 0 or 1, with an analog value this number is between 0 and 1 and with a pulse time it is the measured time in milliseconds.</li>
-</ul></div><div id="robSensors_accelerometer_getSample" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»getvaluemilli-gaccelerometer...«">»get value milli-g accelerometer ... «</h3><p>With this sensor you can measure an acceleration that acts on your micro:bit. An acceleration is always expressed by an acting force. For example, if you push your micro:bit in one direction, you exert a force on it and thus an acceleration. The sensor can measure this acceleration and its value is measured in units of acceleration due to gravity. The following applies: 1000 milli-g = 1 g = 9.81 m/s²</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, direction in which you want to measure an acceleration. x is the left-right direction, y the front-back direction and z the top-down direction. »strength« is moreover the total measured acceleration of all axes together.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, measured acceleration as milli-g, i.e. as one thousandth of the acceleration due to gravity.</li>
-</ul></div><div id="robSensors_light_getSample" class="help beginner"><h3 class="auto-cursor-target" id="Blockdescriptionmicro:bit-»getvalue%lightsensor«">»get value % light sensor«</h3><p>With this block you can query the value of your light sensor.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, relative brightness of the robots surroundings.</li>
-</ul><br></div><div id="robControls_if" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="Blockdescriptionmicro:bit-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="Blockdescriptionmicro:bit-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="Blockdescriptionmicro:bit-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="Blockdescriptionmicro:bit-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="Blockdescriptionmicro:bit-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="Blockdescriptionmicro:bit-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="Blockdescriptionmicro:bit-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="Blockdescriptionmicro:bit-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="Blockdescriptionmicro:bit-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="Blockdescriptionmicro:bit-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="Blockdescriptionmicro:bit-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="Blockdescriptionmicro:bit-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="Blockdescriptionmicro:bit-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="Blockdescriptionmicro:bit-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="Blockdescriptionmicro:bit-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="Blockdescriptionmicro:bit-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="Blockdescriptionmicro:bit-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="Blockdescriptionmicro:bit-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="Blockdescriptionmicro:bit-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="Blockdescriptionmicro:bit-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="Blockdescriptionmicro:bit-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="Blockdescriptionmicro:bit-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="Blockdescriptionmicro:bit-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="Blockdescriptionmicro:bit-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="Blockdescriptionmicro:bit-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="Blockdescriptionmicro:bit-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="Blockdescriptionmicro:bit-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="Blockdescriptionmicro:bit-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="Blockdescriptionmicro:bit-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="Blockdescriptionmicro:bit-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="Blockdescriptionmicro:bit-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="Blockdescriptionmicro:bit-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="Blockdescriptionmicro:bit-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="Blockdescriptionmicro:bit-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="Blockdescriptionmicro:bit-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="Blockdescriptionmicro:bit-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="Blockdescriptionmicro:bit-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="Blockdescriptionmicro:bit-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="Blockdescriptionmicro:bit-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="Blockdescriptionmicro:bit-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="Blockdescriptionmicro:bit-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="Blockdescriptionmicro:bit-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="Blockdescriptionmicro:bit-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="Blockdescriptionmicro:bit-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="Blockdescriptionmicro:bit-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="Blockdescriptionmicro:bit-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="Blockdescriptionmicro:bit-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="Blockdescriptionmicro:bit-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="Blockdescriptionmicro:bit-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div><div id="mbedCommunication_sendBlock" class="help expert"><h3 class="auto-cursor-target" id="Blockdescriptionmicro:bit-»sendmessage...withstrength...«[expertblock]">»send message ... with strength ... « <span class="typcn typcn-star"></span></h3><p>With this block you can send a message to other robots in your environment. The message can be either a number, a logical value or a string.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the data type of the message that you want to send.</li><li class="typcn typcn-arrow-left">element of the chosen data type, the message that you want to send to other robots.</li><li class="typcn typcn-arrow-sorted-down">option, strength with which you want to send your message. The higher the strength, the further your message will be sent.</li>
-</ul><br></div><div id="mbedCommunication_receiveBlock" class="help expert"><h3 class="auto-cursor-target" id="Blockdescriptionmicro:bit-»receivemessage...«[expertblock]">»receive message ... « <span class="typcn typcn-star"></span></h3><p>With this block you can receive messages from other robots. You can choose which data the message should contain.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, data type of the message.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">element of the data type, received message.</li>
-</ul><br></div><div id="mbedCommunication_setChannel" class="help expert"><h3 class="auto-cursor-target" id="Blockdescriptionmicro:bit-»setchannelto...«[expertblock]">»set channel to ...« <span class="typcn typcn-star"></span></h3><p>With this block you can change the channel on which your robot sends and receives its messages. You can only communicate with other robots that send and receive on the same channel.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, channel that you want to communicate on with other robots.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»Programstart«">»Program start «</h3>
+            <p>Each program starts with the »Program start block«, which cannot be deleted. The first block to be used
+                is connected directly to the »Sequence connection« on the program start block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Create a new global variable.</li>
+                <li class="typcn typcn-minus">Remove the global variable.</li>
+            </ul>
+            <p class="auto-cursor-target">If global variables have been created:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable.</li>
+                <li class="typcn typcn-arrow-left">Value, initial value of the variable.</li>
+            </ul><br>
+        </div>
+        <div id="mbedActions_display_text" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»Showtext...«">»Show text ... «</h3>
+            <p>With this block you can output a text on the screen of the micro:bit.</p>
+            <p>Options and Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, the way you want the text to appear on the display.
+                    With »text« the text is displayed as a scrolling text from right to left, with »character« all
+                    characters are displayed one after the other on the screen.</li>
+                <li class="typcn typcn-arrow-left">String, text that you want to display on your micro:bit.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_image" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»Showimage...«">»Show image ... «</h3>
+            <p>With this block you can display an image or animation on the micro:bit screen.</p>
+            <p>Options and Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, the way the image is to be displayed. With »image«
+                    only a single image is displayed, with »animation« a list of images is displayed one after the
+                    other.</li>
+                <li class="typcn typcn-arrow-left">Image or list of images, the image or the list of images you want to
+                    be displayed on your micro:bit.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_clear" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»Cleardisplay«">»Clear display«</h3>
+            <p>With this block you can clear the display of your micro:bit, that means that all LEDs are turned off.</p>
+        </div>
+        <div id="mbedActions_display_setpixel" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»SetLEDx...y...brightness...«[Expert-block]">»Set LED x ... y ...
+                brightness ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can set the brightness of one specific LED to a desired value between 0 and 9, where
+                0 is off and 9 is the maximum brightness.</p>
+            <p>Options and input values
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, x coordinate of the LED you want to control. The x-axis runs
+                    parallel to the long side ouf your micro:bit. Possible inputs are integers between 0 and 4.</li>
+                <li class="typcn typcn-arrow-left">Number, y coordinate of the LED you want to control. The y-axis runs
+                    parallel to the short side of your micro:bit. Possible inputs are integers between 0 and 4.</li>
+                <li class="typcn typcn-arrow-left">Number, desired brightness of the LED. 0 means off and 9 is the
+                    maximum brightness.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_display_getPixel" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»GetLEDbrightnessx...y...«[Expert-block]">»Get LED brightness x ... y ...
+                « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can querry the brightness of on of your micro:bits LEDs.</p>
+            <p>Options ans input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, x coordinate of the LED you want to control. The x-axis runs
+                    parallel to the long side ouf your micro:bit. Possible inputs are integers between 0 and 4.</li>
+                <li class="typcn typcn-arrow-left">Number, y coordinate of the LED you want to control. The y-axis runs
+                    parallel to the short side of your micro:bit. Possible inputs are integers between 0 and 4.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, brightness of the chosen LED. This number can be an integer
+                    between 0 for off and 9 for maximum brightness.</li>
+            </ul>
+        </div>
+        <div id="robActions_serial_print" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»ShowonSerialMonitor...«[Expert-block]">»Show on Serial Monitor ... «
+                <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can display a text on your computer. This text is transferred to your computer via
+                serial port. You can read how to set up a Serial Monitor <a
+                    href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo/Set+Up+Calliope+mini">here</a>.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the String that you want to display on the connected
+                    computer.</li>
+            </ul>
+        </div>
+        <div id="mbedActions_write_to_pin" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»Write...valuetopin...«[Expert-block]">»Write ... value to pin ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can output either a digital or analog value on one of the pins of your micro:bit.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select whether you want to output a »digital« or
+                    »analog« value on your pin. »Digital« means either 0 or 1, »analog« means a number between 0 and 1,
+                    i.e. a percentage of the total voltage of 3,3,V.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, pin on which you want to output this value. Note that
+                    not all pins can output an "analog" value.</li>
+                <li class="typcn typcn-arrow-left">Number, the value that you want to write to the pin. With »digital«
+                    this means either 0 or 1 and with »analog« this means a number between 0 and 1.</li>
+            </ul>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»Button..pressed?«">»Button .. pressed?«</h3>
+            <p>With this button you can check whether a button is currently being pressed.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, the button that you want to check.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, »true« if the button is being pressed, otherwise »false«
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_gesture_getSample" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»Get...gesture«">»Get ... gesture «</h3>
+            <p>With this block you can check whether your micro.bit is in a certain position or certain gesture is being
+                done.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, gesture or position that you want to check for.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, »true« if the micro:bit is in that position, »false«
+                    otherwise.</li>
+            </ul>
+        </div>
+        <div id="robSensors_compass_getSample" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»getangle°compasssensor«">»get angle ° compass sensor «</h3>
+            <p>With this block you can check the compass sensor of your micro:bits. This sensor can measure the angle by
+                which your micro.bit has rotated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, angle by which your micro.bit has rotated. This value can be
+                    any number between 0 and 360 for a full rotation.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»getvaluetimer...«">»get value timer ... «</h3>
+            <p>With this block you can query the value of a timer. The first timer is started automatically at the start
+                of the program, all other timers have to be set first with the "Set timer ..." button. back " can be
+                started.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the timer you want to check.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, time since the start or the last reset of the timer in
+                    millesconds.</li>
+            </ul>
+        </div>
+        <div id="mbedSensors_timer_reset" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»resettimer...«">»reset timer ... «</h3>
+            <p>With this block you can reset the timer of your micro:bit.</p>
+        </div>
+        <div id="robSensors_temperature_getSample" class="help beginner"><br>
+            <h3 id="Blockdescriptionmicro:bit-»getvalue°temperaturesensor«">»get value ° temperature sensor «</h3>
+            <p>With this block you can check the temperature sensor for the ambient temperature.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, ambient temperature in degrees Celsius.</li>
+            </ul>
+        </div>
+        <div id="robSensors_pintouch_getSample" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»pin..pressed?«">»pin .. pressed? «</h3>
+            <p>With this block you can check whether the chosen pin is pressed by a person. But be aware that not all
+                pins can check whether they are being pressed.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, pin that you want to check.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolena, »true« if the pin is pressed, »false« otherwise.</li>
+            </ul>
+        </div>
+        <div id="robSensors_pin_getSample" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»get...valuepin...«[Expert-block]">»get ... value pin ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can read a value at one of the pins of the micro:bit. This value can be either
+                »digital«, meaning 1 or 0, or the value can be »analog«, meaning between 0 and 1. You can also measure
+                the time how long either a high, »pulse time HIGH«, or a low, »pulse time LOW«, was registered at the
+                pin.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the type of value or which pulse time you want
+                    to check.</li>
+                <li class="typcn typcn-arrow-sorted-down">option, select the pin you want to measure against. Note that
+                    not all pins can measure an analog value. You can see which pin can measure an analog value by
+                    selecting the analog value and then clicking on the list of pins.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, value measured. With a digital value this number is either 0
+                    or 1, with an analog value this number is between 0 and 1 and with a pulse time it is the measured
+                    time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robSensors_accelerometer_getSample" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»getvaluemilli-gaccelerometer...«">»get value milli-g accelerometer ... «
+            </h3>
+            <p>With this sensor you can measure an acceleration that acts on your micro:bit. An acceleration is always
+                expressed by an acting force. For example, if you push your micro:bit in one direction, you exert a
+                force on it and thus an acceleration. The sensor can measure this acceleration and its value is measured
+                in units of acceleration due to gravity. The following applies: 1000 milli-g = 1 g = 9.81 m/s²</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, direction in which you want to measure an
+                    acceleration. x is the left-right direction, y the front-back direction and z the top-down
+                    direction. »strength« is moreover the total measured acceleration of all axes together.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, measured acceleration as milli-g, i.e. as one thousandth of
+                    the acceleration due to gravity.</li>
+            </ul>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 class="auto-cursor-target" id="Blockdescriptionmicro:bit-»getvalue%lightsensor«">»get value % light
+                sensor«</h3>
+            <p>With this block you can query the value of your light sensor.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, relative brightness of the robots surroundings.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="Blockdescriptionmicro:bit-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»breakout/continuewithnextiterationofloop«[Expert-block]">»break
+                out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="Blockdescriptionmicro:bit-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="Blockdescriptionmicro:bit-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»mathematicalfunction«[Expert-block]">»mathematical function« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»constant«[Expert-block]">»constant« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="Blockdescriptionmicro:bit-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»constrain«[Expert-block]">»constrain« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="Blockdescriptionmicro:bit-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="Blockdescriptionmicro:bit-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="Blockdescriptionmicro:bit-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="Blockdescriptionmicro:bit-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="Blockdescriptionmicro:bit-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="Blockdescriptionmicro:bit-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="Blockdescriptionmicro:bit-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="Blockdescriptionmicro:bit-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to
+                Number« <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="Blockdescriptionmicro:bit-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="Blockdescriptionmicro:bit-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="Blockdescriptionmicro:bit-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="Blockdescriptionmicro:bit-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="Blockdescriptionmicro:bit-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="Blockdescriptionmicro:bit-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="Blockdescriptionmicro:bit-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="Blockdescriptionmicro:bit-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="Blockdescriptionmicro:bit-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="Blockdescriptionmicro:bit-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="Blockdescriptionmicro:bit-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="Blockdescriptionmicro:bit-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red
+                ... green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="Blockdescriptionmicro:bit-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green
+                ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="Blockdescriptionmicro:bit-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ...
+                green ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="Blockdescriptionmicro:bit-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function
+                blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function
+                blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»ifblocktobeusedwithinafunction«">»if block to be used within a function«
+            </h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="Blockdescriptionmicro:bit-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function
+                with return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="Blockdescriptionmicro:bit-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a
+                function with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="Blockdescriptionmicro:bit-»functioncallwithoutreturnvalue«">»function call without return value «
+            </h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="Blockdescriptionmicro:bit-»functioncallwithreturnvalue«">»function call
+                with return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul>
+        </div>
+        <div id="mbedCommunication_sendBlock" class="help expert">
+            <h3 class="auto-cursor-target" id="Blockdescriptionmicro:bit-»sendmessage...withstrength...«[expertblock]">
+                »send message ... with strength ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can send a message to other robots in your environment. The message can be either a
+                number, a logical value or a string.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the data type of the message that you want to
+                    send.</li>
+                <li class="typcn typcn-arrow-left">element of the chosen data type, the message that you want to send to
+                    other robots.</li>
+                <li class="typcn typcn-arrow-sorted-down">option, strength with which you want to send your message. The
+                    higher the strength, the further your message will be sent.</li>
+            </ul><br>
+        </div>
+        <div id="mbedCommunication_receiveBlock" class="help expert">
+            <h3 class="auto-cursor-target" id="Blockdescriptionmicro:bit-»receivemessage...«[expertblock]">»receive
+                message ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can receive messages from other robots. You can choose which data the message should
+                contain.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, data type of the message.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">element of the data type, received message.</li>
+            </ul><br>
+        </div>
+        <div id="mbedCommunication_setChannel" class="help expert">
+            <h3 class="auto-cursor-target" id="Blockdescriptionmicro:bit-»setchannelto...«[expertblock]">»set channel to
+                ...« <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can change the channel on which your robot sends and receives its messages. You can
+                only communicate with other robots that send and receive on the same channel.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, channel that you want to communicate on with other robots.
+                </li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_nano33ble_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nano33ble_de.html
@@ -1,484 +1,1803 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start_ardu" class="help beginner"><h3 id="BlockbeschreibungArduinoNano33BLE-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am »Wiederhole unendlich oft«-Block.</p><p>Für Systeme, die auf einem Arduino oder einem ähnlichen Mikrocontroller basieren, ist hier immer eine »Wiederhole unendlich oft«-Schleife mit dem Start-Block verbunden, die ebenfalls nicht entfernt werden kann. Dies liegt daran, dass solche Mikrocontroller meistens für genau eine Aufgabe programmiert werden, die dann immer wieder ausgeführt werden soll. Wenn du nur einen Durchlauf des Programm möchtest, kannst du den Roboter am Ende der Schleife einfach für eine sehr lange Zeit warten lassen.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
-</ul><br><p>Wenn globale Variablen erzeugt wurden:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variablen.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
-</ul><br></div><div id="robActions_motor_on_for_ardu" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»ServomotorSG90...Setzean°«"><span style="color: rgb(0,0,0);">»Servomotor SG90 ... Setze an°« </span></h3><p>Mit dem Block »Servormotor SG90 ... Setze an°« programmierst du die Position eines Servomotors in Grad. Der Servomotor fährt dann in die entsprechende Position.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor Port, wähle einen Servomotor aus, den du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-left">Gradzahl, in die der Motor bewegt werden soll.</li>
-</ul><br></div><div id="robActions_motor_on_for" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»Motor28BYJ-48Port...anrpm...fürUmdrehungen/Grad...«"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Motor 28BYJ-48 Port ... an  rpm ... für Umdrehungen/Grad ...«</span><br></span></h3><p>Mit dem Block »Motor 28BYJ-48 Port ... an rpm ... für ... Umdrehungen/Grad« stellst du die Geschwindigkeit und Anzahl der Umdrehungen ein, die sich der Motor drehen soll. Dein Roboter startet den gewählten Motor, bis er die eingestellte Anzahl Umdrehungen bzw. Winkelgrade gemacht hat.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor Port, wähle einen Schrittmotor aus, den du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-left">Tempo, dreht sich der Motor rückwärts.</li><li class="typcn typcn-arrow-sorted-down">Umdrehungen oder Grad. 1 Umdrehung entspricht 360 Grad.</li><li class="typcn typcn-arrow-left">Zahl, Anzahl der Umdrehungen bzw. Winkelgrade. Es sind nur positive Zahlen zugelassen.</li>
-</ul><br></div><div id="robActions_set_relay" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»SchalteRelaisSRD-05VDC-SL-C...an/aus«"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Schalte Relais  SRD-05VDC-SL-C ... an/aus«</span><br></span></h3><p>Mit dem Block »Schalte Relais SRD-05VDC-SL-C ... an/aus« kannst du ein Relais an einem bestimmten Pin steuern.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle ein Relais aus, das du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-sorted-down">an/aus, wähle ob das Relais ein- oder ausgeschaltet werden soll.</li>
-</ul><br></div><div id="robActions_serial_print" class="help beginner"><h3 id="BlockbeschreibungArduinoNano33BLE-»ZeigeaufSerialMonitor...«">»Zeige auf Serial Monitor ...«</h3><p>Mit dem Block »Zeige auf Serial Monitor ...« kannst du Text und Zahlen über die serielle Schnittstelle deines Roboters versenden. Du kannst dir die Ausgaben der seriellen Schnittstelle im USB-Programm anschauen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, der über die serielle Schnittstelle ausgegeben werden soll.</li>
-</ul></div><div id="robActions_display_text" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»LCD1602...«"><span style="color: rgb(85,85,85);">»LCD 1602 ...«</span></h3><p>Mit dem Block »LCD 1602 ...« kannst du Text und Zahlen auf einem LCD 1602 anzeigen lassen. Dabei kannst du zusätzlich noch bestimmen, in welcher Spalte und in welcher Zeile der Text auf dem LCD erscheinen soll.</p><p>Das Display ist für Texte in mehreren Zeilen (von links nach rechts) und Spalten (von oben nach unten) eingeteilt. Die Zählung beginnt jeweils bei 0.</p><p>Wenn zuvor schon etwas auf dem Display angezeigt war, werden nur die Stellen überschrieben, in die der Text geschrieben wird.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 aus, das du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li><li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li><li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
-</ul></div><div id="robActions_display_clear" class="help expert"><h3 style="letter-spacing: normal;" id="BlockbeschreibungArduinoNano33BLE-»LöscheBildschirmLCD1602«">»Lösche Bildschirm LCD 1602«</h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »Lösche Bildschirm« kannst du Text und Zahlen auf dem LCD 1602 löschen. Das Display ist anschließend leer.
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 aus, das du in der Roboterkonfiguration angelegt hast.</li>
-</ul></div><div id="robActions_display_text_i2c" class="help beginner"><h3 style="letter-spacing: normal;" id="BlockbeschreibungArduinoNano33BLE-»LCD1602I²C...«">»LCD 1602 I²C ...«</h3><p>Mit dem Block »LCD 1602 I²C« kannst du Text und Zahlen auf einem über den I²C-Bus angeschlossenen LCD 1602 anzeigen lassen. Dabei kannst du zusätzlich noch bestimmen, in welcher Spalte und in welcher Zeile der Text auf dem LCD erscheinen soll.</p><p>Das Display ist für Texte in mehreren Zeilen (von links nach rechts) und Spalten (von oben nach unten) eingeteilt. Die Zählung beginnt jeweils bei 0.</p><p>Wenn zuvor schon etwas auf dem Display angezeigt war, werden nur die Stellen überschrieben, in die der Text geschrieben wird.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 I²C aus, das du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li><li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li><li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
-</ul></div><div id="robActions_display_clear_i2c" class="help beginner"><h3 id="BlockbeschreibungArduinoNano33BLE-»LöscheBildschirmLCD1602I²C«">»Lösche Bildschirm LCD 1602 I²C«</h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »Lösche Bildschirm LCD 1602 I²C« kannst du Text und Zahlen auf dem LCD 1602 löschen, der über den I²C Bus angeschlossen ist. Das Display ist anschließend leer.
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 I²C aus, das du in der Roboterkonfiguration angelegt hast.</li>
-</ul></div><div id="robActions_play_tone" class="help beginner"><h3 id="BlockbeschreibungArduinoNano33BLE-»Spiele...FrequenzHz...Dauerms«">»Spiele ... Frequenz Hz ... Dauer ms«</h3><p>Mit dem Block »Spiele Frequenz Hz... Dauer ms« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie lange der Ton gespielt wird) programmieren. Der Ton wird über einen an den Arduino angeschlossenen Lautsprecher abgespielt, bis die eingestellte Dauer erreicht ist.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Bitte beachte, dass das menschliche Gehör Frequenzen zwischen ca. 30 Hz bis ca. 15.000 Hz (15 kHz) wahrnehmen kann - je nach Mensch und Alter kann dies unterschiedlich sein.</p></div></div><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Summer aus, den du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-left">Zahl, gewünschte Frequenz in Hz (Hertz) eingeben.</li><li class="typcn typcn-arrow-left"> Zahl, gewünschte Dauer des Tons in Millisekunden (ms) eingeben.</li>
-</ul></div><div id="robActions_brickLight_on" class="help beginner"><h3 style="letter-spacing: normal;" id="BlockbeschreibungArduinoNano33BLE-»LED...an/aus«">»LED ... an/aus«</h3><p><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »LED ... an/aus« kannst du die eine an deinen Arduino angeschlossene LED ein- oder ausschalten.</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle eine LED aus, die du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-sorted-down">Option, An/aus, wähle aus, ob du die LED ein- oder ausschalten möchtest.</li>
-</ul><br></div><div id="robActions_led_on" class="help expert"><h3 style="letter-spacing: normal;" id="BlockbeschreibungArduinoNano33BLE-»SetzeLEDan...Farbe«">»Setze LED an ... Farbe« </h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block "Setze LED an ... Farbe" kannst du eine an deinen Arduino angeschlossene Farb-LED mit einer bestimmten Farbe einschalten.</p><p style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle eine RGB LED aus, die du in der Roboterkonfiguration angelegt hast.</li><li class="typcn typcn-arrow-left">Farbe, wähle dir Farbe  aus, in der die LED leuchten soll.</li>
-</ul></div><div id="robActions_led_off" class="help expert"><h3 style="letter-spacing: normal;" id="BlockbeschreibungArduinoNano33BLE-»SchalteLEDaus...«">»Schalte LED aus ...«</h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »Schalte LED aus ...« kannst du die eine an deinen Arduino angeschlossene Farb-LED ausschalten.
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle eine RGB LED aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul></div><div id="robActions_write_pin" class="help beginner"><h3 id="BlockbeschreibungArduinoNano33BLE-»Schreibedigitalen/analogenWertAktor...«">»Schreibe digitalen/analogen Wert Aktor ...«</h3><p>Mit dem Block »Schreibe analogen/digitalen Wert Aktor ...« kannst du einen analogen oder digitalen Wert auf einen Pin deines Arduino schreiben. </p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">analog/digital, wähle aus ob du einen digitalen oder analogen Wert schreiben willst.</li><li class="typcn typcn-arrow-sorted-down">Pin, wähle den Pin aus auf den du schreiben möchtest.</li><li class="typcn typcn-arrow-left">Zahl, Wert der geschrieben werden soll.</li>
-</ul><br></div><div id="robSensors_out_getSample" class="help beginner"> <h3 id="BlockbeschreibungArduinoNano33BLE-»gibanalogen/digitalenWertSensor...«">»gib analogen/digitalen Wert Sensor...«</h3><p>Mit dem Block »gib analogen/digitalen Wert Sensor...« kannst du einem anderen Block »mitteilen«, welcher analoge oder digitale Wert an einem Sensor deines Arduino anliegt.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»analog« oder »digital«. Stelle ein, wie der welche Art der zu messende Wert hat.</li><li class="typcn typcn-arrow-sorted-down">Pin, wähle einen Pin aus.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Wert der an dem Pin anliegt.</li>
-</ul><br> </div><div id="robSensors_timer_getSample" class="help beginner"> <h3 id="BlockbeschreibungArduinoNano33BLE-»GibWertmsZeitgeber«">»Gib Wert ms Zeitgeber«</h3><p>Mit dem Block »Gib Wert Zeitgeber« kannst du einem anderen Block den aktuellen Stand des internen Zeitgebers in Millisekunden »mitteilen«. Der Zeitgeber wird automatisch mit dem Beginn eines Programms gestartet.</p><p>Einstellöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zeitgeber-Nummer, wähle den Zeitgeber aus, dessen Wert du ermitteln möchtest.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl Millisekunden, die seit dem Programmstart oder dem letzten Zurücksetzen des Zeitgebers vergangen sind.</li>
-</ul><br></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="BlockbeschreibungArduinoNano33BLE-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück«</h3><p>Mit dem Block »Setze Zeitgeber ... zurück« können die internen Zeitgeber auf den Wert 0 zurückgesetzt werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zeitgeber-Nummer, wähle den Zeitgeber aus, den du zurücksetzen möchtest.</li>
-</ul><br></div><div id="robSensors_key_getSample" class="help beginner"> <h3 id="BlockbeschreibungArduinoNano33BLE-»Taste...gedrückt?«">»Taste ... gedrückt?«</h3><p>Mit dem Block »Taste ... gedrückt?« kannst du einem anderen Block »mitteilen« , ob die ausgewählte Taste gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>true = gedrückt</em> oder <em>false = nicht gedrückt</em> zurück.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle eine Taste aus, die du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><br>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »true«, wenn die gewählte Taste gedrückt ist, sonst »false«.</li>
-</ul> </div><div id="robSensors_motion_getSample" class="help beginner"> <h3 id="BlockbeschreibungArduinoNano33BLE-»gibAnwesenheitBewegungssensorHC-SR501...«">»gib Anwesenheit Bewegungssensor HC-SR501...«</h3><p>Mit dem Block »gib Anwesenheit Bewegungssensor ...« kannst du einem anderen Block »mitteilen« , ob der Bewegungssensor eine Bewegung wahrnimmt oder nicht.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, wähle einen Bewegungssensor aus, den du in der Roboterkonfiguration angelegt hast.<br></span></li>
-</ul><br><p><br>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »true«, wenn eine Bewegung wahrgenommen wird, sonst »false«.</li>
-</ul> </div><div id="robSensors_light_getSample" class="help beginner"> <h3 id="BlockbeschreibungArduinoNano33BLE-»gibLicht%Lichtsensor...«">»gib Licht % Lichtsensor ...«</h3><p>Mit dem Block »gib Licht % Lichtsensor ...« kannst du einem anderen Block »mitteilen«, welchen Helligkeitswert zwischen 0 und 100 der Lichtsensor misst.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Lichtsensor aus, den du in der Roboterkonfiguration erstellt hast.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Helligkeitswert in %<span>.</span></li>
-</ul><br> </div><div id="robSensors_infrared_getSample" class="help expert">  <h3 id="BlockbeschreibungArduinoNano33BLE-»GibAbstand/AnwesenheitInfrarotsensor...«">»Gib Abstand/Anwesenheit Infrarotsensor ...«</h3><p>Mit dem Block »Gib Abstand/Anwesenheit Infrarotsensor ...« kannst du einem anderen Block »mitteilen«, welchen Abstand der Infrarotsensor misst.</p><p>Im Modus »Abstand« wird der Abstand als Zahl übermittelt.</p><p>Im Modus »Anwesenheit« gibt der Sensor an, ob Infrarot empfangen wird oder nicht.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Ein exakte Messung der Abstände in cm ist mit dem Infrarotsensor nicht möglich. Die gemessenen Abstände sind also ungefähre Werte.</p></div></div><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»Abstand« oder »Anwesenheit«. Stelle ein, wie der Infrarotsensor messen soll.</li><li class="typcn typcn-arrow-sorted-down">Port, wähle einen Infrarotsensor aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, bei »Abstand«, maximaler Abstand 70 cm.</p><p>Logischer Wert, bei »Anwesenheit«;<span> »Wahr« wenn Infrarot empfangen wird und <span> »Falsch« wenn nicht</span></span> .</p></li>
-</ul><br> </div><div id="robSensors_temperature_getSample" class="help expert">  <h3 id="BlockbeschreibungArduinoNano33BLE-»gibWert°TemperatursensorTMP36...«">»gib Wert ° Temperatursensor TMP36...«</h3><p>Mit dem Block »gib Wert ° Temperatursensor ...« kannst du einem anderen Block »mitteilen« , welche Temperatur durch den Temperatursensor gemessen wird.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Temperatursensor aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><br>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die vom Sensor gemessene Temperatur in Grad Celsius.</li>
-</ul><br> </div><div id="robSensors_humidity_getSample" class="help expert"> <h3 id="BlockbeschreibungArduinoNano33BLE-»gibWert%LuftfeuchtigkeitsensorDHT11...«">»gib Wert % Luftfeuchtigkeitsensor DHT11...«</h3><p>Mit dem Block »gib Wert % Luftfeuchtigkeitsensor ...« kannst du einem anderen Block »mitteilen«, wie hoch die Luftfeuchtigkeit zwischen 0% und 100% ist, die der Luftfeuchtigkeitssensor misst.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Luftfeuchtigkeitsensor aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Luftfeuchtigkeit in %.</li>
-</ul><br> </div><div id="robSensors_drop_getSample" class="help expert"> <h3 id="BlockbeschreibungArduinoNano33BLE-»gibWert%Tropfsensor...«">»gib Wert % Tropfsensor...«</h3><p>Mit dem Block »gib Wert % Tropfsensor ...« kannst du einem anderen Block »mitteilen«, wie hoch die nass der Tropfsensor zwischen 0% und 100% ist.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Tropfensensor aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Nässe in %.</li>
-</ul><br> </div><div id="robSensors_pulse_getSample" class="help expert"> <h3 id="BlockbeschreibungArduinoNano33BLE-»gibWertPulssensor...«">»gib Wert Pulssensor...«</h3><p>Mit dem Block »gib Wert Pulssensor ...« kannst du einem anderen Block »mitteilen«, wie hoch der Puls der Person ist, bei der der Sensor verwendet wird.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Pulssensor aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gemessener Puls.</li>
-</ul><br> </div><div id="robSensors_potentiometer_getSample" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»GibWertVPotentiometer...«">»Gib Wert V Potentiometer ...«</h3><p>Mit dem Block »Gib Wert V Potentiometer ...« kannst du einem anderen Block »mitteilen«, auf welchen Wert in Volt das an deinen Arduino angeschlossene Potentiometer eingestellt ist.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle ein Potentiometer aus, das du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Spannung in Volt, auf die das Potentiometer eingestellt ist.</li>
-</ul><br></div><div id="robSensors_moisture_getSample" class="help expert"> <h3 id="BlockbeschreibungArduinoNano33BLE-»gibWert%Feuchtigkeitssensor...«">»gib Wert % Feuchtigkeitssensor ...«</h3><p>Mit dem Block »gib Wert % Feuchtigkeitssensor ...« kannst du einem anderen Block »mitteilen«, wie hoch die Feuchtigkeit zwischen 0 und 100 ist, die der Feuchtigkeitssensor misst.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Feuchtigkeitsensor aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Feuchtigkeit in %<span>.</span></li>
-</ul><br> </div><div id="robSensors_ultrasonic_getSample" class="help expert"> <h3 id="BlockbeschreibungArduinoNano33BLE-»gibAbstandcmUltraschallHC-SR04...«">»gib Abstand cm Ultraschall HC-SR04 ...«</h3><p>Mit dem Block »gib Abstand cm Ultraschall HC-SR04 ...« kannst du einem anderen Block »mitteilen«,  welcher Abstand in cm von dem Ultraschallsensor gemessen wird.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle einen Ultraschallsensor HS-SR04 aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Abstand in cm</li>
-</ul><br> </div><div id="robSensors_rfid_getSample" class="help expert"> <h3 id="BlockbeschreibungArduinoNano33BLE-»gibID/AnwesenheitRFID-RC522Reader...«">»gib ID/Anwesenheit RFID-RC522 Reader...«</h3><p>Mit dem Block »gib ID/Anwesenheit RFID-RC522 Reader ...« kannst du einem anderen Block »mitteilen«, welche UID (Unique Identification Number) ein RFID-Tag hat, dass du an den Sensor hälst oder ob ein RFID-Tag erkannt wurde.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»ID« oder »Anwesenheit«. Stelle ein, wie der Infrarotsensor messen soll.</li><li class="typcn typcn-arrow-sorted-down">Port, wähle einen RFID Reader aus, den du in der Roboterkonfiguration angelegt hast.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Text,<span> bei »Kartenserie«;</span> UID des RFID-Tags.</p><p><span>Logischer Wert, bei »Anwesenheit«;</span><span> »Wahr« wenn ein RFID-Tag erkannt wird und »Falsch« wenn nicht</span><span> .</span></p></li>
-</ul><br> </div><div id="robSensors_lsm9ds1_acceleration_getDataAvailableSample" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»LSM9DS1Beschleunigungx...y...z...«[Experten-Block]">»LSM9DS1 Beschleunigung x ... y ... z ... « <span class="typcn typcn-star"></span></h3><p>Dieser Sensor misst die Beschleunigung, die der Roboter erfährt. Dies kann z.B. die Gravitation sein, die jeder Gegenstand auf der Erde erfährt.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Beschleunigung in x-Richtung gespeichert werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Beschleunigung in y-Richtung gespeichert werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Beschleunigung in z-Richtung gespeichert werden soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
-</ul></div><div id="robSensors_lsm9ds1_gyro_getDataAvailableSample" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»LSM9DS1Gyroskopx...y...z...°/s«[Experten-Block]">»LSM9DS1 Gyroskop x ... y ... z ... °/s « <span class="typcn typcn-star"></span></h3><p>Dieser Sensor misst die Rotationsgeschwindigkeit deines Roboters. Dabei kann sich der Roboter um die drei Achsen drehen, also die x-, y- und z-Achse.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Rotation um die x-Achse gespeichert werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Rotation um die y-Achse gespeichert werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Rotation um die z-Achse gespeichert werden soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
-</ul></div><div id="robSensors_lsm9ds1_magneticfield_getDataAvailableSample" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»LSM9DS1Magnetfeldx...y...z...Gauss«[Experten-Block]">»LSM9DS1 Magnetfeld x ... y ... z ... Gauss « <span class="typcn typcn-star"></span></h3><p>Dieser Sensor misst die Anwesenheit eines Magnetfeldes. Dieses kann z.B. das Magnetfeld der Erde oder das Feld einer von Strom durchflossenen Spule sein. Dabei setzt sich ein solches Magnetfeld aus drei Komponenten in den drei Raumrichtungen zusammen, es formt also quasi einen Pfeil in der Luft.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Stärke des Magnetfelds in x-Richtung gespeichert werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Stärke des Magnetfelds in y-Richtung gespeichert werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Stärke des Magnetfelds in z-Richtung gespeichert werden soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
-</ul></div><div id="robSensors_apds9960_distance_getDataAvailableSample" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»APDS9960Abstand...cm«[Experten-Block]">»APDS9960 Abstand ... cm « <span class="typcn typcn-star"></span></h3><p>Dieser Sensor misst den Abstand eines Gegenstands bzw. einer Hand zu diesem Sensor. Dabei sendet der Sensor Infrarot-Strahlung aus und anhand der Reflexion dieser Strahlung wird der Abstand bestimmt. Dies funktioniert allerdings nur für kurze Distanzen bis etwa 20 cm.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der der Abstand des nächsten Objekts gespeichert werden soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
-</ul></div><div id="robSensors_apds9960_gesture_getDataAvailableSample" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»APDS9960Geste...«[Experten-Block]">»APDS9960 Geste ... « <span class="typcn typcn-star"></span></h3><p>Dieser Sensor kann vordefinierte Gesten erkennen, die du mit der Hand über diesem Sensor ausführst. Dazu musst du deine Hand in geringem Abstand über dem Sensor bewegen. Die möglichen Gesten sind:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="normalBullet">-1 : keine Geste erkannt</li><li class="normalBullet">0 : Hand nach vorne bewegen</li><li class="normalBullet">1 : Hand nach unten bewegen</li><li class="normalBullet">2 : Hand nach links bewegen</li><li class="normalBullet">3 : Hand nach rechts bewegen</li>
-</ul><br><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Lage des Roboters gespeichert werden soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
-</ul></div><div id="robSensors_apds9960_color_getDataAvailableSample" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»APDS9960FarbeR...G...B...«[Experten-Block]">»APDS9960 Farbe R ... G ... B ... « <span class="typcn typcn-star"></span></h3><p>Dieser Sensor misst die Farbzusammensetzung des Untergrunds. Dazu sendet der Sensor die Farben Rot, Grün und Blau aus und misst die Stärke des reflektierten Lichts.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Stärke des roten Lichts gespeichert werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Stärke des grünen Lichts gespeichert werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Stärke des blauen Lichts gespeichert werden soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
-</ul></div><div id="robSensors_lps22hb_pressure_getDataAvailableSample" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»LPS22HBLuftdruck...Pa«[Experten-Block]">»LPS22HB Luftdruck ... Pa « <span class="typcn typcn-star"></span></h3><p>Dieser Sensor misst den Luftdruck der Umgebung. Der normale Luftdruck auf Höhe des Meeresspiegels ist 1013 Hecto Pascal.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der der momentane Luftdruck gespeichert werden soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
-</ul></div><div id="robSensors_hts221_temperature_getDataAvailableSample" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»HTS221Temperatur...°C«[Experten-Block]">»HTS221 Temperatur ... °C « <span class="typcn typcn-star"></span></h3><p>Dieser Sensor misst die Temperatur der Umgebung in Grad Celsius.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die momentane Temperatur gespeichert werden soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
-</ul></div><div id="robSensors_hts221_humidity_getDataAvailableSample" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»HTS221Luftfeuchtigkeit...%«[Experten-Block]">»HTS221 Luftfeuchtigkeit ... % « <span class="typcn typcn-star"></span></h3><p>Dieser Sensor misst die Luftfeuchtigkeit der Umgebung in Prozent.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die momentane Luftfeuchtigkeit gespeichert werden soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 class="auto-cursor-target" id="BlockbeschreibungArduinoNano33BLE-»Wartebis...«">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wartems...«">»Warte ms ... «</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wartebis...«.1">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Zufallszahl«">»Zufallszahl« </h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungArduinoNano33BLE-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungArduinoNano33BLE-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt werden soll. Zahl zwischen 0 und 255.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungArduinoNano33BLE-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von der verwendeten Programmiersprache des Roboters abhängt. </span><span style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt, sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der Zeichenkette »52abcd« die Zahl 52.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungArduinoNano33BLE-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li><li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte das die Nummerierung bei 0 anfängt.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungArduinoNano33BLE-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungArduinoNano33BLE-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungArduinoNano33BLE-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungArduinoNano33BLE-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungArduinoNano33BLE-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungArduinoNano33BLE-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungArduinoNano33BLE-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="BlockbeschreibungArduinoNano33BLE-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockbeschreibungArduinoNano33BLE-»Farbwahl«">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="BlockbeschreibungArduinoNano33BLE-»Farbwahl«.1">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="BlockbeschreibungArduinoNano33BLE-»Farbwahl«.2">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 class="auto-cursor-target" id="BlockbeschreibungArduinoNano33BLE-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, die  Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 class="auto-cursor-target" id="BlockbeschreibungArduinoNano33BLE-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 class="auto-cursor-target" id="BlockbeschreibungArduinoNano33BLE-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="BlockbeschreibungArduinoNano33BLE-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="BlockbeschreibungArduinoNano33BLE-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="BlockbeschreibungArduinoNano33BLE-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="BlockbeschreibungArduinoNano33BLE-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="BlockbeschreibungArduinoNano33BLE-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen Wert zurück.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="BlockbeschreibungArduinoNano33BLE-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit Rückgabewert «</h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start_ardu" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den
+                man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am »Wiederhole unendlich
+                oft«-Block.</p>
+            <p>Für Systeme, die auf einem Arduino oder einem ähnlichen Mikrocontroller basieren, ist hier immer eine
+                »Wiederhole unendlich oft«-Schleife mit dem Start-Block verbunden, die ebenfalls nicht entfernt werden
+                kann. Dies liegt daran, dass solche Mikrocontroller meistens für genau eine Aufgabe programmiert werden,
+                die dann immer wieder ausgeführt werden soll. Wenn du nur einen Durchlauf des Programm möchtest, kannst
+                du den Roboter am Ende der Schleife einfach für eine sehr lange Zeit warten lassen.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
+            </ul><br>
+            <p>Wenn globale Variablen erzeugt wurden:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variablen.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on_for_ardu" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»ServomotorSG90...Setzean°«"><span
+                    style="color: rgb(0,0,0);">»Servomotor SG90 ... Setze an°« </span></h3>
+            <p>Mit dem Block »Servormotor SG90 ... Setze an°« programmierst du die Position eines Servomotors in Grad.
+                Der Servomotor fährt dann in die entsprechende Position.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor Port, wähle einen Servomotor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+                <li class="typcn typcn-arrow-left">Gradzahl, in die der Motor bewegt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on_for" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»Motor28BYJ-48Port...anrpm...fürUmdrehungen/Grad...«"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Motor 28BYJ-48 Port ... an rpm ...
+                        für Umdrehungen/Grad ...«</span><br></span></h3>
+            <p>Mit dem Block »Motor 28BYJ-48 Port ... an rpm ... für ... Umdrehungen/Grad« stellst du die
+                Geschwindigkeit und Anzahl der Umdrehungen ein, die sich der Motor drehen soll. Dein Roboter startet den
+                gewählten Motor, bis er die eingestellte Anzahl Umdrehungen bzw. Winkelgrade gemacht hat.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor Port, wähle einen Schrittmotor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+                <li class="typcn typcn-arrow-left">Tempo, dreht sich der Motor rückwärts.</li>
+                <li class="typcn typcn-arrow-sorted-down">Umdrehungen oder Grad. 1 Umdrehung entspricht 360 Grad.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anzahl der Umdrehungen bzw. Winkelgrade. Es sind nur positive
+                    Zahlen zugelassen.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_set_relay" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»SchalteRelaisSRD-05VDC-SL-C...an/aus«"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Schalte Relais SRD-05VDC-SL-C ...
+                        an/aus«</span><br></span></h3>
+            <p>Mit dem Block »Schalte Relais SRD-05VDC-SL-C ... an/aus« kannst du ein Relais an einem bestimmten Pin
+                steuern.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle ein Relais aus, das du in der Roboterkonfiguration
+                    angelegt hast.</li>
+                <li class="typcn typcn-arrow-sorted-down">an/aus, wähle ob das Relais ein- oder ausgeschaltet werden
+                    soll.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_serial_print" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»ZeigeaufSerialMonitor...«">»Zeige auf Serial Monitor ...«</h3>
+            <p>Mit dem Block »Zeige auf Serial Monitor ...« kannst du Text und Zahlen über die serielle Schnittstelle
+                deines Roboters versenden. Du kannst dir die Ausgaben der seriellen Schnittstelle im USB-Programm
+                anschauen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, der über die serielle Schnittstelle ausgegeben werden soll.
+                </li>
+            </ul>
+        </div>
+        <div id="robActions_display_text" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»LCD1602...«"><span style="color: rgb(85,85,85);">»LCD 1602
+                    ...«</span></h3>
+            <p>Mit dem Block »LCD 1602 ...« kannst du Text und Zahlen auf einem LCD 1602 anzeigen lassen. Dabei kannst
+                du zusätzlich noch bestimmen, in welcher Spalte und in welcher Zeile der Text auf dem LCD erscheinen
+                soll.</p>
+            <p>Das Display ist für Texte in mehreren Zeilen (von links nach rechts) und Spalten (von oben nach unten)
+                eingeteilt. Die Zählung beginnt jeweils bei 0.</p>
+            <p>Wenn zuvor schon etwas auf dem Display angezeigt war, werden nur die Stellen überschrieben, in die der
+                Text geschrieben wird.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 aus, das du in der
+                    Roboterkonfiguration angelegt hast.</li>
+                <li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear" class="help expert">
+            <h3 style="letter-spacing: normal;" id="BlockbeschreibungArduinoNano33BLE-»LöscheBildschirmLCD1602«">»Lösche
+                Bildschirm LCD 1602«</h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »Lösche
+                Bildschirm« kannst du Text und Zahlen auf dem LCD 1602 löschen. Das Display ist anschließend leer.
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 aus, das du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_text_i2c" class="help beginner">
+            <h3 style="letter-spacing: normal;" id="BlockbeschreibungArduinoNano33BLE-»LCD1602I²C...«">»LCD 1602 I²C
+                ...«</h3>
+            <p>Mit dem Block »LCD 1602 I²C« kannst du Text und Zahlen auf einem über den I²C-Bus angeschlossenen LCD
+                1602 anzeigen lassen. Dabei kannst du zusätzlich noch bestimmen, in welcher Spalte und in welcher Zeile
+                der Text auf dem LCD erscheinen soll.</p>
+            <p>Das Display ist für Texte in mehreren Zeilen (von links nach rechts) und Spalten (von oben nach unten)
+                eingeteilt. Die Zählung beginnt jeweils bei 0.</p>
+            <p>Wenn zuvor schon etwas auf dem Display angezeigt war, werden nur die Stellen überschrieben, in die der
+                Text geschrieben wird.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 I²C aus, das du in der
+                    Roboterkonfiguration angelegt hast.</li>
+                <li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear_i2c" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»LöscheBildschirmLCD1602I²C«">»Lösche Bildschirm LCD 1602 I²C«
+            </h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »Lösche
+                Bildschirm LCD 1602 I²C« kannst du Text und Zahlen auf dem LCD 1602 löschen, der über den I²C Bus
+                angeschlossen ist. Das Display ist anschließend leer.
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 I²C aus, das du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul>
+        </div>
+        <div id="robActions_play_tone" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»Spiele...FrequenzHz...Dauerms«">»Spiele ... Frequenz Hz ... Dauer
+                ms«</h3>
+            <p>Mit dem Block »Spiele Frequenz Hz... Dauer ms« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie
+                lange der Ton gespielt wird) programmieren. Der Ton wird über einen an den Arduino angeschlossenen
+                Lautsprecher abgespielt, bis die eingestellte Dauer erreicht ist.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Bitte beachte, dass das menschliche Gehör Frequenzen zwischen ca. 30 Hz bis ca. 15.000 Hz (15
+                        kHz) wahrnehmen kann - je nach Mensch und Alter kann dies unterschiedlich sein.</p>
+                </div>
+            </div>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Summer aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+                <li class="typcn typcn-arrow-left">Zahl, gewünschte Frequenz in Hz (Hertz) eingeben.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, gewünschte Dauer des Tons in Millisekunden (ms) eingeben.</li>
+            </ul>
+        </div>
+        <div id="robActions_brickLight_on" class="help beginner">
+            <h3 style="letter-spacing: normal;" id="BlockbeschreibungArduinoNano33BLE-»LED...an/aus«">»LED ... an/aus«
+            </h3>
+            <p><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block »LED ... an/aus«
+                    kannst du die eine an deinen Arduino angeschlossene LED ein- oder ausschalten.</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle eine LED aus, die du in der Roboterkonfiguration
+                    angelegt hast.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, An/aus, wähle aus, ob du die LED ein- oder ausschalten
+                    möchtest.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_led_on" class="help expert">
+            <h3 style="letter-spacing: normal;" id="BlockbeschreibungArduinoNano33BLE-»SetzeLEDan...Farbe«">»Setze LED
+                an ... Farbe« </h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block "Setze
+                LED an ... Farbe" kannst du eine an deinen Arduino angeschlossene Farb-LED mit einer bestimmten Farbe
+                einschalten.</p>
+            <p style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle eine RGB LED aus, die du in der
+                    Roboterkonfiguration angelegt hast.</li>
+                <li class="typcn typcn-arrow-left">Farbe, wähle dir Farbe aus, in der die LED leuchten soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_off" class="help expert">
+            <h3 style="letter-spacing: normal;" id="BlockbeschreibungArduinoNano33BLE-»SchalteLEDaus...«">»Schalte LED
+                aus ...«</h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Mit dem Block
+                »Schalte LED aus ...« kannst du die eine an deinen Arduino angeschlossene Farb-LED ausschalten.
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle eine RGB LED aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul>
+        </div>
+        <div id="robActions_write_pin" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»Schreibedigitalen/analogenWertAktor...«">»Schreibe
+                digitalen/analogen Wert Aktor ...«</h3>
+            <p>Mit dem Block »Schreibe analogen/digitalen Wert Aktor ...« kannst du einen analogen oder digitalen Wert
+                auf einen Pin deines Arduino schreiben. </p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">analog/digital, wähle aus ob du einen digitalen oder analogen
+                    Wert schreiben willst.</li>
+                <li class="typcn typcn-arrow-sorted-down">Pin, wähle den Pin aus auf den du schreiben möchtest.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert der geschrieben werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_out_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»gibanalogen/digitalenWertSensor...«">»gib analogen/digitalen Wert
+                Sensor...«</h3>
+            <p>Mit dem Block »gib analogen/digitalen Wert Sensor...« kannst du einem anderen Block »mitteilen«, welcher
+                analoge oder digitale Wert an einem Sensor deines Arduino anliegt.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»analog« oder »digital«. Stelle ein, wie der welche Art der zu
+                    messende Wert hat.</li>
+                <li class="typcn typcn-arrow-sorted-down">Pin, wähle einen Pin aus.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Wert der an dem Pin anliegt.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»GibWertmsZeitgeber«">»Gib Wert ms Zeitgeber«</h3>
+            <p>Mit dem Block »Gib Wert Zeitgeber« kannst du einem anderen Block den aktuellen Stand des internen
+                Zeitgebers in Millisekunden »mitteilen«. Der Zeitgeber wird automatisch mit dem Beginn eines Programms
+                gestartet.</p>
+            <p>Einstellöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zeitgeber-Nummer, wähle den Zeitgeber aus, dessen Wert du
+                    ermitteln möchtest.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl Millisekunden, die seit dem Programmstart oder dem
+                    letzten Zurücksetzen des Zeitgebers vergangen sind.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück«</h3>
+            <p>Mit dem Block »Setze Zeitgeber ... zurück« können die internen Zeitgeber auf den Wert 0 zurückgesetzt
+                werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zeitgeber-Nummer, wähle den Zeitgeber aus, den du zurücksetzen
+                    möchtest.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»Taste...gedrückt?«">»Taste ... gedrückt?«</h3>
+            <p>Mit dem Block »Taste ... gedrückt?« kannst du einem anderen Block »mitteilen« , ob die ausgewählte Taste
+                gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>true = gedrückt</em> oder <em>false
+                    = nicht gedrückt</em> zurück.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle eine Taste aus, die du in der Roboterkonfiguration
+                    angelegt hast.</li>
+            </ul><br>
+            <p><br>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »true«, wenn die gewählte Taste gedrückt ist, sonst
+                    »false«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_motion_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»gibAnwesenheitBewegungssensorHC-SR501...«">»gib Anwesenheit
+                Bewegungssensor HC-SR501...«</h3>
+            <p>Mit dem Block »gib Anwesenheit Bewegungssensor ...« kannst du einem anderen Block »mitteilen« , ob der
+                Bewegungssensor eine Bewegung wahrnimmt oder nicht.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, wähle einen Bewegungssensor aus, den du in der
+                        Roboterkonfiguration angelegt hast.<br></span></li>
+            </ul><br>
+            <p><br>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »true«, wenn eine Bewegung wahrgenommen wird, sonst
+                    »false«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»gibLicht%Lichtsensor...«">»gib Licht % Lichtsensor ...«</h3>
+            <p>Mit dem Block »gib Licht % Lichtsensor ...« kannst du einem anderen Block »mitteilen«, welchen
+                Helligkeitswert zwischen 0 und 100 der Lichtsensor misst.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Lichtsensor aus, den du in der
+                    Roboterkonfiguration erstellt hast.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Helligkeitswert in %<span>.</span></li>
+            </ul><br>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»GibAbstand/AnwesenheitInfrarotsensor...«">»Gib
+                Abstand/Anwesenheit Infrarotsensor ...«</h3>
+            <p>Mit dem Block »Gib Abstand/Anwesenheit Infrarotsensor ...« kannst du einem anderen Block »mitteilen«,
+                welchen Abstand der Infrarotsensor misst.</p>
+            <p>Im Modus »Abstand« wird der Abstand als Zahl übermittelt.</p>
+            <p>Im Modus »Anwesenheit« gibt der Sensor an, ob Infrarot empfangen wird oder nicht.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Ein exakte Messung der Abstände in cm ist mit dem Infrarotsensor nicht möglich. Die gemessenen
+                        Abstände sind also ungefähre Werte.</p>
+                </div>
+            </div>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»Abstand« oder »Anwesenheit«. Stelle ein, wie der
+                    Infrarotsensor messen soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Infrarotsensor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, bei »Abstand«, maximaler Abstand 70 cm.</p>
+                    <p>Logischer Wert, bei »Anwesenheit«;<span> »Wahr« wenn Infrarot empfangen wird und <span> »Falsch«
+                                wenn nicht</span></span> .</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_temperature_getSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»gibWert°TemperatursensorTMP36...«">»gib Wert ° Temperatursensor
+                TMP36...«</h3>
+            <p>Mit dem Block »gib Wert ° Temperatursensor ...« kannst du einem anderen Block »mitteilen« , welche
+                Temperatur durch den Temperatursensor gemessen wird.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Temperatursensor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><br>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die vom Sensor gemessene Temperatur in Grad Celsius.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_humidity_getSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»gibWert%LuftfeuchtigkeitsensorDHT11...«">»gib Wert %
+                Luftfeuchtigkeitsensor DHT11...«</h3>
+            <p>Mit dem Block »gib Wert % Luftfeuchtigkeitsensor ...« kannst du einem anderen Block »mitteilen«, wie hoch
+                die Luftfeuchtigkeit zwischen 0% und 100% ist, die der Luftfeuchtigkeitssensor misst.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Luftfeuchtigkeitsensor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Luftfeuchtigkeit in %.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_drop_getSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»gibWert%Tropfsensor...«">»gib Wert % Tropfsensor...«</h3>
+            <p>Mit dem Block »gib Wert % Tropfsensor ...« kannst du einem anderen Block »mitteilen«, wie hoch die nass
+                der Tropfsensor zwischen 0% und 100% ist.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Tropfensensor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Nässe in %.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_pulse_getSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»gibWertPulssensor...«">»gib Wert Pulssensor...«</h3>
+            <p>Mit dem Block »gib Wert Pulssensor ...« kannst du einem anderen Block »mitteilen«, wie hoch der Puls der
+                Person ist, bei der der Sensor verwendet wird.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Pulssensor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gemessener Puls.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_potentiometer_getSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»GibWertVPotentiometer...«">»Gib Wert V Potentiometer ...«</h3>
+            <p>Mit dem Block »Gib Wert V Potentiometer ...« kannst du einem anderen Block »mitteilen«, auf welchen Wert
+                in Volt das an deinen Arduino angeschlossene Potentiometer eingestellt ist.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle ein Potentiometer aus, das du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Spannung in Volt, auf die das Potentiometer eingestellt ist.
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_moisture_getSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»gibWert%Feuchtigkeitssensor...«">»gib Wert % Feuchtigkeitssensor
+                ...«</h3>
+            <p>Mit dem Block »gib Wert % Feuchtigkeitssensor ...« kannst du einem anderen Block »mitteilen«, wie hoch
+                die Feuchtigkeit zwischen 0 und 100 ist, die der Feuchtigkeitssensor misst.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Feuchtigkeitsensor aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Feuchtigkeit in %<span>.</span></li>
+            </ul><br>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»gibAbstandcmUltraschallHC-SR04...«">»gib Abstand cm Ultraschall
+                HC-SR04 ...«</h3>
+            <p>Mit dem Block »gib Abstand cm Ultraschall HC-SR04 ...« kannst du einem anderen Block »mitteilen«, welcher
+                Abstand in cm von dem Ultraschallsensor gemessen wird.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen Ultraschallsensor HS-SR04 aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Abstand in cm</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_rfid_getSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»gibID/AnwesenheitRFID-RC522Reader...«">»gib ID/Anwesenheit
+                RFID-RC522 Reader...«</h3>
+            <p>Mit dem Block »gib ID/Anwesenheit RFID-RC522 Reader ...« kannst du einem anderen Block »mitteilen«,
+                welche UID (Unique Identification Number) ein RFID-Tag hat, dass du an den Sensor hälst oder ob ein
+                RFID-Tag erkannt wurde.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»ID« oder »Anwesenheit«. Stelle ein, wie der Infrarotsensor
+                    messen soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle einen RFID Reader aus, den du in der
+                    Roboterkonfiguration angelegt hast.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Text,<span> bei »Kartenserie«;</span> UID des RFID-Tags.</p>
+                    <p><span>Logischer Wert, bei »Anwesenheit«;</span><span> »Wahr« wenn ein RFID-Tag erkannt wird und
+                            »Falsch« wenn nicht</span><span> .</span></p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_lsm9ds1_acceleration_getDataAvailableSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»LSM9DS1Beschleunigungx...y...z...«[Experten-Block]">»LSM9DS1
+                Beschleunigung x ... y ... z ... « <span class="typcn typcn-star"></span></h3>
+            <p>Dieser Sensor misst die Beschleunigung, die der Roboter erfährt. Dies kann z.B. die Gravitation sein, die
+                jeder Gegenstand auf der Erde erfährt.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Beschleunigung in x-Richtung
+                    gespeichert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Beschleunigung in y-Richtung
+                    gespeichert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Beschleunigung in z-Richtung
+                    gespeichert werden soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
+            </ul>
+        </div>
+        <div id="robSensors_lsm9ds1_gyro_getDataAvailableSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»LSM9DS1Gyroskopx...y...z...°/s«[Experten-Block]">»LSM9DS1
+                Gyroskop x ... y ... z ... °/s « <span class="typcn typcn-star"></span></h3>
+            <p>Dieser Sensor misst die Rotationsgeschwindigkeit deines Roboters. Dabei kann sich der Roboter um die drei
+                Achsen drehen, also die x-, y- und z-Achse.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Rotation um die x-Achse
+                    gespeichert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Rotation um die y-Achse
+                    gespeichert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Rotation um die z-Achse
+                    gespeichert werden soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
+            </ul>
+        </div>
+        <div id="robSensors_lsm9ds1_magneticfield_getDataAvailableSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»LSM9DS1Magnetfeldx...y...z...Gauss«[Experten-Block]">»LSM9DS1
+                Magnetfeld x ... y ... z ... Gauss « <span class="typcn typcn-star"></span></h3>
+            <p>Dieser Sensor misst die Anwesenheit eines Magnetfeldes. Dieses kann z.B. das Magnetfeld der Erde oder das
+                Feld einer von Strom durchflossenen Spule sein. Dabei setzt sich ein solches Magnetfeld aus drei
+                Komponenten in den drei Raumrichtungen zusammen, es formt also quasi einen Pfeil in der Luft.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Stärke des Magnetfelds in
+                    x-Richtung gespeichert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Stärke des Magnetfelds in
+                    y-Richtung gespeichert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Stärke des Magnetfelds in
+                    z-Richtung gespeichert werden soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
+            </ul>
+        </div>
+        <div id="robSensors_apds9960_distance_getDataAvailableSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»APDS9960Abstand...cm«[Experten-Block]">»APDS9960 Abstand ... cm «
+                <span class="typcn typcn-star"></span></h3>
+            <p>Dieser Sensor misst den Abstand eines Gegenstands bzw. einer Hand zu diesem Sensor. Dabei sendet der
+                Sensor Infrarot-Strahlung aus und anhand der Reflexion dieser Strahlung wird der Abstand bestimmt. Dies
+                funktioniert allerdings nur für kurze Distanzen bis etwa 20 cm.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der der Abstand des nächsten Objekts
+                    gespeichert werden soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
+            </ul>
+        </div>
+        <div id="robSensors_apds9960_gesture_getDataAvailableSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»APDS9960Geste...«[Experten-Block]">»APDS9960 Geste ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Dieser Sensor kann vordefinierte Gesten erkennen, die du mit der Hand über diesem Sensor ausführst. Dazu
+                musst du deine Hand in geringem Abstand über dem Sensor bewegen. Die möglichen Gesten sind:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="normalBullet">-1 : keine Geste erkannt</li>
+                <li class="normalBullet">0 : Hand nach vorne bewegen</li>
+                <li class="normalBullet">1 : Hand nach unten bewegen</li>
+                <li class="normalBullet">2 : Hand nach links bewegen</li>
+                <li class="normalBullet">3 : Hand nach rechts bewegen</li>
+            </ul><br>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Lage des Roboters gespeichert
+                    werden soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
+            </ul>
+        </div>
+        <div id="robSensors_apds9960_color_getDataAvailableSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»APDS9960FarbeR...G...B...«[Experten-Block]">»APDS9960 Farbe R ...
+                G ... B ... « <span class="typcn typcn-star"></span></h3>
+            <p>Dieser Sensor misst die Farbzusammensetzung des Untergrunds. Dazu sendet der Sensor die Farben Rot, Grün
+                und Blau aus und misst die Stärke des reflektierten Lichts.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Stärke des roten Lichts
+                    gespeichert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Stärke des grünen Lichts
+                    gespeichert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die Stärke des blauen Lichts
+                    gespeichert werden soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
+            </ul>
+        </div>
+        <div id="robSensors_lps22hb_pressure_getDataAvailableSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»LPS22HBLuftdruck...Pa«[Experten-Block]">»LPS22HB Luftdruck ... Pa
+                « <span class="typcn typcn-star"></span></h3>
+            <p>Dieser Sensor misst den Luftdruck der Umgebung. Der normale Luftdruck auf Höhe des Meeresspiegels ist
+                1013 Hecto Pascal.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der der momentane Luftdruck
+                    gespeichert werden soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
+            </ul>
+        </div>
+        <div id="robSensors_hts221_temperature_getDataAvailableSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»HTS221Temperatur...°C«[Experten-Block]">»HTS221 Temperatur ... °C
+                « <span class="typcn typcn-star"></span></h3>
+            <p>Dieser Sensor misst die Temperatur der Umgebung in Grad Celsius.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die momentane Temperatur
+                    gespeichert werden soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
+            </ul>
+        </div>
+        <div id="robSensors_hts221_humidity_getDataAvailableSample" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»HTS221Luftfeuchtigkeit...%«[Experten-Block]">»HTS221
+                Luftfeuchtigkeit ... % « <span class="typcn typcn-star"></span></h3>
+            <p>Dieser Sensor misst die Luftfeuchtigkeit der Umgebung in Prozent.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Variable vom Typ Zahl, in der die momentane Luftfeuchtigkeit
+                    gespeichert werden soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wahrheitswert, beschreibt ob der Sensor bereit ist oder nicht.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wennmachesonst«">»Wenn mache sonst«
+            </h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wiederholeunendlichoft«">»Wiederhole
+                unendlich oft«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wiederholenmal«">»Wiederhole n mal«
+            </h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungArduinoNano33BLE-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»FürWertausderListe«[Experten-Block]">
+                »Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Zählevonbis«[Experten-Block]">»Zähle
+                von bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungArduinoNano33BLE-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungArduinoNano33BLE-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wartems...«">»Warte ms ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wartebis...«.1">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungArduinoNano33BLE-»MathematischeFunktionen«[Experten-Block]">»Mathematische
+                Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungArduinoNano33BLE-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische
+                Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Konstanten«[Experten-Block]">
+                »Konstanten« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Zahleneigenschaft«[Experten-Block]">
+                »Zahleneigenschaft« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Erhöheumx«[Experten-Block]">»Erhöhe um
+                x« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»runden«[Experten-Block]">»runden« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Listeauswerten«[Experten-Block]">»Liste
+                auswerten« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Restvon«[Experten-Block]">»Rest von«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Begrenze«[Experten-Block]">»Begrenze«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungArduinoNano33BLE-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige
+                Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Zufallszahl«">»Zufallszahl« </h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in
+                Zeichenkette« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen«
+                <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»ErstelleText«[Experten-Block]">
+                »Erstelle Text« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungArduinoNano33BLE-»Textanhängen«[Experten-Block]">»Text
+                anhängen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle
+                Zeichen ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in
+                Liste« <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»Länge«[Experten-Block]">»Länge« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»istleer?«[Experten-Block]">»ist leer?« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungArduinoNano33BLE-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit
+                Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungArduinoNano33BLE-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ...
+                Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungArduinoNano33BLE-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot
+                ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3
+                id="BlockbeschreibungArduinoNano33BLE-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3
+                id="BlockbeschreibungArduinoNano33BLE-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage
+                innerhalb einer Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="BlockbeschreibungArduinoNano33BLE-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage
+                innerhalb einer Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="BlockbeschreibungArduinoNano33BLE-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage
+                innerhalb einer Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="BlockbeschreibungArduinoNano33BLE-»FunktionsaufrufohneRückgabewert«[Experten-Block]">
+                »Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungArduinoNano33BLE-»FunktionsaufrufmitRückgabewert«">
+                »Funktionsaufruf mit Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_nano33ble_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nano33ble_en.html
@@ -1,478 +1,1724 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start_ardu" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»Programstart«"><span style="color: rgb(0,0,0);">»Program start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Each program starts with the »Start« block, which cannot be deleted. The first block you want to use is connected directly to the »Sequence connection« on the »Repeat indefinitely« block.</p><p>For systems based on an Arduino or similar microcontroller, there is always a »repeat indefinitely« loop connected to the start block, which also cannot be removed. This is due to the fact that such microcontrollers are usually programmed for exactly one task, which then has to be executed again and again. If you only want one run of the program, you can simply make the robot wait at the end of the loop for a very long time.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">create a new global variable</li><li class="typcn typcn-minus">delete the global variable</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable</li><li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«, »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li><li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial value of the variable.</li>
-</ul></div><div id="robActions_motor_on_for_ardu" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»servomotorSG90...setto°«"><span style="color: rgb(0,0,0);">»servo motor SG90 ... set to°« </span></h3><p>With the block »servo motor SG90 ... set to°« you can set the position of your servo motor in degree. The servo motor is going to move into the position.</p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected </span>the motor to.</span></li><li class="typcn typcn-arrow-left">Ammount of degree, the motor shall be moved.</li>
-</ul><br></div><div id="robActions_motor_on_for" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»motor28BYJ-48port...onrpm...forrotation/degree...«"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»motor 28BYJ-48 port ... on  rpm ... for rotation/degree ...«</span><br></span></h3><p>With the »motor 28BYJ-48 port ... on rpm... for rotation/degree« block you can program the speed (velocity) of the selected motor. Your robot starts the selected motor and rotates the motor until the specified number of rotations or degrees is done. </p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the motor to.</span></li><li class="typcn typcn-arrow-left">number, speed in rounds per minute, in which the motor shall rotate. Negative values lets the motor rotate into the other direction.</li><li class="typcn typcn-arrow-sorted-down">rotation or degree. Choose the one which fits best. 1 rotation is the same than 360 degrees.</li><li class="typcn typcn-arrow-left">number, rotations or degrees, only positive numbers are allowed.</li>
-</ul></div><div id="robActions_set_relay" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»turnrelaySRD-05VDC-SL-C...on/off«"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»turn relay  SRD-05VDC-SL-C ... on/off«</span><br></span></h3><p>With the  »turn relay SRD-05VDC-SL-C ... on/of« block you can control the relay connected to the chosen pin.</p><p>Options and Arguments
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the relay to.</span></li><li class="typcn typcn-arrow-sorted-down">on/off, choose wether the relay is turned on or off.</li>
-</ul><br></div><div id="robActions_serial_print" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»showonSerialMonitor...«">»show on Serial Monitor ...«</h3><p>With the  »show on Serial Monitor ...« block you can send texts or numbers using the serial interface of your Arduino. Using the serial display of the usb-programm you can read these messages.</p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, you want to send.</li>
-</ul></div><div id="robActions_display_text" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»LCD1602...«"><span style="color: rgb(85,85,85);">»LCD 1602 ...«</span></h3><p>With the »LCD 1602 ...« block you can display texts or numbers on your LCD 1602. You can although set the column and row the text is .</p><p>The display is seperatet into several rows (from left to right) an rows (from top to bottom). Counting starts at 0.</p><p>If there was a text displayed before, only the characters are going to be overwritten, where the new text is going to be displayed.</p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the display to.</span></li><li class="typcn typcn-arrow-left">Text, to be shown on the display.</li><li class="typcn typcn-arrow-left">number, column-id the text is going to be shown.</li><li class="typcn typcn-arrow-left">number, row-id, the text should start at.</li>
-</ul></div><div id="robActions_display_clear" class="help expert"><h3 style="letter-spacing: normal;" id="programmingblocksArduinoNano33BLE-»cleardisplayLCD1602«">»clear display LCD 1602«</h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »clear displys LCD 1602« you can clear the text, displayed on your LCD. After using this block the display will show nothing.
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the display to.</span></li>
-</ul></div><div id="robActions_display_text_i2c" class="help beginner"><h3 style="letter-spacing: normal;" id="programmingblocksArduinoNano33BLE-»LCD1602I²C...«">»LCD 1602 I²C ...«</h3><p>With the »LCD 1602 I²C...« block you can display texts or numbers on your LCD 1602, connected to the I²C-Bus. You can although set the column and row the text is .</p><p>The display is seperatet into several rows (from left to right) an rows (from top to bottom). Counting starts at 0.</p><p>If there was a text displayed before, only the characters are going to be overwritten, where the new text is going to be displayed.</p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected</span> the display to.</li><li class="typcn typcn-arrow-left">Text, to be shown on the display.</li><li class="typcn typcn-arrow-left">number, column-id the text is going to be shown.</li><li class="typcn typcn-arrow-left">number, row-id, the text should start at.</li>
-</ul></div><div id="robActions_display_clear_i2c" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»deletedisplayLCD1602I²C«">»delete display LCD 1602 I²C«</h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »clear displys LCD 1602 I²C« you can clear the text, displayed on your LCD, connect to the I²C-Bus. After using this block the display will show nothing.</p><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected</span> the display to.</li>
-</ul></div><div id="robActions_play_tone" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»play...frequencyHz..durationms«">»play ... frequency Hz .. duration ms«</h3><p>With the »play ... frequency Hz ... duration ms« block you can program the frequency (pitch level) and the time (how long the sound should be played) that a sound is played. The sound is played by a buzzer connected to your Arduino. The frequency setting corresponds directly to the frequency in Hertz, for example, setting the frequency to 400 corresponds to 400 Hertz. Example: 261 = C.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Note that the human ear can perceive frequencies from about 30Hz to about 15,000Hz (15kHz). This can vary depending on the person and their age.</p></div></div><p>Options and Arguments::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected</span> the buzzer to.</li><li class="typcn typcn-arrow-left">Number, desired frequency in Hz (Hertz) .</li><li class="typcn typcn-arrow-left">Number, desired duration in milliseconds (ms).</li>
-</ul></div><div id="robActions_brickLight_on" class="help beginner"><h3 style="letter-spacing: normal;" id="programmingblocksArduinoNano33BLE-»LED...on/off«">»LED ... on/off«</h3><p><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »LED ... on/off«block you can switch on or off a LED connected to your Arduino.</span></p><p><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the LED to.</span></li><li class="typcn typcn-arrow-sorted-down">on/off, choose wether the LED is turned on or off.</li>
-</ul><br></div><div id="robActions_led_on" class="help expert"><h3 style="letter-spacing: normal;" id="programmingblocksArduinoNano33BLE-»turnLEDon...colour«">»turn LED on ... colour« </h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the "tunr LED on ... colour" block you can turn on a RGB-LED, connected to your Arduino in the colour you want to.</p><p style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options and Arguments::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the RGB-LED to.</span></li><li class="typcn typcn-arrow-left">colour, you want the LED to have.</li>
-</ul></div><div id="robActions_led_off" class="help expert"><h3 style="letter-spacing: normal;" id="programmingblocksArduinoNano33BLE-»turnLEDoff...«">»turn LED off ...«</h3><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »turn LED off« block you can turn off the LED.</p><p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the RGB-LED to.</span></li>
-</ul></div><div id="robActions_write_pin" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»writedigital/analogvalueactuator...«">»write digital/analog value actuator...«</h3><p>With the »write digital/analog value actuator ...« block you can write a digital or an analog value to an actuator connected to your Arduino. </p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">digital/analog, choose wether you want to write a digital or an analog value to an actuator. (By changing this option the pickable actuators change)</li><li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set the pins you connected</span> the actuator to.</span></li><li class="typcn typcn-arrow-left">Number, value to be written.</li>
-</ul><br></div><div id="robSensors_out_getSample" class="help beginner"> <h3 id="programmingblocksArduinoNano33BLE-»getanalog/digitalvaluesensor...«">»get analog/digital value sensor...«</h3><p>With the »get analog/digital value sensor...« block you can »tell« another block, wich analog or digital value is read from a sensor, connected to your Arduino.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»analog« or »digital«. pick in which format the data are read.</li><li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, value read from the sensor.</li>
-</ul> </div><div id="robSensors_timer_getSample" class="help beginner"> <h3 id="programmingblocksArduinoNano33BLE-»getvaluemstimer«">»get value ms timer«</h3><p>With the  »get value ms timer« block you can read the current state of one of the internal timers of your Arduino in millseconds. The timer is started automatically when the program starts .</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">timer-id, choose the timer, from which you want to read.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, time in milliseconds since programstart or last reset of the timer.</li>
-</ul><br></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»resettimer...«">»reset timer ...«</h3><p>With the »reset timer ...« block you can set the count of an internal timer to 0.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>timer-id, choose the timer, from which you want to reset.</span></li>
-</ul><br></div><div id="robSensors_key_getSample" class="help beginner"> <h3 id="programmingblocksArduinoNano33BLE-»button...pressed?«">»button... pressed?«</h3><p>With the »button ... pressed?« block you can query wether a button is pressed or not. </p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean value, »true«, if the button is pressed, else »false«.</li>
-</ul> </div><div id="robSensors_motion_getSample" class="help beginner"> <h3 id="programmingblocksArduinoNano33BLE-»getpresencemotionsensorHC-SR501...«">»get presence motion sensor HC-SR501...«</h3><p>With the »get presence motion sensor HC-SR501...« block you can query if the motion sensor is recognizing a motion.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean value, »true«, if the button is pressed, else »false«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><span>boolean value, »true«, if a motion is recognized, else »false«.</span></li>
-</ul> </div><div id="robSensors_light_getSample" class="help beginner"> <h3 id="programmingblocksArduinoNano33BLE-»getlight%lightsensor...«">»get light % light sensor ...«</h3><p>With the »get light % light sensor ...« block you can read the measured brighness in % from your light sensor</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, brightness from 0% to 100%.</li>
-</ul> </div><div id="robSensors_infrared_getSample" class="help expert">  <h3 id="programmingblocksArduinoNano33BLE-»getvalue/presenceinfraredsensor...«">»get value/presence infrared sensor ...«</h3><p>With the  »get value/presence infrared sensor ...« you can read the measured distance from your infrared sensor or if it detects infrared light.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>In <span>»presence«</span>-mode infrared light is detected. This can be emmited by annother infrared sensor.</p></div></div><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>An exact measurement of the distances in cm is not possible with the infrared sensor. The measured distances are therefore approximate values.</p></div></div><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»value« or »presence«, choose wich measuringmode should be used.</li><li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>number, from 0 cm to 70 cm.</p><p><span>boolean value, »true«, if infrared light is detected, else »false«.</span></p></li>
-</ul><br> </div><div id="robSensors_temperature_getSample" class="help expert">  <h3 id="programmingblocksArduinoNano33BLE-»getvalue°temperaturesensorTMP36...«">»get value ° temperature sensor TMP36...«</h3><p>With the  »get value ° temperature sensor TMP36...« you can read the temperature your sensor is measuring.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, measured temperature in degree Celsius.</li>
-</ul><br> </div><div id="robSensors_humidity_getSample" class="help expert"> <h3 id="programmingblocksArduinoNano33BLE-»gethumidity%/temperature°humiditysensorDHT11...«">»get humidity %/temperature ° humidity sensor DHT11...«</h3><p>With the  »gib humidity %/temperature ° humidity sensor DHT11...« block you can measure humidity in % or temperature in  ° Celsius.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">humidity %/temperature °, choose which value you want to read.</li><li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, humidity in % or temperature in °.</li>
-</ul> </div><div id="robSensors_drop_getSample" class="help expert"> <h3 id="programmingblocksArduinoNano33BLE-»getvalue%dropsensor...«">»get value % drop sensor...«</h3><p>With the  »get value % drop sensor ...« block you can read how wet the sensor is.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><p class="auto-cursor-target"><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, wetness between 0% and 100%.</li>
-</ul> </div><div id="robSensors_pulse_getSample" class="help expert"> <h3 id="programmingblocksArduinoNano33BLE-»getvaluepulssensor...«">»get value puls sensor...«</h3><p>With the  »get value puls sensor ...« block you can read how high the heartrate of a person, the sensor is attached to, is.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, measured pulse.</li>
-</ul> </div><div id="robSensors_potentiometer_getSample" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»getvalueVpotentiometer...«">»get value V potentiometer ...«</h3><p>With the  »get value V potentiometer ...« block you can read to which value the potentiometer is set to.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, voltage the potentiometer is set so.</li>
-</ul><br></div><div id="robSensors_moisture_getSample" class="help expert"> <h3 id="programmingblocksArduinoNano33BLE-»getvalue%moisturesensor...«">»get value % moisture sensor ...«</h3><p>With the  »get value % moisture sensor ...« block you can read the moisture between 0% and 100%.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><p class="auto-cursor-target"><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, moisture in %.</li>
-</ul> </div><div id="robSensors_ultrasonic_getSample" class="help expert"> <h3 id="programmingblocksArduinoNano33BLE-»getdistancecmultrasonicsensorHC-SR04...«">»get distance cm ultrasonic sensor HC-SR04 ...«</h3><p>With the  »get distance ultrasonic sensor HC-SR04 ...« block you can measure the distance between your ultrasonic sensor and an obstacle.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the sensor to.</span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, distance in cm</li>
-</ul><br> </div><div id="robSensors_rfid_getSample" class="help expert"> <h3 id="programmingblocksArduinoNano33BLE-»getID/presenceRFID-RC522Reader...«">»get ID/presence RFID-RC522 Reader...«</h3><p>With the  »get ID/presence RFID-RC522 Reader ...« block you can read which  UID (Unique Identification Number) an RFID-Tag got or if a RFID-Tag was recognized.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»ID« or »presence«. choose the value to be measured.</li><li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the pins you connected the RFID-reader to.</span></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Text,<span> when »ID«;</span> UID of the RFID-Tags.</p><p><span>boolean, when »presence«;</span><span> »true« if a RFID-Tag was detected, else »false«</span><span> .</span></p></li>
-</ul><br> </div><div id="robSensors_lsm9ds1_acceleration_getDataAvailableSample" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»LSM9DS1accelerationx...y...z...milli-g«[Expertblock]">»LSM9DS1 acceleration x ... y ... z ... milli-g « <span class="typcn typcn-star"></span></h3><p>This sensor measures the acceleration that the robot experiences. This can be, for example, the gravity experienced by any object on Earth.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, variable of type Number, in which the acceleration in x-direction is to be stored.</li><li class="typcn typcn-arrow-left">Number, variable of type Number, in which the acceleration in y-direction is to be stored.</li><li class="typcn typcn-arrow-left">Number, variable of type Number, in which the acceleration in z-direction is to be stored.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
-</ul></div><div id="robSensors_lsm9ds1_gyro_getDataAvailableSample" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»LSM9DS1gyroscopex...y...z...°/s«[Expertblock]">»LSM9DS1 gyroscope x ... y ... z ... °/s « <span class="typcn typcn-star"></span></h3><p>This sensor measures the rotational speed of your robot. It allows the measure the robot's rotation around the three axes, i.e. the x-, y- and z-axis.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, variable of type Number, in which the rotational speed around the x-axis is to be stored.</li><li class="typcn typcn-arrow-left">Number, variable of type Number, in which the rotational speed around the y-axis is to be stored.</li><li class="typcn typcn-arrow-left">Number, variable of type Number, in which the rotational speed around the z-axis is to be stored.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
-</ul></div><div id="robSensors_lsm9ds1_magneticfield_getDataAvailableSample" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»LSM9DS1magneticfieldx...y...z...Gauss«[Expertblock]">»LSM9DS1 magnetic field x ... y ... z ... Gauss « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: 0.0px;">This sensor measures the presence of a magnetic field. This can be, for example, the magnetic field of the earth or the field of a coil through which current flows. Such a magnetic field consists of three components in the three spatial directions, so it virtually forms an arrow in the air.</span></p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, variable of type Number, in which the strength of the magnetic field in x-direction is to be stored.</li><li class="typcn typcn-arrow-left">Number, variable of type Number, in which the strength of the magnetic field in y-direction is to be stored.</li><li class="typcn typcn-arrow-left">Number, variable of type Number, in which the strength of the magnetic field in z-direction is to be stored.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
-</ul></div><div id="robSensors_apds9960_distance_getDataAvailableSample" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»APD9960distance...cm«[Expertblock]">»APD9960 distance ... cm « <span class="typcn typcn-star"></span></h3><p>This sensor measures the distance of an object or hand to this sensor. The sensor emits infrared radiation and the distance is determined based on the reflection of this radiation. However, this only works for short distances up to about 20 cm.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, variable of type Number, in which the distance to the nearest object is to be stored.</li>
-</ul><br><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
-</ul></div><div id="robSensors_apds9960_gesture_getDataAvailableSample" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»APD9960gesture...«[Expertblock]">»APD9960 gesture ... « <span class="typcn typcn-star"></span></h3><p>This sensor can recognize predefined gestures that you perform with your hand over this sensor. To do this, you have to move your hand a short distance above the sensor. The possible gestures are:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="normalBullet">-1 : no gesture detected.</li><li class="normalBullet">0 : hand moved forwards</li><li class="normalBullet">1 : hand moved backwards</li><li class="normalBullet">2 : hand moved to the left</li><li class="normalBullet">3 : hand moved to the right</li>
-</ul><br><p>input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, variable of type number in which the number of the detected gesture is to be stored.</li>
-</ul><br><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
-</ul></div><div id="robSensors_apds9960_color_getDataAvailableSample" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»APD9960colorR...G...B...«[Expertblock]">»APD9960 color R ... G ... B ... « <span class="typcn typcn-star"></span></h3><p>This sensor measures the color composition of the underlying surface. To do this, the sensor emits the colors red, green and blue and measures the strength of the reflected light.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, variable of type number in value in which the strength of the red light is to be stored.</li><li class="typcn typcn-arrow-left">Number, variable of type number in value in which the strength of the green light is to be stored.</li><li class="typcn typcn-arrow-left">Number, variable of type number in value in which the strength of the blue light is to be stored.</li>
-</ul><br><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
-</ul></div><div id="robSensors_lps22hb_pressure_getDataAvailableSample" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»LPS22HBpressure...hPa«[Expertblock]">»LPS22HB pressure ... hPa « <span class="typcn typcn-star"></span></h3><p>This sensor measures the air pressure of the environment. The normal air pressure at sea level is 1013 hPa.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, variable of type number in which the air pressure of the surroundings is to be stored.</li>
-</ul><br><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
-</ul></div><div id="robSensors_hts221_temperature_getDataAvailableSample" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»HTS221temperature...°C«[Expertblock]">»HTS221 temperature ... °C « <span class="typcn typcn-star"></span></h3><p>This sensors measures the temperature of the surroundings.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, variable of type number in which the temperature of the surroundings is to be stored.</li>
-</ul><br><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
-</ul></div><div id="robSensors_hts221_humidity_getDataAvailableSample" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»HTS221humidity...%«[Expertblock]">»HTS221 humidity ... % « <span class="typcn typcn-star"></span></h3><p>This sensors measures the humidity of the surroundings in percent.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, variable of type number in which the humidity of the surroundings is to be stored.</li>
-</ul><br><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="programmingblocksArduinoNano33BLE-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="programmingblocksArduinoNano33BLE-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="programmingblocksArduinoNano33BLE-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="programmingblocksArduinoNano33BLE-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="programmingblocksArduinoNano33BLE-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="programmingblocksArduinoNano33BLE-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="programmingblocksArduinoNano33BLE-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="programmingblocksArduinoNano33BLE-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="programmingblocksArduinoNano33BLE-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="programmingblocksArduinoNano33BLE-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="programmingblocksArduinoNano33BLE-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="programmingblocksArduinoNano33BLE-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="programmingblocksArduinoNano33BLE-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="programmingblocksArduinoNano33BLE-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="programmingblocksArduinoNano33BLE-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="programmingblocksArduinoNano33BLE-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="programmingblocksArduinoNano33BLE-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="programmingblocksArduinoNano33BLE-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="programmingblocksArduinoNano33BLE-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="programmingblocksArduinoNano33BLE-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="programmingblocksArduinoNano33BLE-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="programmingblocksArduinoNano33BLE-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="programmingblocksArduinoNano33BLE-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="programmingblocksArduinoNano33BLE-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="programmingblocksArduinoNano33BLE-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="programmingblocksArduinoNano33BLE-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="programmingblocksArduinoNano33BLE-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="programmingblocksArduinoNano33BLE-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="programmingblocksArduinoNano33BLE-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="programmingblocksArduinoNano33BLE-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="programmingblocksArduinoNano33BLE-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start_ardu" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»Programstart«"><span style="color: rgb(0,0,0);">»Program
+                    start«</span><span style="color: rgb(0,0,0);"> </span></h3>
+            <p>Each program starts with the »Start« block, which cannot be deleted. The first block you want to use is
+                connected directly to the »Sequence connection« on the »Repeat indefinitely« block.</p>
+            <p>For systems based on an Arduino or similar microcontroller, there is always a »repeat indefinitely« loop
+                connected to the start block, which also cannot be removed. This is due to the fact that such
+                microcontrollers are usually programmed for exactly one task, which then has to be executed again and
+                again. If you only want one run of the program, you can simply make the robot wait at the end of the
+                loop for a very long time.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">create a new global variable</li>
+                <li class="typcn typcn-minus">delete the global variable</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«,
+                    »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li>
+                <li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial
+                    value of the variable.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on_for_ardu" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»servomotorSG90...setto°«"><span style="color: rgb(0,0,0);">»servo
+                    motor SG90 ... set to°« </span></h3>
+            <p>With the block »servo motor SG90 ... set to°« you can set the position of your servo motor in degree. The
+                servo motor is going to move into the position.</p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected </span>the motor to.</span></li>
+                <li class="typcn typcn-arrow-left">Ammount of degree, the motor shall be moved.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on_for" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»motor28BYJ-48port...onrpm...forrotation/degree...«"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»motor 28BYJ-48 port ... on rpm ...
+                        for rotation/degree ...«</span><br></span></h3>
+            <p>With the »motor 28BYJ-48 port ... on rpm... for rotation/degree« block you can program the speed
+                (velocity) of the selected motor. Your robot starts the selected motor and rotates the motor until the
+                specified number of rotations or degrees is done. </p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the motor to.</span></li>
+                <li class="typcn typcn-arrow-left">number, speed in rounds per minute, in which the motor shall rotate.
+                    Negative values lets the motor rotate into the other direction.</li>
+                <li class="typcn typcn-arrow-sorted-down">rotation or degree. Choose the one which fits best. 1 rotation
+                    is the same than 360 degrees.</li>
+                <li class="typcn typcn-arrow-left">number, rotations or degrees, only positive numbers are allowed.</li>
+            </ul>
+        </div>
+        <div id="robActions_set_relay" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»turnrelaySRD-05VDC-SL-C...on/off«"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»turn relay SRD-05VDC-SL-C ...
+                        on/off«</span><br></span></h3>
+            <p>With the »turn relay SRD-05VDC-SL-C ... on/of« block you can control the relay connected to the chosen
+                pin.</p>
+            <p>Options and Arguments
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the relay to.</span></li>
+                <li class="typcn typcn-arrow-sorted-down">on/off, choose wether the relay is turned on or off.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_serial_print" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»showonSerialMonitor...«">»show on Serial Monitor ...«</h3>
+            <p>With the »show on Serial Monitor ...« block you can send texts or numbers using the serial interface of
+                your Arduino. Using the serial display of the usb-programm you can read these messages.</p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, you want to send.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_text" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»LCD1602...«"><span style="color: rgb(85,85,85);">»LCD 1602
+                    ...«</span></h3>
+            <p>With the »LCD 1602 ...« block you can display texts or numbers on your LCD 1602. You can although set the
+                column and row the text is .</p>
+            <p>The display is seperatet into several rows (from left to right) an rows (from top to bottom). Counting
+                starts at 0.</p>
+            <p>If there was a text displayed before, only the characters are going to be overwritten, where the new text
+                is going to be displayed.</p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the display to.</span></li>
+                <li class="typcn typcn-arrow-left">Text, to be shown on the display.</li>
+                <li class="typcn typcn-arrow-left">number, column-id the text is going to be shown.</li>
+                <li class="typcn typcn-arrow-left">number, row-id, the text should start at.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear" class="help expert">
+            <h3 style="letter-spacing: normal;" id="programmingblocksArduinoNano33BLE-»cleardisplayLCD1602«">»clear
+                display LCD 1602«</h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »clear
+                displys LCD 1602« you can clear the text, displayed on your LCD. After using this block the display will
+                show nothing.
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the display to.</span></li>
+            </ul>
+        </div>
+        <div id="robActions_display_text_i2c" class="help beginner">
+            <h3 style="letter-spacing: normal;" id="programmingblocksArduinoNano33BLE-»LCD1602I²C...«">»LCD 1602 I²C
+                ...«</h3>
+            <p>With the »LCD 1602 I²C...« block you can display texts or numbers on your LCD 1602, connected to the
+                I²C-Bus. You can although set the column and row the text is .</p>
+            <p>The display is seperatet into several rows (from left to right) an rows (from top to bottom). Counting
+                starts at 0.</p>
+            <p>If there was a text displayed before, only the characters are going to be overwritten, where the new text
+                is going to be displayed.</p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected</span> the display to.</li>
+                <li class="typcn typcn-arrow-left">Text, to be shown on the display.</li>
+                <li class="typcn typcn-arrow-left">number, column-id the text is going to be shown.</li>
+                <li class="typcn typcn-arrow-left">number, row-id, the text should start at.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear_i2c" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»deletedisplayLCD1602I²C«">»delete display LCD 1602 I²C«</h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »clear
+                displys LCD 1602 I²C« you can clear the text, displayed on your LCD, connect to the I²C-Bus. After using
+                this block the display will show nothing.</p>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected</span> the display to.</li>
+            </ul>
+        </div>
+        <div id="robActions_play_tone" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»play...frequencyHz..durationms«">»play ... frequency Hz ..
+                duration ms«</h3>
+            <p>With the »play ... frequency Hz ... duration ms« block you can program the frequency (pitch level) and
+                the time (how long the sound should be played) that a sound is played. The sound is played by a buzzer
+                connected to your Arduino. The frequency setting corresponds directly to the frequency in Hertz, for
+                example, setting the frequency to 400 corresponds to 400 Hertz. Example: 261 = C.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Note that the human ear can perceive frequencies from about 30Hz to about 15,000Hz (15kHz). This
+                        can vary depending on the person and their age.</p>
+                </div>
+            </div>
+            <p>Options and Arguments::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected</span> the buzzer to.</li>
+                <li class="typcn typcn-arrow-left">Number, desired frequency in Hz (Hertz) .</li>
+                <li class="typcn typcn-arrow-left">Number, desired duration in milliseconds (ms).</li>
+            </ul>
+        </div>
+        <div id="robActions_brickLight_on" class="help beginner">
+            <h3 style="letter-spacing: normal;" id="programmingblocksArduinoNano33BLE-»LED...on/off«">»LED ... on/off«
+            </h3>
+            <p><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »LED ... on/off«block you
+                    can switch on or off a LED connected to your Arduino.</span></p>
+            <p><span style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the LED to.</span></li>
+                <li class="typcn typcn-arrow-sorted-down">on/off, choose wether the LED is turned on or off.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_led_on" class="help expert">
+            <h3 style="letter-spacing: normal;" id="programmingblocksArduinoNano33BLE-»turnLEDon...colour«">»turn LED on
+                ... colour« </h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the "tunr LED on
+                ... colour" block you can turn on a RGB-LED, connected to your Arduino in the colour you want to.</p>
+            <p style="color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options and Arguments::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the RGB-LED to.</span></li>
+                <li class="typcn typcn-arrow-left">colour, you want the LED to have.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_off" class="help expert">
+            <h3 style="letter-spacing: normal;" id="programmingblocksArduinoNano33BLE-»turnLEDoff...«">»turn LED off
+                ...«</h3>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">With the »turn LED
+                off« block you can turn off the LED.</p>
+            <p style="margin-top: 10.0px;color: rgb(51,51,51);font-size: 14.0px;font-weight: 300;">Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the RGB-LED to.</span></li>
+            </ul>
+        </div>
+        <div id="robActions_write_pin" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»writedigital/analogvalueactuator...«">»write digital/analog value
+                actuator...«</h3>
+            <p>With the »write digital/analog value actuator ...« block you can write a digital or an analog value to an
+                actuator connected to your Arduino. </p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">digital/analog, choose wether you want to write a digital or
+                    an analog value to an actuator. (By changing this option the pickable actuators change)</li>
+                <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
+                            the pins you connected</span> the actuator to.</span></li>
+                <li class="typcn typcn-arrow-left">Number, value to be written.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_out_getSample" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»getanalog/digitalvaluesensor...«">»get analog/digital value
+                sensor...«</h3>
+            <p>With the »get analog/digital value sensor...« block you can »tell« another block, wich analog or digital
+                value is read from a sensor, connected to your Arduino.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»analog« or »digital«. pick in which format the data are read.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, value read from the sensor.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»getvaluemstimer«">»get value ms timer«</h3>
+            <p>With the »get value ms timer« block you can read the current state of one of the internal timers of your
+                Arduino in millseconds. The timer is started automatically when the program starts .</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">timer-id, choose the timer, from which you want to read.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, time in milliseconds since programstart or last reset of the
+                    timer.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»resettimer...«">»reset timer ...«</h3>
+            <p>With the »reset timer ...« block you can set the count of an internal timer to 0.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>timer-id, choose the timer, from which you want to
+                        reset.</span></li>
+            </ul><br>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»button...pressed?«">»button... pressed?«</h3>
+            <p>With the »button ... pressed?« block you can query wether a button is pressed or not. </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean value, »true«, if the button is pressed, else »false«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_motion_getSample" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»getpresencemotionsensorHC-SR501...«">»get presence motion sensor
+                HC-SR501...«</h3>
+            <p>With the »get presence motion sensor HC-SR501...« block you can query if the motion sensor is recognizing
+                a motion.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean value, »true«, if the button is pressed, else »false«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"><span>boolean value, »true«, if a motion is recognized, else
+                        »false«.</span></li>
+            </ul>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»getlight%lightsensor...«">»get light % light sensor ...«</h3>
+            <p>With the »get light % light sensor ...« block you can read the measured brighness in % from your light
+                sensor</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, brightness from 0% to 100%.</li>
+            </ul>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»getvalue/presenceinfraredsensor...«">»get value/presence infrared
+                sensor ...«</h3>
+            <p>With the »get value/presence infrared sensor ...« you can read the measured distance from your infrared
+                sensor or if it detects infrared light.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>In <span>»presence«</span>-mode infrared light is detected. This can be emmited by annother
+                        infrared sensor.</p>
+                </div>
+            </div>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>An exact measurement of the distances in cm is not possible with the infrared sensor. The
+                        measured distances are therefore approximate values.</p>
+                </div>
+            </div>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»value« or »presence«, choose wich measuringmode should be
+                    used.</li>
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>number, from 0 cm to 70 cm.</p>
+                    <p><span>boolean value, »true«, if infrared light is detected, else »false«.</span></p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_temperature_getSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»getvalue°temperaturesensorTMP36...«">»get value ° temperature
+                sensor TMP36...«</h3>
+            <p>With the »get value ° temperature sensor TMP36...« you can read the temperature your sensor is measuring.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, measured temperature in degree Celsius.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_humidity_getSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»gethumidity%/temperature°humiditysensorDHT11...«">»get humidity
+                %/temperature ° humidity sensor DHT11...«</h3>
+            <p>With the »gib humidity %/temperature ° humidity sensor DHT11...« block you can measure humidity in % or
+                temperature in ° Celsius.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">humidity %/temperature °, choose which value you want to read.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, humidity in % or temperature in °.</li>
+            </ul>
+        </div>
+        <div id="robSensors_drop_getSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»getvalue%dropsensor...«">»get value % drop sensor...«</h3>
+            <p>With the »get value % drop sensor ...« block you can read how wet the sensor is.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul>
+            <p class="auto-cursor-target"><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, wetness between 0% and 100%.</li>
+            </ul>
+        </div>
+        <div id="robSensors_pulse_getSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»getvaluepulssensor...«">»get value puls sensor...«</h3>
+            <p>With the »get value puls sensor ...« block you can read how high the heartrate of a person, the sensor is
+                attached to, is.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, measured pulse.</li>
+            </ul>
+        </div>
+        <div id="robSensors_potentiometer_getSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»getvalueVpotentiometer...«">»get value V potentiometer ...«</h3>
+            <p>With the »get value V potentiometer ...« block you can read to which value the potentiometer is set to.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, voltage the potentiometer is set so.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_moisture_getSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»getvalue%moisturesensor...«">»get value % moisture sensor ...«
+            </h3>
+            <p>With the »get value % moisture sensor ...« block you can read the moisture between 0% and 100%.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul>
+            <p class="auto-cursor-target"><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, moisture in %.</li>
+            </ul>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»getdistancecmultrasonicsensorHC-SR04...«">»get distance cm
+                ultrasonic sensor HC-SR04 ...«</h3>
+            <p>With the »get distance ultrasonic sensor HC-SR04 ...« block you can measure the distance between your
+                ultrasonic sensor and an obstacle.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the sensor to.</span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, distance in cm</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_rfid_getSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»getID/presenceRFID-RC522Reader...«">»get ID/presence RFID-RC522
+                Reader...«</h3>
+            <p>With the »get ID/presence RFID-RC522 Reader ...« block you can read which UID (Unique Identification
+                Number) an RFID-Tag got or if a RFID-Tag was recognized.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»ID« or »presence«. choose the value to be measured.</li>
+                <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
+                        pins you connected the RFID-reader to.</span></li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Text,<span> when »ID«;</span> UID of the RFID-Tags.</p>
+                    <p><span>boolean, when »presence«;</span><span> »true« if a RFID-Tag was detected, else
+                            »false«</span><span> .</span></p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_lsm9ds1_acceleration_getDataAvailableSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»LSM9DS1accelerationx...y...z...milli-g«[Expertblock]">»LSM9DS1
+                acceleration x ... y ... z ... milli-g « <span class="typcn typcn-star"></span></h3>
+            <p>This sensor measures the acceleration that the robot experiences. This can be, for example, the gravity
+                experienced by any object on Earth.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, variable of type Number, in which the acceleration in
+                    x-direction is to be stored.</li>
+                <li class="typcn typcn-arrow-left">Number, variable of type Number, in which the acceleration in
+                    y-direction is to be stored.</li>
+                <li class="typcn typcn-arrow-left">Number, variable of type Number, in which the acceleration in
+                    z-direction is to be stored.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
+            </ul>
+        </div>
+        <div id="robSensors_lsm9ds1_gyro_getDataAvailableSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»LSM9DS1gyroscopex...y...z...°/s«[Expertblock]">»LSM9DS1 gyroscope
+                x ... y ... z ... °/s « <span class="typcn typcn-star"></span></h3>
+            <p>This sensor measures the rotational speed of your robot. It allows the measure the robot's rotation
+                around the three axes, i.e. the x-, y- and z-axis.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, variable of type Number, in which the rotational speed around
+                    the x-axis is to be stored.</li>
+                <li class="typcn typcn-arrow-left">Number, variable of type Number, in which the rotational speed around
+                    the y-axis is to be stored.</li>
+                <li class="typcn typcn-arrow-left">Number, variable of type Number, in which the rotational speed around
+                    the z-axis is to be stored.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
+            </ul>
+        </div>
+        <div id="robSensors_lsm9ds1_magneticfield_getDataAvailableSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»LSM9DS1magneticfieldx...y...z...Gauss«[Expertblock]">»LSM9DS1
+                magnetic field x ... y ... z ... Gauss « <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: 0.0px;">This sensor measures the presence of a magnetic field. This can be,
+                    for example, the magnetic field of the earth or the field of a coil through which current flows.
+                    Such a magnetic field consists of three components in the three spatial directions, so it virtually
+                    forms an arrow in the air.</span></p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, variable of type Number, in which the strength of the
+                    magnetic field in x-direction is to be stored.</li>
+                <li class="typcn typcn-arrow-left">Number, variable of type Number, in which the strength of the
+                    magnetic field in y-direction is to be stored.</li>
+                <li class="typcn typcn-arrow-left">Number, variable of type Number, in which the strength of the
+                    magnetic field in z-direction is to be stored.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
+            </ul>
+        </div>
+        <div id="robSensors_apds9960_distance_getDataAvailableSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»APD9960distance...cm«[Expertblock]">»APD9960 distance ... cm «
+                <span class="typcn typcn-star"></span></h3>
+            <p>This sensor measures the distance of an object or hand to this sensor. The sensor emits infrared
+                radiation and the distance is determined based on the reflection of this radiation. However, this only
+                works for short distances up to about 20 cm.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, variable of type Number, in which the distance to the nearest
+                    object is to be stored.</li>
+            </ul><br>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
+            </ul>
+        </div>
+        <div id="robSensors_apds9960_gesture_getDataAvailableSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»APD9960gesture...«[Expertblock]">»APD9960 gesture ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This sensor can recognize predefined gestures that you perform with your hand over this sensor. To do
+                this, you have to move your hand a short distance above the sensor. The possible gestures are:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="normalBullet">-1 : no gesture detected.</li>
+                <li class="normalBullet">0 : hand moved forwards</li>
+                <li class="normalBullet">1 : hand moved backwards</li>
+                <li class="normalBullet">2 : hand moved to the left</li>
+                <li class="normalBullet">3 : hand moved to the right</li>
+            </ul><br>
+            <p>input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, variable of type number in which the number of the detected
+                    gesture is to be stored.</li>
+            </ul><br>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
+            </ul>
+        </div>
+        <div id="robSensors_apds9960_color_getDataAvailableSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»APD9960colorR...G...B...«[Expertblock]">»APD9960 color R ... G
+                ... B ... « <span class="typcn typcn-star"></span></h3>
+            <p>This sensor measures the color composition of the underlying surface. To do this, the sensor emits the
+                colors red, green and blue and measures the strength of the reflected light.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, variable of type number in value in which the strength of the
+                    red light is to be stored.</li>
+                <li class="typcn typcn-arrow-left">Number, variable of type number in value in which the strength of the
+                    green light is to be stored.</li>
+                <li class="typcn typcn-arrow-left">Number, variable of type number in value in which the strength of the
+                    blue light is to be stored.</li>
+            </ul><br>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
+            </ul>
+        </div>
+        <div id="robSensors_lps22hb_pressure_getDataAvailableSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»LPS22HBpressure...hPa«[Expertblock]">»LPS22HB pressure ... hPa «
+                <span class="typcn typcn-star"></span></h3>
+            <p>This sensor measures the air pressure of the environment. The normal air pressure at sea level is 1013
+                hPa.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, variable of type number in which the air pressure of the
+                    surroundings is to be stored.</li>
+            </ul><br>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
+            </ul>
+        </div>
+        <div id="robSensors_hts221_temperature_getDataAvailableSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»HTS221temperature...°C«[Expertblock]">»HTS221 temperature ... °C
+                « <span class="typcn typcn-star"></span></h3>
+            <p>This sensors measures the temperature of the surroundings.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, variable of type number in which the temperature of the
+                    surroundings is to be stored.</li>
+            </ul><br>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
+            </ul>
+        </div>
+        <div id="robSensors_hts221_humidity_getDataAvailableSample" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»HTS221humidity...%«[Expertblock]">»HTS221 humidity ... % « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This sensors measures the humidity of the surroundings in percent.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, variable of type number in which the humidity of the
+                    surroundings is to be stored.</li>
+            </ul><br>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">boolean, shows whether the sensor is ready or not.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="programmingblocksArduinoNano33BLE-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»breakout/continuewithnextiterationofloop«[Expert-block]">»break
+                out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="programmingblocksArduinoNano33BLE-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="programmingblocksArduinoNano33BLE-»test«[Expert-block]">»test« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»null«[Expert-block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»mathematicalfunction«[Expert-block]">»mathematical function«
+                <span class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»trigonometricfunctions«[Expert-block]">»trigonometric functions«
+                <span class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»constant«[Expert-block]">»constant« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»round«[Expert-block]">»round« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="programmingblocksArduinoNano33BLE-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»constrain«[Expert-block]">»constrain« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="programmingblocksArduinoNano33BLE-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="programmingblocksArduinoNano33BLE-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="programmingblocksArduinoNano33BLE-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="programmingblocksArduinoNano33BLE-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="programmingblocksArduinoNano33BLE-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="programmingblocksArduinoNano33BLE-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="programmingblocksArduinoNano33BLE-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="programmingblocksArduinoNano33BLE-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index
+                ... to Number« <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="programmingblocksArduinoNano33BLE-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="programmingblocksArduinoNano33BLE-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="programmingblocksArduinoNano33BLE-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="programmingblocksArduinoNano33BLE-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="programmingblocksArduinoNano33BLE-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="programmingblocksArduinoNano33BLE-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="programmingblocksArduinoNano33BLE-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="programmingblocksArduinoNano33BLE-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="programmingblocksArduinoNano33BLE-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="programmingblocksArduinoNano33BLE-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="programmingblocksArduinoNano33BLE-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="programmingblocksArduinoNano33BLE-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour
+                with red ... green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="programmingblocksArduinoNano33BLE-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red
+                ... green ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="programmingblocksArduinoNano33BLE-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red
+                ... green ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="programmingblocksArduinoNano33BLE-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»Functionblockswith/withoutinputparametersandnoreturnstatement«">
+                »Function blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»Functionblockswith/withoutinputparameterswithreturnstatements«">
+                »Function blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»ifblocktobeusedwithinafunction«">»if block to be used within a
+                function«</h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="programmingblocksArduinoNano33BLE-Ifstatementwithinafunctionwithreturnvalue:">If statement within a
+                function with return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="programmingblocksArduinoNano33BLE-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within
+                a function with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="programmingblocksArduinoNano33BLE-»functioncallwithoutreturnvalue«">»function call without return
+                value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="programmingblocksArduinoNano33BLE-»functioncallwithreturnvalue«">
+                »function call with return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_nao_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nao_de.html
@@ -1,417 +1,1575 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="ProgrammierungNAO-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am »Start«-Block.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus">Entferne die globale Variable.</li><li class="typcn typcn-input-checked">Zeige Sensordaten - während des Programmablaufs werden im Display die Werte der angeschlossenen Sensoren gezeigt.</li>
-</ul>Wenn globale Variablen erzeugt wurden:<ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variablen.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
-</ul><br></div><div id="naoActions_applyPosture" class="help beginner"><h3 id="ProgrammierungNAO-»LasseNAO...«">»Lasse NAO ... «</h3><p>Mit diesem Block kannst du die Aktion deines Roboters steuern. Der Roboter kann dabei viele verschiedene Positionen einnehmen, wie z.B. hocken, stehen oder sitzen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Position aus, die dein Roboter einnehmen soll.</li>
-</ul></div><div id="naoActions_hand" class="help expert"><h3 id="ProgrammierungNAO-»Hand......«[ExpertenBlock]">»Hand ... ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine Hand deines Roboters kontrollieren. Die Hand kann sich dabei entweder öffnen oder schließen.</p><p class="auto-cursor-target">Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Hand aus, die du steuern möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle ob sich die Hand öffnen oder schließen soll.</li>
-</ul></div><div id="naoActions_moveJoint" class="help expert"><h3 id="ProgrammierungNAO-»Bewege.........«[ExpertenBlock]">»Bewege ... ... ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du ein einzelnes Gelenk deines Roboters ansteuern. Die Gelenke können sich dabei entweder relativ zu ihrer jetzigen Position oder absolut zu ihrer Ausgangsposition bewegen.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle das Gelenk aus, das du ansteuern möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle ob die Bewegung relativ zur jetzigen Position oder absolut zur Ausgangsposition sein soll.</li><li class="typcn typcn-arrow-left">Zahl, Rotation des Gelenks in Grad °. Zahl zwischen 0 und 360.</li>
-</ul></div><div id="naoActions_stiffness" class="help expert"><h3 id="ProgrammierungNAO-»BlockiereMotoren......«[ExpertenBlock]">»Blockiere Motoren ... ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du die Motoren eines Bereichs deines Roboters blockieren, sodass sich dieser Motor nicht mehr bewegen kann, bis die Blockierung wieder aufgehoben wird.</span></p><p><span style="letter-spacing: -0.006em;">Optionen:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den Bereich deines Roboters, dessen Motoren du blockieren möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle ob die Motoren blockiert werden sollen oder nicht.</li>
-</ul></div><div id="naoActions_walk" class="help beginner"><h3 id="ProgrammierungNAO-»Gehe...Streckecm...«">»Gehe ... Strecke cm ... «</h3><p>Mit diesem Block kannst du deinen Roboter eine gewisse Strecke geradeaus laufen lassen.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle ob der Roboter vorwärts oder rückwärts gehen soll.</li><li class="typcn typcn-arrow-left">Zahl, die Strecke die der Roboter zurücklegen soll in Zentimetern.</li>
-</ul></div><div id="naoActions_turn" class="help beginner"><h3 id="ProgrammierungNAO-»Drehe...Grad°...«">»Drehe ... Grad ° ... «</h3><p>Mit diesem Block kannst du deinen Roboter auf der Stelle drehen.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle ob sich der Roboter nach rechts oder links drehen soll.</li><li class="typcn typcn-arrow-left">Zahl, wähle den Winkel um den sich der Roboter drehen soll.</li>
-</ul></div><div id="naoActions_walkTo" class="help expert"><h3 id="ProgrammierungNAO-»Gehezux...y...Theta...«[ExpertenBlock]">»Gehe zu x ... y ... Theta ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du deinen Roboter relativ zu seiner jetzigen Position bewegen.</span></p><p><span style="letter-spacing: -0.006em;">Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, x-Koordinate für die neue Position,</li><li class="typcn typcn-arrow-left">Zahl, y-Koordinate für die neue Position.</li><li class="typcn typcn-arrow-left">Zahl, Winkel um die sich dein Roboter drehen soll.</li>
-</ul></div><div id="naoActions_walk_async" class="help expert"><h3 id="ProgrammierungNAO-»GehezuxTempo%...yTempo%...DreheTempo%...«[ExpertenBlock]">»Gehe zu x Tempo % ... y Tempo % ... Drehe Tempo % ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du die Geschwindigkeit deines Roboters bei einer freien Bewegung einstellen.</span></p><p><span style="letter-spacing: -0.006em;">Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Tempo für die Bewegung in x-Richtung. Zahl zwischen 1 und 100.</li><li class="typcn typcn-arrow-left">Zahl, Tempo für die Bewegung in y-Richtung. Zahl zwischen 1 und 100.</li><li class="typcn typcn-arrow-sorted-down">Zahl, Tempo für die Drehung deines Roboters. Zahl zwischen 1 und 100.</li>
-</ul></div><div id="naoActions_stop" class="help expert"><h3 id="ProgrammierungNAO-»StoppeBewegung...«[ExpertenBlock]">»Stoppe Bewegung ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du alle laufenden Bewegungen deines Roboters stoppen.</span></p></div><div id="naoActions_animation" class="help beginner"><h3 id="ProgrammierungNAO-»Führeaus...«">»Führe aus ... «</h3><p>Mit diesem Block kannst du deinen Roboter eine vorgefertigte Animation ausführen lassen. Zur Auswahl stehen dabei Tai Chi, Winken, Blinken und die Stirn wischen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle eine vorgefertigte Animation aus.</li>
-</ul></div><div id="naoActions_autonomous" class="help expert"><h3 id="ProgrammierungNAO-»SchalteautonomesVerhalten...«[ExpertenBlock]">»Schalte autonomes Verhalten ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du das autonome Verhalten deines Roboters ein- oder ausschalten. Mit eingeschaltetem autonomen Verhalten läuft der Roboter z.B. nicht gegen Wände.</span></p><p><span style="letter-spacing: -0.006em;">Optionen:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle ob du das autonome Verhalten ein- oder ausschalten möchtest.</li>
-</ul></div><div id="naoActions_pointLookAt" class="help expert"><h3 id="ProgrammierungNAO-»Zeige/SchaueaufKoordinatensystem...x...y...z...Tempo%...«[ExpertenBlock]">»Zeige/ Schaue auf Koordinatensystem ... x ... y ... z ... Tempo % ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du deinen Roboter auf eine beliebe Stelle im Raum zeigen lassen. Dabei kannst du aus drei Koordinatensystemen wählen. Das Koordinatensystem »Oberkörper« geht von dem Oberkörper deines Roboters aus, das Koordinatensystem »Welt« bezieht sich auf den gesamten Raum und das Koordinatensystem »Roboter« geht vom Mittelpunkt deines Roboters aus.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option,  wähle ob dein Roboter auf die Stelle zeigen oder schauen soll.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle das Koordinatensystem.</li><li class="typcn typcn-arrow-left">Zahl, die x-Koordinate auf die dein Roboter zeigen oder schauen soll.</li><li class="typcn typcn-arrow-left">Zahl, die y-Koordinate auf die dein Roboter zeigen oder schauen soll.</li><li class="typcn typcn-arrow-left">Zahl, die z-Koordinate auf die dein Roboter zeigen oder schauen soll.</li><li class="typcn typcn-arrow-left">Zahl, Tempo mit dem sich der Roboter bewegen soll. Zahl zwischen 1 und 100.</li>
-</ul></div><div id="robActions_sayText" class="help beginner"><h3 id="ProgrammierungNAO-»Sage...«">»Sage ... «</h3><p>Mit diesem Block kannst du die Sprachausgabe deines Roboters steuern. Der Roboter verwendet dabei die eingestellte Sprache, die du auch mit dem Block »setze Sprache ...« ändern kannst.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, Text den dein Roboter sagen soll.</li>
-</ul></div><div id="robActions_sayText_parameters" class="help expert"><h3 id="ProgrammierungNAO-»Sage...Sprechgeschwindigkeit...Stimmlage...«[ExpertenBlock]">»Sage ... Sprechgeschwindigkeit ... Stimmlage ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du die Sprachausgabe inklusive der Stimmlage und Sprechgeschwindigkeit  deines Roboters steuern. Der Roboter verwendet dabei die eingestellte Sprache, die du auch mit dem Block »setze Sprache ...« ändern kannst.</span></p><p><span style="letter-spacing: -0.084px;">Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, Text den dein Roboter sagen soll.</li><li class="typcn typcn-arrow-left">Zahl, die Sprechgeschwindigkeit des Roboters, zwischen 1 und 100.</li><li class="typcn typcn-arrow-left">Zahl, die Stimmlage des Roboters, zwischen 1 und 100.</li>
-</ul></div><div id="naoActions_getLanguage" class="help expert"><h3 id="ProgrammierungNAO-»GibSprache«[ExpertenBlock]">»Gib Sprache « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du dir die momentan eingestellte Sprache ausgeben lassen.</span></p><p><span style="letter-spacing: -0.006em;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, die momentan eingestellte Sprache.</li>
-</ul></div><div id="robActions_setLanguage" class="help beginner"><h3 id="ProgrammierungNAO-»SetzeSprache...«">»Setze Sprache ... «</h3><p>Mit diesem Block kannst du die Sprache deines Roboters für die Sprachausgabe ändern.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Option, wähle die gewünschte Sprache aus.</li>
-</ul></div><div id="naoActions_getVolume" class="help beginner"><h3 id="ProgrammierungNAO-»GibLautstärke«">»Gib Lautstärke «</h3><p>Mit diesem Block kannst du dir die momentane Lautstärke deines Roboters ausgeben lassen.</p><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Lautstärke des Roboters in Prozent, zwischen 0 und 100.</li>
-</ul></div><div id="naoActions_setVolume" class="help beginner"><h3 id="ProgrammierungNAO-»SetzeLautstärke...«">»Setze Lautstärke ... «</h3><p>Mit diesem Block kannst du die Lautstärke deines Roboters einstellen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die gewünschte Lautstärke deines Roboters, zwischen 0 und 100.</li>
-</ul></div><div id="naoActions_learnFace" class="help expert"><h3 id="ProgrammierungNAO-»MerkeGesichtvon...«[ExpertenBlock]">»Merke Gesicht von ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst die Gesichtserkennung deines Roboters steuern. Der Roboter erkennt dabei das momentane Gesicht und merkt sich dieses zusammen mit dem eingegebenen Namen.</span></p><p><span style="letter-spacing: -0.084px;">Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, Namen oder Bezeichnung für das Gesicht.</li>
-</ul><br><p><span class="auto-cursor-target" style="letter-spacing: -0.084px;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wahrheitswert, wahr wenn ein Gesicht erkannt wurde, sonst falsch.</li>
-</ul></div><div id="naoActions_forgetFace" class="help expert"><h3 id="ProgrammierungNAO-»VergesseGesichtvon...«[ExpertenBlock]">»Vergesse Gesicht von ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du ein bereits gemerktes Gesicht wieder vergessen, sodass es dein Roboter nicht mehr erkennt.</span></p><p><span style="letter-spacing: -0.006em;">Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Zeichenkette, Name oder Bezeichnung des Gesichts, das vergessen werden soll.</li>
-</ul></div><div id="naoActions_takePicture" class="help expert"><h3 id="ProgrammierungNAO-»MacheFotomitKamera...Dateiname...«[ExpertenBlock]">»Mache Foto mit Kamera ... Dateiname ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du ein Foto mit einer der Kameras deines Roboters machen und dieses abspeichern.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Kamera aus, die du verwenden möchtest.</li><li class="typcn typcn-arrow-left">Zeichenkette, Dateiname unter dem das Foto abgespeichert werden soll.</li>
-</ul></div><div id="naoActions_recordVideo" class="help expert"><h3 id="ProgrammierungNAO-»NehmeVideoaufmitAuflösung...Kamera...Dauerms...Dateiname...«[ExpertenBlock]">»Nehme Video auf mit Auflösung ... Kamera ... Dauer ms ... Dateiname ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du ein Video mit einer der Kameras deines Roboters aufnehmen und abspeichern.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Auflösung des Videos.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle die Kamera, die du verwenden möchtest.</li><li class="typcn typcn-arrow-left">Zahl, die Dauer des Videos in Millisekunden.</li><li class="typcn typcn-arrow-left">Zeichenkette, Dateinamen unter dem das Video abgespeichert werden soll.</li>
-</ul></div><div id="naoActions_rgbLeds" class="help beginner"><h3 id="ProgrammierungNAO-»LED...Farbe...«">»LED ... Farbe ... «</h3><p>Mit diesem Block kannst du eine Farb-LED deines Roboters ansteuern und ihre Farbe ändern.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du ansteuern möchtest.</li><li class="typcn typcn-arrow-left">Farbe, die neue Farbe der LED.</li>
-</ul></div><div id="naoActions_setIntensity" class="help beginner"><h3 id="ProgrammierungNAO-»LED...Intensität...«">»LED ... Intensität ... «</h3><p>Mit diesem Block kannst du Intensität, also die Helligkeit, einer oder mehrere LEDs deines Roboters steuern.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du steuern möchtest.</li><li class="typcn typcn-arrow-left">Zahl, die Intensität der LED in Prozent, zwischen 0 und 100.</li>
-</ul></div><div id="naoActions_ledOff" class="help beginner"><h3 id="ProgrammierungNAO-»LED...aus«">»LED ... aus «</h3><p>Mit diesem Block kannst du eine oder mehrere LEDs deines Roboters ausschalten.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du ausschalten möchtest.</li>
-</ul></div><div id="naoActions_ledReset" class="help expert"><h3 id="ProgrammierungNAO-»LED...Setze«[ExpertenBlock]">»LED ... Setze « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du eine oder mehrere LEDs deines Roboters zurücksetzen. Die LEDs werden dabei auf den Zustand bei Programmstart zurückgesetzt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du zurücksetzen möchtest.</li>
-</ul></div><div id="naoActions_randomEyes" class="help beginner"><h3 id="ProgrammierungNAO-»ZufälligeAnimationderAugenDauerms...«">»Zufällige Animation der Augen Dauer ms ... «</h3><p>Mit diesem Block kannst du die Augen deines Roboters eine zufällig ausgewählte Animation anzeigen lassen. Du kannst dabei die Dauer der Animation steuern.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Dauer der Animation in Millisekunden.</li>
-</ul></div><div id="naoActions_rasta" class="help beginner"><h3 id="ProgrammierungNAO-»AbwechselndeAnimationallerLEDsDauerms...«">»Abwechselnde Animation aller LEDs Dauer ms ... «</h3><p>Mit diesem Block kannst du eine vorgefertigte Animation auf allen LEDs deines Roboters abspielen. Du kannst dabei die Dauer der Animation bestimmen, aber nicht welche Animation ausgeführt wird.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Dauer der Animation in Millisekunden.</li>
-</ul></div><div id="robSensors_touch_getSample" class="help beginner"><h3 id="ProgrammierungNAO-»Berührungssensor......gedrückt?«">»Berührungssensor ... ... gedrückt?«</h3><p>Mit diesem Sensor kannst du einen der Berührungssensoren deines Roboters abfragen. Der Block gibt dann »wahr« zurück, wenn der Sensor gedrückt wird, sonst »falsch«.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den Bereich für den Sensor aus.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle den genauen Sensor aus, den du abfragen möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Wahrheitswert, der Status des Sensors.</li>
-</ul></div><div id="robSensors_ultrasonic_getSample" class="help beginner"><h3 id="ProgrammierungNAO-»GibAbstandcmUltraschallsensor«">»Gib Abstand cm Ultraschallsensor «</h3><p>Mit diesem Block kannst du den Ultraschallsensor deines Roboters abfragen und damit den Abstand zum nächsten Objekt bestimmen.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Abstand zum nächsten Objekt in Zentimetern.</li>
-</ul></div><div id="robSensors_detectmark_getSample" class="help beginner"><h3 id="ProgrammierungNAO-»Gib...NAOMarkSensor«">»Gib ... NAO Mark Sensor «</h3><p>Mit diesem Block kannst du den NAO Mark Sensor abfragen. Dieser Sensor kann vorgefertigte Bilder erkennen und ordnet diesen dann eine spezielle ID zu. DIese ID kannst du mit diesem Block abfragen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle ob du eine einzelne ID oder eine Liste von IDs abfragen möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl oder Liste von Zahlen, je nachdem ob du eine einzelne ID oder mehrere IDs abgefragt hast.</li>
-</ul></div><div id="naoSensors_getMarkInformation" class="help beginner"><h3 id="ProgrammierungNAO-»GibInformationenNAOMarkSensorüber...«">»Gib Informationen NAO Mark Sensor über ... «</h3><p>Mit diesem Block kannst du weitere Informationen über ein erkanntes Muster des NAO Mark Sensors erfahren. Diese Informationen sind die Winkel in x- und y-Richtung, die Größe in x- und y-Richtung und die Ausrichtung des Bildes.</p><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste von Zahlen, diese Liste enthält die oben genannten Informationen in  dieser Reihenfolge.</li>
-</ul></div><div id="robSensors_detectface_getSample" class="help beginner"><h3 id="ProgrammierungNAO-»Gib...Gesichtserkennung«">»Gib ... Gesichtserkennung «</h3><p>Mit diesem Block kannst du die Gesichtserkennung deines Roboters abfragen. Dabei kannst du entweder den Namen des aktuellen Gesichts oder eine Liste von Namen des aktuellen Gesichts abfragen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle zwischen einem einzelnen Namen oder einer Liste von Namen.</li>
-</ul><p class="auto-cursor-target">Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette oder Liste von Zeichenketten, der Name oder Liste von Namen des aktuellen Gesichts.</li>
-</ul></div><div id="naoSensors_getFaceInformation" class="help beginner"><h3 id="ProgrammierungNAO-»GibInformationGesichtserkennungüber...«">»Gib Information Gesichtserkennung über ... «</h3><p>Mit diesem Block kannst du weitere Informationen über schon gespeicherte Gesichter abfragen. Diese Informationen enthalten <span style="letter-spacing: 0.0px;">die Winkel in x- und y-Richtung, die Größe in x- und y-Richtung und die Ausrichtung des Bildes.</span></p><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste von Zahlen, diese Liste enthält die oben genannten Informationen in  dieser Reihenfolge.</li>
-</ul></div><div id="naoSensors_recognizeWord" class="help beginner"><h3 id="ProgrammierungNAO-»GibWortSpracherkennungvon...«">»Gib Wort Spracherkennung von ... «</h3><p>Mit diesem Block kannst du die Spracherkennung deines Roboters abfragen. Du kannst allerdings nur Wörter erkennen, die du diesem Block als Eingabewert mitgibst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, das Wort das dein Roboter erkennen soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, das erkannt Wort der Spracherkennung.</li>
-</ul></div><div id="robSensors_gyro_getSample" class="help expert"><h3 id="ProgrammierungNAO-»GibWinkelKreiselsensor...«[ExpertenBlock]">»Gib Winkel Kreiselsensor ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du den Kreiselsensor deines Roboters abfragen. Dieser Sensor misst wie stark sich dein Roboter in eine Richtung gedreht hat.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Rotationsachse, deren Rotation du abfragen möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, der Winkel um die sich der Roboter gedreht hat.</li>
-</ul></div><div id="robSensors_accelerometer_getSample" class="help expert"><h3 id="ProgrammierungNAO-»GibWertmilli-gBeschleunigungssensor...«[ExpertenBlock]">»Gib Wert milli-g Beschleunigungssensor ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du den Beschleunigungssensor deines Roboters abfragen. Dieser Sensor misst die Beschleunigung, die den Roboter in eine Richtung erfährt.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Richtung in die die Beschleunigung gemessen werden soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die gemessene Beschleunigung in milli-g. Dabei entsprechen 1000 milli-g einem g, also der Erdbeschleunigung.</li>
-</ul></div><div id="robSensors_fsr_getSample" class="help expert"><h3 id="ProgrammierungNAO-»GibWertNDrucksensor...«[ExpertenBlock]">»Gib Wert N Drucksensor ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Sensor kannst du den Drucksensor deines Roboters abfragen. Dieser Sensor misst den ausgeübten Druck und kann dadurch die ausgeübte Kraft berechnen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den Sensor aus, den du abfragen möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die gemessene Kraft in Newton.</li>
-</ul></div><div id="robSensors_electriccurrent_getSample" class="help expert"><h3 id="ProgrammierungNAO-»GibWertAStromsensor......«[ExpertenBlock]">»Gib Wert A Stromsensor ... ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du den Stromsensor deines Roboters abfragen. Dieser Sensor misst den Stromfluss durch einen Motor und gibt diesen zurück.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle den Motor aus, dessen Stromfluss bestimmt werden soll.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, der gemessene Stromfluss in Ampere.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="ProgrammierungNAO-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="ProgrammierungNAO-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="ProgrammierungNAO-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="ProgrammierungNAO-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierungNAO-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammierungNAO-»Wartebis...«">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="ProgrammierungNAO-»Wartems...«">»Warte ms ... «</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="ProgrammierungNAO-»Wartebis...«.1">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="ProgrammierungNAO-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="ProgrammierungNAO-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="ProgrammierungNAO-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="ProgrammierungNAO-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="ProgrammierungNAO-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="ProgrammierungNAO-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierungNAO-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="ProgrammierungNAO-»Zufallszahl«[Experten-Block]">»Zufallszahl« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="ProgrammierungNAO-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="ProgrammierungNAO-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 style="text-align: left;" id="ProgrammierungNAO-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierungNAO-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammierungNAO-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammierungNAO-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammierungNAO-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammierungNAO-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammierungNAO-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierungNAO-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierungNAO-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="ProgrammierungNAO-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammierungNAO-»Farbwahl«">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammierungNAO-»Farbwahl«.1">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammierungNAO-»Farbwahl«.2">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierungNAO-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, die  Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierungNAO-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 class="auto-cursor-target" id="ProgrammierungNAO-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammierungNAO-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="ProgrammierungNAO-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammierungNAO-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammierungNAO-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammierungNAO-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="ProgrammierungNAO-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="ProgrammierungNAO-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammierungNAO-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen Wert zurück.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierungNAO-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit Rückgabewert «</h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="ProgrammierungNAO-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den
+                man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am »Start«-Block.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus">Entferne die globale Variable.</li>
+                <li class="typcn typcn-input-checked">Zeige Sensordaten - während des Programmablaufs werden im Display
+                    die Werte der angeschlossenen Sensoren gezeigt.</li>
+            </ul>Wenn globale Variablen erzeugt wurden:<ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variablen.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
+            </ul><br>
+        </div>
+        <div id="naoActions_applyPosture" class="help beginner">
+            <h3 id="ProgrammierungNAO-»LasseNAO...«">»Lasse NAO ... «</h3>
+            <p>Mit diesem Block kannst du die Aktion deines Roboters steuern. Der Roboter kann dabei viele verschiedene
+                Positionen einnehmen, wie z.B. hocken, stehen oder sitzen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Position aus, die dein Roboter einnehmen
+                    soll.</li>
+            </ul>
+        </div>
+        <div id="naoActions_hand" class="help expert">
+            <h3 id="ProgrammierungNAO-»Hand......«[ExpertenBlock]">»Hand ... ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine Hand deines Roboters kontrollieren. Die Hand kann sich dabei entweder
+                öffnen oder schließen.</p>
+            <p class="auto-cursor-target">Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Hand aus, die du steuern möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob sich die Hand öffnen oder schließen soll.
+                </li>
+            </ul>
+        </div>
+        <div id="naoActions_moveJoint" class="help expert">
+            <h3 id="ProgrammierungNAO-»Bewege.........«[ExpertenBlock]">»Bewege ... ... ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du ein einzelnes Gelenk deines Roboters
+                    ansteuern. Die Gelenke können sich dabei entweder relativ zu ihrer jetzigen Position oder absolut zu
+                    ihrer Ausgangsposition bewegen.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle das Gelenk aus, das du ansteuern möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob die Bewegung relativ zur jetzigen Position
+                    oder absolut zur Ausgangsposition sein soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Rotation des Gelenks in Grad °. Zahl zwischen 0 und 360.</li>
+            </ul>
+        </div>
+        <div id="naoActions_stiffness" class="help expert">
+            <h3 id="ProgrammierungNAO-»BlockiereMotoren......«[ExpertenBlock]">»Blockiere Motoren ... ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du die Motoren eines Bereichs deines
+                    Roboters blockieren, sodass sich dieser Motor nicht mehr bewegen kann, bis die Blockierung wieder
+                    aufgehoben wird.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Bereich deines Roboters, dessen Motoren du
+                    blockieren möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob die Motoren blockiert werden sollen oder
+                    nicht.</li>
+            </ul>
+        </div>
+        <div id="naoActions_walk" class="help beginner">
+            <h3 id="ProgrammierungNAO-»Gehe...Streckecm...«">»Gehe ... Strecke cm ... «</h3>
+            <p>Mit diesem Block kannst du deinen Roboter eine gewisse Strecke geradeaus laufen lassen.</p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob der Roboter vorwärts oder rückwärts gehen
+                    soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Strecke die der Roboter zurücklegen soll in Zentimetern.
+                </li>
+            </ul>
+        </div>
+        <div id="naoActions_turn" class="help beginner">
+            <h3 id="ProgrammierungNAO-»Drehe...Grad°...«">»Drehe ... Grad ° ... «</h3>
+            <p>Mit diesem Block kannst du deinen Roboter auf der Stelle drehen.</p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob sich der Roboter nach rechts oder links
+                    drehen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, wähle den Winkel um den sich der Roboter drehen soll.</li>
+            </ul>
+        </div>
+        <div id="naoActions_walkTo" class="help expert">
+            <h3 id="ProgrammierungNAO-»Gehezux...y...Theta...«[ExpertenBlock]">»Gehe zu x ... y ... Theta ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du deinen Roboter relativ zu seiner
+                    jetzigen Position bewegen.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, x-Koordinate für die neue Position,</li>
+                <li class="typcn typcn-arrow-left">Zahl, y-Koordinate für die neue Position.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Winkel um die sich dein Roboter drehen soll.</li>
+            </ul>
+        </div>
+        <div id="naoActions_walk_async" class="help expert">
+            <h3 id="ProgrammierungNAO-»GehezuxTempo%...yTempo%...DreheTempo%...«[ExpertenBlock]">»Gehe zu x Tempo % ...
+                y Tempo % ... Drehe Tempo % ... « <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du die Geschwindigkeit deines Roboters
+                    bei einer freien Bewegung einstellen.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Tempo für die Bewegung in x-Richtung. Zahl zwischen 1 und 100.
+                </li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo für die Bewegung in y-Richtung. Zahl zwischen 1 und 100.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Zahl, Tempo für die Drehung deines Roboters. Zahl zwischen 1
+                    und 100.</li>
+            </ul>
+        </div>
+        <div id="naoActions_stop" class="help expert">
+            <h3 id="ProgrammierungNAO-»StoppeBewegung...«[ExpertenBlock]">»Stoppe Bewegung ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du alle laufenden Bewegungen deines
+                    Roboters stoppen.</span></p>
+        </div>
+        <div id="naoActions_animation" class="help beginner">
+            <h3 id="ProgrammierungNAO-»Führeaus...«">»Führe aus ... «</h3>
+            <p>Mit diesem Block kannst du deinen Roboter eine vorgefertigte Animation ausführen lassen. Zur Auswahl
+                stehen dabei Tai Chi, Winken, Blinken und die Stirn wischen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle eine vorgefertigte Animation aus.</li>
+            </ul>
+        </div>
+        <div id="naoActions_autonomous" class="help expert">
+            <h3 id="ProgrammierungNAO-»SchalteautonomesVerhalten...«[ExpertenBlock]">»Schalte autonomes Verhalten ... «
+                <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du das autonome Verhalten deines Roboters
+                    ein- oder ausschalten. Mit eingeschaltetem autonomen Verhalten läuft der Roboter z.B. nicht gegen
+                    Wände.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob du das autonome Verhalten ein- oder
+                    ausschalten möchtest.</li>
+            </ul>
+        </div>
+        <div id="naoActions_pointLookAt" class="help expert">
+            <h3 id="ProgrammierungNAO-»Zeige/SchaueaufKoordinatensystem...x...y...z...Tempo%...«[ExpertenBlock]">»Zeige/
+                Schaue auf Koordinatensystem ... x ... y ... z ... Tempo % ... « <span class="typcn typcn-star"></span>
+            </h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du deinen Roboter auf eine beliebe Stelle
+                    im Raum zeigen lassen. Dabei kannst du aus drei Koordinatensystemen wählen. Das Koordinatensystem
+                    »Oberkörper« geht von dem Oberkörper deines Roboters aus, das Koordinatensystem »Welt« bezieht sich
+                    auf den gesamten Raum und das Koordinatensystem »Roboter« geht vom Mittelpunkt deines Roboters
+                    aus.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob dein Roboter auf die Stelle zeigen oder
+                    schauen soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle das Koordinatensystem.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die x-Koordinate auf die dein Roboter zeigen oder schauen soll.
+                </li>
+                <li class="typcn typcn-arrow-left">Zahl, die y-Koordinate auf die dein Roboter zeigen oder schauen soll.
+                </li>
+                <li class="typcn typcn-arrow-left">Zahl, die z-Koordinate auf die dein Roboter zeigen oder schauen soll.
+                </li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo mit dem sich der Roboter bewegen soll. Zahl zwischen 1
+                    und 100.</li>
+            </ul>
+        </div>
+        <div id="robActions_sayText" class="help beginner">
+            <h3 id="ProgrammierungNAO-»Sage...«">»Sage ... «</h3>
+            <p>Mit diesem Block kannst du die Sprachausgabe deines Roboters steuern. Der Roboter verwendet dabei die
+                eingestellte Sprache, die du auch mit dem Block »setze Sprache ...« ändern kannst.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, Text den dein Roboter sagen soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_sayText_parameters" class="help expert">
+            <h3 id="ProgrammierungNAO-»Sage...Sprechgeschwindigkeit...Stimmlage...«[ExpertenBlock]">»Sage ...
+                Sprechgeschwindigkeit ... Stimmlage ... « <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du die Sprachausgabe inklusive der
+                    Stimmlage und Sprechgeschwindigkeit deines Roboters steuern. Der Roboter verwendet dabei die
+                    eingestellte Sprache, die du auch mit dem Block »setze Sprache ...« ändern kannst.</span></p>
+            <p><span style="letter-spacing: -0.084px;">Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, Text den dein Roboter sagen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Sprechgeschwindigkeit des Roboters, zwischen 1 und 100.
+                </li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stimmlage des Roboters, zwischen 1 und 100.</li>
+            </ul>
+        </div>
+        <div id="naoActions_getLanguage" class="help expert">
+            <h3 id="ProgrammierungNAO-»GibSprache«[ExpertenBlock]">»Gib Sprache « <span class="typcn typcn-star"></span>
+            </h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du dir die momentan eingestellte Sprache
+                    ausgeben lassen.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die momentan eingestellte Sprache.</li>
+            </ul>
+        </div>
+        <div id="robActions_setLanguage" class="help beginner">
+            <h3 id="ProgrammierungNAO-»SetzeSprache...«">»Setze Sprache ... «</h3>
+            <p>Mit diesem Block kannst du die Sprache deines Roboters für die Sprachausgabe ändern.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Option, wähle die gewünschte Sprache aus.</li>
+            </ul>
+        </div>
+        <div id="naoActions_getVolume" class="help beginner">
+            <h3 id="ProgrammierungNAO-»GibLautstärke«">»Gib Lautstärke «</h3>
+            <p>Mit diesem Block kannst du dir die momentane Lautstärke deines Roboters ausgeben lassen.</p>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Lautstärke des Roboters in Prozent, zwischen 0 und 100.</li>
+            </ul>
+        </div>
+        <div id="naoActions_setVolume" class="help beginner">
+            <h3 id="ProgrammierungNAO-»SetzeLautstärke...«">»Setze Lautstärke ... «</h3>
+            <p>Mit diesem Block kannst du die Lautstärke deines Roboters einstellen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die gewünschte Lautstärke deines Roboters, zwischen 0 und 100.
+                </li>
+            </ul>
+        </div>
+        <div id="naoActions_learnFace" class="help expert">
+            <h3 id="ProgrammierungNAO-»MerkeGesichtvon...«[ExpertenBlock]">»Merke Gesicht von ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst die Gesichtserkennung deines Roboters
+                    steuern. Der Roboter erkennt dabei das momentane Gesicht und merkt sich dieses zusammen mit dem
+                    eingegebenen Namen.</span></p>
+            <p><span style="letter-spacing: -0.084px;">Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, Namen oder Bezeichnung für das Gesicht.</li>
+            </ul><br>
+            <p><span class="auto-cursor-target" style="letter-spacing: -0.084px;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wahrheitswert, wahr wenn ein Gesicht erkannt wurde, sonst falsch.
+                </li>
+            </ul>
+        </div>
+        <div id="naoActions_forgetFace" class="help expert">
+            <h3 id="ProgrammierungNAO-»VergesseGesichtvon...«[ExpertenBlock]">»Vergesse Gesicht von ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du ein bereits gemerktes Gesicht wieder
+                    vergessen, sodass es dein Roboter nicht mehr erkennt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Zeichenkette, Name oder Bezeichnung des Gesichts, das
+                    vergessen werden soll.</li>
+            </ul>
+        </div>
+        <div id="naoActions_takePicture" class="help expert">
+            <h3 id="ProgrammierungNAO-»MacheFotomitKamera...Dateiname...«[ExpertenBlock]">»Mache Foto mit Kamera ...
+                Dateiname ... « <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du ein Foto mit einer der Kameras deines
+                    Roboters machen und dieses abspeichern.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Kamera aus, die du verwenden möchtest.</li>
+                <li class="typcn typcn-arrow-left">Zeichenkette, Dateiname unter dem das Foto abgespeichert werden soll.
+                </li>
+            </ul>
+        </div>
+        <div id="naoActions_recordVideo" class="help expert">
+            <h3 id="ProgrammierungNAO-»NehmeVideoaufmitAuflösung...Kamera...Dauerms...Dateiname...«[ExpertenBlock]">
+                »Nehme Video auf mit Auflösung ... Kamera ... Dauer ms ... Dateiname ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du ein Video mit einer der Kameras deines
+                    Roboters aufnehmen und abspeichern.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Auflösung des Videos.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Kamera, die du verwenden möchtest.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Dauer des Videos in Millisekunden.</li>
+                <li class="typcn typcn-arrow-left">Zeichenkette, Dateinamen unter dem das Video abgespeichert werden
+                    soll.</li>
+            </ul>
+        </div>
+        <div id="naoActions_rgbLeds" class="help beginner">
+            <h3 id="ProgrammierungNAO-»LED...Farbe...«">»LED ... Farbe ... «</h3>
+            <p>Mit diesem Block kannst du eine Farb-LED deines Roboters ansteuern und ihre Farbe ändern.</p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du ansteuern möchtest.</li>
+                <li class="typcn typcn-arrow-left">Farbe, die neue Farbe der LED.</li>
+            </ul>
+        </div>
+        <div id="naoActions_setIntensity" class="help beginner">
+            <h3 id="ProgrammierungNAO-»LED...Intensität...«">»LED ... Intensität ... «</h3>
+            <p>Mit diesem Block kannst du Intensität, also die Helligkeit, einer oder mehrere LEDs deines Roboters
+                steuern.</p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du steuern möchtest.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Intensität der LED in Prozent, zwischen 0 und 100.</li>
+            </ul>
+        </div>
+        <div id="naoActions_ledOff" class="help beginner">
+            <h3 id="ProgrammierungNAO-»LED...aus«">»LED ... aus «</h3>
+            <p>Mit diesem Block kannst du eine oder mehrere LEDs deines Roboters ausschalten.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du ausschalten möchtest.</li>
+            </ul>
+        </div>
+        <div id="naoActions_ledReset" class="help expert">
+            <h3 id="ProgrammierungNAO-»LED...Setze«[ExpertenBlock]">»LED ... Setze « <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du eine oder mehrere LEDs deines Roboters
+                    zurücksetzen. Die LEDs werden dabei auf den Zustand bei Programmstart zurückgesetzt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du zurücksetzen möchtest.</li>
+            </ul>
+        </div>
+        <div id="naoActions_randomEyes" class="help beginner">
+            <h3 id="ProgrammierungNAO-»ZufälligeAnimationderAugenDauerms...«">»Zufällige Animation der Augen Dauer ms
+                ... «</h3>
+            <p>Mit diesem Block kannst du die Augen deines Roboters eine zufällig ausgewählte Animation anzeigen lassen.
+                Du kannst dabei die Dauer der Animation steuern.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Dauer der Animation in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="naoActions_rasta" class="help beginner">
+            <h3 id="ProgrammierungNAO-»AbwechselndeAnimationallerLEDsDauerms...«">»Abwechselnde Animation aller LEDs
+                Dauer ms ... «</h3>
+            <p>Mit diesem Block kannst du eine vorgefertigte Animation auf allen LEDs deines Roboters abspielen. Du
+                kannst dabei die Dauer der Animation bestimmen, aber nicht welche Animation ausgeführt wird.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Dauer der Animation in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robSensors_touch_getSample" class="help beginner">
+            <h3 id="ProgrammierungNAO-»Berührungssensor......gedrückt?«">»Berührungssensor ... ... gedrückt?«</h3>
+            <p>Mit diesem Sensor kannst du einen der Berührungssensoren deines Roboters abfragen. Der Block gibt dann
+                »wahr« zurück, wenn der Sensor gedrückt wird, sonst »falsch«.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Bereich für den Sensor aus.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den genauen Sensor aus, den du abfragen
+                    möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Wahrheitswert, der Status des Sensors.</li>
+            </ul>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help beginner">
+            <h3 id="ProgrammierungNAO-»GibAbstandcmUltraschallsensor«">»Gib Abstand cm Ultraschallsensor «</h3>
+            <p>Mit diesem Block kannst du den Ultraschallsensor deines Roboters abfragen und damit den Abstand zum
+                nächsten Objekt bestimmen.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Abstand zum nächsten Objekt in Zentimetern.</li>
+            </ul>
+        </div>
+        <div id="robSensors_detectmark_getSample" class="help beginner">
+            <h3 id="ProgrammierungNAO-»Gib...NAOMarkSensor«">»Gib ... NAO Mark Sensor «</h3>
+            <p>Mit diesem Block kannst du den NAO Mark Sensor abfragen. Dieser Sensor kann vorgefertigte Bilder erkennen
+                und ordnet diesen dann eine spezielle ID zu. DIese ID kannst du mit diesem Block abfragen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob du eine einzelne ID oder eine Liste von IDs
+                    abfragen möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl oder Liste von Zahlen, je nachdem ob du eine einzelne ID oder
+                    mehrere IDs abgefragt hast.</li>
+            </ul>
+        </div>
+        <div id="naoSensors_getMarkInformation" class="help beginner">
+            <h3 id="ProgrammierungNAO-»GibInformationenNAOMarkSensorüber...«">»Gib Informationen NAO Mark Sensor über
+                ... «</h3>
+            <p>Mit diesem Block kannst du weitere Informationen über ein erkanntes Muster des NAO Mark Sensors erfahren.
+                Diese Informationen sind die Winkel in x- und y-Richtung, die Größe in x- und y-Richtung und die
+                Ausrichtung des Bildes.</p>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste von Zahlen, diese Liste enthält die oben genannten
+                    Informationen in dieser Reihenfolge.</li>
+            </ul>
+        </div>
+        <div id="robSensors_detectface_getSample" class="help beginner">
+            <h3 id="ProgrammierungNAO-»Gib...Gesichtserkennung«">»Gib ... Gesichtserkennung «</h3>
+            <p>Mit diesem Block kannst du die Gesichtserkennung deines Roboters abfragen. Dabei kannst du entweder den
+                Namen des aktuellen Gesichts oder eine Liste von Namen des aktuellen Gesichts abfragen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle zwischen einem einzelnen Namen oder einer Liste
+                    von Namen.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette oder Liste von Zeichenketten, der Name oder Liste von
+                    Namen des aktuellen Gesichts.</li>
+            </ul>
+        </div>
+        <div id="naoSensors_getFaceInformation" class="help beginner">
+            <h3 id="ProgrammierungNAO-»GibInformationGesichtserkennungüber...«">»Gib Information Gesichtserkennung über
+                ... «</h3>
+            <p>Mit diesem Block kannst du weitere Informationen über schon gespeicherte Gesichter abfragen. Diese
+                Informationen enthalten <span style="letter-spacing: 0.0px;">die Winkel in x- und y-Richtung, die Größe
+                    in x- und y-Richtung und die Ausrichtung des Bildes.</span></p>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste von Zahlen, diese Liste enthält die oben genannten
+                    Informationen in dieser Reihenfolge.</li>
+            </ul>
+        </div>
+        <div id="naoSensors_recognizeWord" class="help beginner">
+            <h3 id="ProgrammierungNAO-»GibWortSpracherkennungvon...«">»Gib Wort Spracherkennung von ... «</h3>
+            <p>Mit diesem Block kannst du die Spracherkennung deines Roboters abfragen. Du kannst allerdings nur Wörter
+                erkennen, die du diesem Block als Eingabewert mitgibst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, das Wort das dein Roboter erkennen soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, das erkannt Wort der Spracherkennung.</li>
+            </ul>
+        </div>
+        <div id="robSensors_gyro_getSample" class="help expert">
+            <h3 id="ProgrammierungNAO-»GibWinkelKreiselsensor...«[ExpertenBlock]">»Gib Winkel Kreiselsensor ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du den Kreiselsensor deines Roboters abfragen. Dieser Sensor misst wie stark sich
+                dein Roboter in eine Richtung gedreht hat.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Rotationsachse, deren Rotation du abfragen
+                    möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der Winkel um die sich der Roboter gedreht hat.</li>
+            </ul>
+        </div>
+        <div id="robSensors_accelerometer_getSample" class="help expert">
+            <h3 id="ProgrammierungNAO-»GibWertmilli-gBeschleunigungssensor...«[ExpertenBlock]">»Gib Wert milli-g
+                Beschleunigungssensor ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du den Beschleunigungssensor deines Roboters abfragen. Dieser Sensor misst die
+                Beschleunigung, die den Roboter in eine Richtung erfährt.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Richtung in die die Beschleunigung gemessen
+                    werden soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die gemessene Beschleunigung in milli-g. Dabei entsprechen
+                    1000 milli-g einem g, also der Erdbeschleunigung.</li>
+            </ul>
+        </div>
+        <div id="robSensors_fsr_getSample" class="help expert">
+            <h3 id="ProgrammierungNAO-»GibWertNDrucksensor...«[ExpertenBlock]">»Gib Wert N Drucksensor ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Sensor kannst du den Drucksensor deines Roboters abfragen. Dieser Sensor misst den ausgeübten
+                Druck und kann dadurch die ausgeübte Kraft berechnen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Sensor aus, den du abfragen möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die gemessene Kraft in Newton.</li>
+            </ul>
+        </div>
+        <div id="robSensors_electriccurrent_getSample" class="help expert">
+            <h3 id="ProgrammierungNAO-»GibWertAStromsensor......«[ExpertenBlock]">»Gib Wert A Stromsensor ... ... «
+                <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du den Stromsensor deines Roboters abfragen. Dieser Sensor misst den Stromfluss
+                durch einen Motor und gibt diesen zurück.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Motor aus, dessen Stromfluss bestimmt werden
+                    soll.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der gemessene Stromfluss in Ampere.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Wennmachesonst«">»Wenn mache sonst«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«
+            </h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Wiederholenmal«">»Wiederhole n mal«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole
+                solange/bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»FürWertausderListe«[Experten-Block]">»Für Wert aus der
+                Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="ProgrammierungNAO-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammierungNAO-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Wartems...«">»Warte ms ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Wartebis...«.1">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»MathematischeFunktionen«[Experten-Block]">
+                »Mathematische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»TrigonometrischeFunktionen«[Experten-Block]">
+                »Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Konstanten«[Experten-Block]">»Konstanten« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»runden«[Experten-Block]">»runden« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Listeauswerten«[Experten-Block]">»Liste auswerten«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Restvon«[Experten-Block]">»Rest von« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Begrenze«[Experten-Block]">»Begrenze« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige
+                Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Zufallszahl«[Experten-Block]">»Zufallszahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»ErstelleText«[Experten-Block]">»Erstelle Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Textanhängen«[Experten-Block]">»Text anhängen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierungNAO-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierungNAO-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierungNAO-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierungNAO-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierungNAO-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierungNAO-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierungNAO-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammierungNAO-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammierungNAO-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammierungNAO-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammierungNAO-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target" id="ProgrammierungNAO-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">
+                »Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target" id="ProgrammierungNAO-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe
+                mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target" id="ProgrammierungNAO-»FarbemitRot...Grün...Blau...«[Experten-Block].1">
+                »Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammierungNAO-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammierungNAO-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammierungNAO-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock
+                ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammierungNAO-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock
+                ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammierungNAO-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer
+                Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="ProgrammierungNAO-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer
+                Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="ProgrammierungNAO-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer
+                Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammierungNAO-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne
+                Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierungNAO-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit
+                Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_nao_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nao_en.html
@@ -1,436 +1,1567 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="ProgrammingblocksNAO-»start«"><span style="color: rgb(0,0,0);">»start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Each program starts with the red »start« block.</p><p>This block is always available in the Open Roberta Lab and cannot be deleted. The little triangle below the start block is called  »sequence connector«. The first block you want to use will be connected by using the »sequence connector« at the start block.  The sequence connector color changes to yellow when a suitable block comes into its range.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">create a new global variable</li><li class="typcn typcn-minus">delete the global variable</li><li class="typcn typcn-arrow-sorted-down">autonomous behaviour, here you can set whether your robot should move autonomously.</li>
-</ul> <p>If global variables have been created:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable</li><li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Colour«, »Image«, »List Number«, »List Boolean«, »List String«, »List Image«</li><li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial value of the variable.</li>
-</ul><br></div><div id="naoActions_applyPosture" class="help beginner"><h3 id="ProgrammingblocksNAO-»letNAO...«">»let NAO ... «</h3><p>With this block you can control the action of your robot. The robot can take up many different posture, such as squatting, standing or sitting.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the posture you robot should take.</li>
-</ul></div><div id="naoActions_hand" class="help expert"><h3 id="ProgrammingblocksNAO-»hand......«[Expert-Block]">»hand ... ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control one hand of your robot. The hand can either open or close.</p><p class="auto-cursor-target">Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the hand you want to control.</li><li class="typcn typcn-arrow-sorted-down">Option, choose whether you want the hand to open or close.</li>
-</ul></div><div id="naoActions_moveJoint" class="help expert"><h3 id="ProgrammingblocksNAO-»move.........«[Expert-Block]">»move ... ... ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control a single joint of your robot. The joints can either move relative to their current position or absolutely to their starting position.</p><p><span>Options and Input values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the joint you want to control.</li><li class="typcn typcn-arrow-sorted-down">Option, choose between a relative or absolute movement.</li><li class="typcn typcn-arrow-left">Number Rotation of the joint in degrees, number between 0 and 360.</li>
-</ul></div><div id="naoActions_stiffness" class="help expert"><h3 id="ProgrammingblocksNAO-»lockmotors......«[Expert-Block]">»lock motors ... ... « <span class="typcn typcn-star"></span></h3><p>This block allows you to lock the motors of an area of your robot so that the motor cannot move until the lock is removed.</p><p><span>Options:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select the area of your robot whose motors you want to lock.</li><li class="typcn typcn-arrow-sorted-down">Option, choose whether you want to lock the motors or release them.</li>
-</ul></div><div id="naoActions_walk" class="help beginner"><h3 id="ProgrammingblocksNAO-»walk...distancecm...«">»walk ... distance cm ... «</h3><p>With this block you can let your robot run a certain distance straight ahead.</p><p>Options and Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose whether your robot should move forwards or backwards.</li><li class="typcn typcn-arrow-left">Number, the distance your robot shall walk.</li>
-</ul></div><div id="naoActions_turn" class="help beginner"><h3 id="ProgrammingblocksNAO-»turn...degrees°...«">»turn ... degrees ° ... «</h3><p>With this block you can turn your robot on the spot.</p><p>Options and Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the direction your robot should turn into.</li><li class="typcn typcn-arrow-left">Number, select the angle by which the robot should turn.</li>
-</ul></div><div id="naoActions_walkTo" class="help expert"><h3 id="ProgrammingblocksNAO-»walktox...y...theta...«[Expert-Block]">»walk to  x ... y ... theta ... « <span class="typcn typcn-star"></span></h3><p>With this block you can move your robot relative to its current position.</p><p><span>Input values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, x-coordinate for the new position.</li><li class="typcn typcn-arrow-left">Number, y-coordinate for the new position.</li><li class="typcn typcn-arrow-left">Number, select the angle by which the robot should turn.</li>
-</ul></div><div id="naoActions_walk_async" class="help expert"><h3 id="ProgrammingblocksNAO-»walktoxspeed%...yspeed%...turnspeed%...«[Expert-Block]">»walk to x speed % ... y speed % ... turn speed % ... « <span class="typcn typcn-star"></span></h3><p>With this block you can adjust the speed of your robot during a free movement.</p><p><span>Input values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, Speed for the movement in x-direction. Number between 1 and 100.</li><li class="typcn typcn-arrow-left">Number, Speed for the movement in y-direction. Number between 1 and 100.</li><li class="typcn typcn-arrow-sorted-down">Number, Speed for the rotation of your robot. Number between 1 and 100.</li>
-</ul></div><div id="naoActions_stop" class="help expert"><h3 id="ProgrammingblocksNAO-»stopmovement...«[Expert-Block]">»stop movement ... « <span class="typcn typcn-star"></span></h3><p>With this block you can stop all running movements of your robot.</p></div><div id="naoActions_animation" class="help beginner"><h3 id="ProgrammingblocksNAO-»perform...«">»perform ... «</h3><p>With this block you can let your robot perform a predefined animation. You can choose between Tai Chi, waving, flashing and wiping your forehead.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose one of the predefined animations.</li>
-</ul></div><div id="naoActions_autonomous" class="help expert"><h3 id="ProgrammingblocksNAO-»turnautonomousbehaviour...«[Expert-Block]">»turn autonomous behaviour ... « <span class="typcn typcn-star"></span></h3><p>With this block you can enable or disable the autonomous behaviour of your robot. With the autonomous behaviour switched on, the robot will not run into walls, for example.</p><p><span>Options:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose between turning to autonomous behaviour on or off.</li>
-</ul></div><div id="naoActions_pointLookAt" class="help expert"><h3 id="ProgrammingblocksNAO-»point/lookatframe...x...y...z...speed%...«[Expert-Block]">»point/look at frame ... x ... y ... z ... speed % ... « <span class="typcn typcn-star"></span></h3><p>With this block you can point your robot to any place in the room. You can choose from three coordinate systems. The coordinate system "upper body" starts from the upper body of your robot, the coordinate system "world" refers to the whole room and the coordinate system "robot" starts from the center of your robot.</p><p><span>Options and Input values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option,  choose between the robot pointing or looking at the spot.</li><li class="typcn typcn-arrow-sorted-down">Option, choose the coordinate system.</li><li class="typcn typcn-arrow-left">Number, die x coordinate of the spot.</li><li class="typcn typcn-arrow-left">Number, die y coordinate of the spot.</li><li class="typcn typcn-arrow-left">Number,die z coordinate of the spot.</li><li class="typcn typcn-arrow-left">Number, the speed with which the robot shall move. Number between 1 and 100.</li>
-</ul></div><div id="robActions_sayText" class="help beginner"><h3 id="ProgrammingblocksNAO-»say...«">»say ... «</h3><p>With this block you can control the voice output of your robot. The robot will use the set language, which you can also change with the block »set language ...«.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, text your robot shall say.</li>
-</ul></div><div id="robActions_sayText_parameters" class="help expert"><h3 id="ProgrammingblocksNAO-»say...voicespeed...voicepitch...«[Expert-Block]">»say ... voice speed ... voice pitch ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control the voice output including the voice pitch and speaking speed of your robot. The robot will use the set language, which you can also change with the block »set language ...«.</p><p><span>Input values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, text your robot shall say.</li><li class="typcn typcn-arrow-left">Number,the voice speed of your robot, between 1 and 100.</li><li class="typcn typcn-arrow-left">Number, the voice pitch of your robot, between 1 and 100.</li>
-</ul></div><div id="naoActions_getLanguage" class="help expert"><h3 id="ProgrammingblocksNAO-»getlanguage«[Expert-Block]">»get language « <span class="typcn typcn-star"></span></h3><p>With this block you can display the currently set language.</p><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the currently selected language.</li>
-</ul></div><div id="robActions_setLanguage" class="help beginner"><h3 id="ProgrammingblocksNAO-»setlanguage...«">»set language ... «</h3><p>With this block you can change the language of your robot for voice output.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the desired language.</li>
-</ul></div><div id="naoActions_getVolume" class="help beginner"><h3 id="ProgrammingblocksNAO-»getvolume«">»get volume «</h3><p>With this block you can display the current volume of your robot.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the current volume of the robot.</li>
-</ul></div><div id="naoActions_setVolume" class="help beginner"><h3 id="ProgrammingblocksNAO-»setvolume...«">»set volume ... «</h3><p>With this block you can adjust the volume of your robot.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the desired volume of the robot, between 1 and 100.</li>
-</ul></div><div id="naoActions_learnFace" class="help expert"><h3 id="ProgrammingblocksNAO-»learnfaceof...«[Expert-Block]">»learn face of ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control the face recognition of your robot. The robot recognizes the current face and remembers it together with the entered name.</p><p><span>Input values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, name to be connected to the face.</li>
-</ul><br><p><span class="auto-cursor-target">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, true if a face has been regonized, false otherwise.</li>
-</ul></div><div id="naoActions_forgetFace" class="help expert"><h3 id="ProgrammingblocksNAO-»forgetfaceof...«[Expert-Block]">»forget face of ... « <span class="typcn typcn-star"></span></h3><p>With this block you can forget a face you have already memorized so that your robot will not recognize it anymore.</p><p><span>Input values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">String, name connected to the face that you want forgotten.</li>
-</ul></div><div id="naoActions_takePicture" class="help expert"><h3 id="ProgrammingblocksNAO-»takepicturecamera...filename...«[Expert-Block]">»take picture camera ... filename ... « <span class="typcn typcn-star"></span></h3><p>With this block you can take a photo with one of your robot's cameras and save it.</p><p><span>Options and Input values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose which camera to use.</li><li class="typcn typcn-arrow-left">String, filename for the photo.</li>
-</ul></div><div id="naoActions_recordVideo" class="help expert"><h3 id="ProgrammingblocksNAO-»recordvideowithresolution...camera...durationms...filename...«[Expert-Block]">»record video with resolution ... camera ... duration ms ... filename ... « <span class="typcn typcn-star"></span></h3><p>With this block you can record and save a video with one of your robot's cameras.</p><p><span>Options and Input values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the resolution of the video.</li><li class="typcn typcn-arrow-sorted-down">Option, choose which camera to use.</li><li class="typcn typcn-arrow-left">Number, the duration of the video in milliseconds.</li><li class="typcn typcn-arrow-left">String, filename for the video.</li>
-</ul></div><div id="naoActions_rgbLeds" class="help beginner"><h3 id="ProgrammingblocksNAO-»LED...colour...«">»LED ... colour ... «</h3><p>With this block you can control a color LED of your robot and change its color.</p><p>Options and Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the LED you want to control.</li><li class="typcn typcn-arrow-left">Colour, the new colour of the LED.</li>
-</ul></div><div id="naoActions_setIntensity" class="help beginner"><h3 id="ProgrammingblocksNAO-»LED...intensity...«">»LED ... intensity ... «</h3><p>With this block you can control the intensity, i.e. the brightness, of one or more LEDs of your robot.</p><p>Options and Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the LED you want to control.</li><li class="typcn typcn-arrow-left">Number, the intensity of the LED, between 0 and 100.</li>
-</ul></div><div id="naoActions_ledOff" class="help beginner"><h3 id="ProgrammingblocksNAO-»LED...off«">»LED ... off«</h3><p>With this block you can switch off one or more LEDs of your robot.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option,choose the LED you want to turn off.</li>
-</ul></div><div id="naoActions_ledReset" class="help expert"><h3 id="ProgrammingblocksNAO-»LED...reset«[Expert-Block]">»LED ... reset« <span class="typcn typcn-star"></span></h3><p>With this block you can reset one or more LEDs of your robot. The LEDs are reset to the state at program start.</p><p><span>Options:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the LED you want to reset.</li>
-</ul></div><div id="naoActions_randomEyes" class="help beginner"><h3 id="ProgrammingblocksNAO-»randomeyesdurationms...«">»random eyes duration ms ... «</h3><p>With this block you can make the eyes of your robot show a randomly selected animation. You can control the duration of the animation.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, duration of the animation in milliseconds.</li>
-</ul></div><div id="naoActions_rasta" class="help beginner"><h3 id="ProgrammingblocksNAO-»rastadurationms...«">»rasta duration ms ... «</h3><p>With this block you can play a ready-made animation on all LEDs of your robot. You can choose the duration of the animation, but not which animation is played.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, duration of the animation in milliseconds.</li>
-</ul></div><div id="robSensors_touch_getSample" class="help beginner"><h3 id="ProgrammingblocksNAO-»touchsensor......pressed?«">»touch sensor ... ... pressed?«</h3><p>With this sensor you can query one of your robot's touch sensors. The block returns "true" when the sensor is pressed, otherwise "false".</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option,select the area for the sensor.</li><li class="typcn typcn-arrow-sorted-down">Option, select the specific sensor you want to query.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean, the state of the sensor.</li>
-</ul></div><div id="robSensors_ultrasonic_getSample" class="help beginner"><h3 id="ProgrammingblocksNAO-»getdistancecmultrasonicsensor«">»get distance cm ultrasonic sensor«</h3><p>With this block you can query the ultrasonic sensor of your robot and determine the distance to the next object.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, distance to the nearest object in centimeter.</li>
-</ul></div><div id="robSensors_detectmark_getSample" class="help beginner"><h3 id="ProgrammingblocksNAO-»get...NAOMarkSensor«">»get ... NAO Mark Sensor «</h3><p>With this block you can query the NAO Mark Sensor. This sensor is able to recognize premade images and assigns them a special ID. This ID can be queried with this block.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option,select whether you want to query a single ID or a list of IDs.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number or List of Numbers, depending on your choice above.</li>
-</ul></div><div id="naoSensors_getMarkInformation" class="help beginner"><h3 id="ProgrammingblocksNAO-»getinformationNAOMarkSensorabout...«">»get information NAO Mark Sensor about ... «</h3><p>With this block you can get more information about a detected pattern of the NAO Mark Sensor. This information is the angles in x and y direction, the size in x and y direction and the orientation of the image.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of Numbers,this list contains all the above mentioned information on that order.</li>
-</ul></div><div id="robSensors_detectface_getSample" class="help beginner"><h3 id="ProgrammingblocksNAO-»get...facedetector«">»get ... face detector«</h3><p>With this block you can query the face recognition of your robot. You can query either the name of the current face or a list of names of the current face.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose between a single name or a list of names.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String or List of Strings, the name or list of names of the recognized face.</li>
-</ul></div><div id="naoSensors_getFaceInformation" class="help beginner"><h3 id="ProgrammingblocksNAO-»getinformationfacedetectorabout...«">»get information face detector about ... «</h3><p>Use this block to request more information about faces already saved. This information includes the angles in x and y direction, the size in x and y direction and the orientation of the image.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List von Numbers, the list contains all the above mentioned information in that order.</li>
-</ul></div><div id="naoSensors_recognizeWord" class="help beginner"><h3 id="ProgrammingblocksNAO-»getwordspeechrecognizerof...«">»get word speech recognizer of ... «</h3><p>With this block you can query the voice recognition of your robot. However, you can only recognize words that you give this block as input value.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the word you want your robot to recognize.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the recognized word.</li>
-</ul></div><div id="robSensors_gyro_getSample" class="help expert"><h3 id="ProgrammingblocksNAO-»getanglegyroscope...«[Expert-Block]">»get angle gyroscope ... « <span class="typcn typcn-star"></span></h3><p>With this block you can query the gyro sensor of your robot. This sensor measures how much your robot has turned in one direction.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select the rotation axis for which you want to query the rotation.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the angle the robot rotated for.</li>
-</ul></div><div id="robSensors_accelerometer_getSample" class="help expert"><h3 id="ProgrammingblocksNAO-»getvaluemilli-gaccelerometer...«[Expert-Block]">»get value milli-g accelerometer ... « <span class="typcn typcn-star"></span></h3><p>With this block you can query the acceleration sensor of your robot. This sensor measures the acceleration the robot experiences in one direction.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select the direction in which the acceleration is to be measured.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the measured acceleration in milli-g. 1000 milli-g correspond to one g, i.e. the acceleration due to gravity.</li>
-</ul></div><div id="robSensors_fsr_getSample" class="help expert"><h3 id="ProgrammingblocksNAO-»getvalueNforce-sensingresistor...«[Expert-Block]">»get value N force-sensing resistor ... « <span class="typcn typcn-star"></span></h3><p>With this sensor you can query the pressure sensor of your robot. This sensor measures the applied pressure and can calculate the applied force from that.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose which sensor to query.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the measured force in Newtowns.</li>
-</ul></div><div id="robSensors_electriccurrent_getSample" class="help expert"><h3 id="ProgrammingblocksNAO-»getvalueAcurrentsensor......«[Expert-Block]">»get value A current sensor ... ... « <span class="typcn typcn-star"></span></h3><p>With this block you can query the current sensor of your robot. This sensor measures the current flow through a motor and returns it.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose which motor's current to measure.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the measured current in Ampere.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 id="ProgrammingblocksNAO-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="ProgrammingblocksNAO-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="ProgrammingblocksNAO-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="ProgrammingblocksNAO-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="ProgrammingblocksNAO-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="ProgrammingblocksNAO-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="ProgrammingblocksNAO-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="ProgrammingblocksNAO-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="ProgrammingblocksNAO-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="ProgrammingblocksNAO-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="ProgrammingblocksNAO-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="ProgrammingblocksNAO-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="ProgrammingblocksNAO-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="ProgrammingblocksNAO-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="ProgrammingblocksNAO-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="ProgrammingblocksNAO-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="ProgrammingblocksNAO-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="ProgrammingblocksNAO-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="ProgrammingblocksNAO-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="ProgrammingblocksNAO-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="ProgrammingblocksNAO-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="ProgrammingblocksNAO-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="ProgrammingblocksNAO-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="ProgrammingblocksNAO-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="ProgrammingblocksNAO-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksNAO-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="ProgrammingblocksNAO-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="ProgrammingblocksNAO-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="ProgrammingblocksNAO-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="ProgrammingblocksNAO-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingblocksNAO-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingblocksNAO-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="ProgrammingblocksNAO-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammingblocksNAO-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="ProgrammingblocksNAO-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksNAO-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingblocksNAO-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingblocksNAO-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksNAO-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksNAO-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksNAO-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksNAO-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksNAO-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksNAO-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksNAO-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksNAO-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingblocksNAO-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammingblocksNAO-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammingblocksNAO-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingblocksNAO-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="ProgrammingblocksNAO-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="ProgrammingblocksNAO-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammingblocksNAO-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="ProgrammingblocksNAO-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammingblocksNAO-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammingblocksNAO-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammingblocksNAO-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="ProgrammingblocksNAO-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="ProgrammingblocksNAO-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammingblocksNAO-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingblocksNAO-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»start«"><span style="color: rgb(0,0,0);">»start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Each program starts with the red »start« block.</p>
+            <p>This block is always available in the Open Roberta Lab and cannot be deleted. The little triangle below
+                the start block is called »sequence connector«. The first block you want to use will be connected by
+                using the »sequence connector« at the start block. The sequence connector color changes to yellow when a
+                suitable block comes into its range.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">create a new global variable</li>
+                <li class="typcn typcn-minus">delete the global variable</li>
+                <li class="typcn typcn-arrow-sorted-down">autonomous behaviour, here you can set whether your robot
+                    should move autonomously.</li>
+            </ul>
+            <p>If global variables have been created:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Colour«,
+                    »Image«, »List Number«, »List Boolean«, »List String«, »List Image«</li>
+                <li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial
+                    value of the variable.</li>
+            </ul><br>
+        </div>
+        <div id="naoActions_applyPosture" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»letNAO...«">»let NAO ... «</h3>
+            <p>With this block you can control the action of your robot. The robot can take up many different posture,
+                such as squatting, standing or sitting.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the posture you robot should take.</li>
+            </ul>
+        </div>
+        <div id="naoActions_hand" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»hand......«[Expert-Block]">»hand ... ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can control one hand of your robot. The hand can either open or close.</p>
+            <p class="auto-cursor-target">Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the hand you want to control.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose whether you want the hand to open or close.
+                </li>
+            </ul>
+        </div>
+        <div id="naoActions_moveJoint" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»move.........«[Expert-Block]">»move ... ... ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can control a single joint of your robot. The joints can either move relative to
+                their current position or absolutely to their starting position.</p>
+            <p><span>Options and Input values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the joint you want to control.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose between a relative or absolute movement.</li>
+                <li class="typcn typcn-arrow-left">Number Rotation of the joint in degrees, number between 0 and 360.
+                </li>
+            </ul>
+        </div>
+        <div id="naoActions_stiffness" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»lockmotors......«[Expert-Block]">»lock motors ... ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block allows you to lock the motors of an area of your robot so that the motor cannot move until the
+                lock is removed.</p>
+            <p><span>Options:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select the area of your robot whose motors you want to
+                    lock.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose whether you want to lock the motors or release
+                    them.</li>
+            </ul>
+        </div>
+        <div id="naoActions_walk" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»walk...distancecm...«">»walk ... distance cm ... «</h3>
+            <p>With this block you can let your robot run a certain distance straight ahead.</p>
+            <p>Options and Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose whether your robot should move forwards or
+                    backwards.</li>
+                <li class="typcn typcn-arrow-left">Number, the distance your robot shall walk.</li>
+            </ul>
+        </div>
+        <div id="naoActions_turn" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»turn...degrees°...«">»turn ... degrees ° ... «</h3>
+            <p>With this block you can turn your robot on the spot.</p>
+            <p>Options and Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the direction your robot should turn into.</li>
+                <li class="typcn typcn-arrow-left">Number, select the angle by which the robot should turn.</li>
+            </ul>
+        </div>
+        <div id="naoActions_walkTo" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»walktox...y...theta...«[Expert-Block]">»walk to x ... y ... theta ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can move your robot relative to its current position.</p>
+            <p><span>Input values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, x-coordinate for the new position.</li>
+                <li class="typcn typcn-arrow-left">Number, y-coordinate for the new position.</li>
+                <li class="typcn typcn-arrow-left">Number, select the angle by which the robot should turn.</li>
+            </ul>
+        </div>
+        <div id="naoActions_walk_async" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»walktoxspeed%...yspeed%...turnspeed%...«[Expert-Block]">»walk to x speed % ...
+                y speed % ... turn speed % ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can adjust the speed of your robot during a free movement.</p>
+            <p><span>Input values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, Speed for the movement in x-direction. Number between 1 and
+                    100.</li>
+                <li class="typcn typcn-arrow-left">Number, Speed for the movement in y-direction. Number between 1 and
+                    100.</li>
+                <li class="typcn typcn-arrow-sorted-down">Number, Speed for the rotation of your robot. Number between 1
+                    and 100.</li>
+            </ul>
+        </div>
+        <div id="naoActions_stop" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»stopmovement...«[Expert-Block]">»stop movement ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can stop all running movements of your robot.</p>
+        </div>
+        <div id="naoActions_animation" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»perform...«">»perform ... «</h3>
+            <p>With this block you can let your robot perform a predefined animation. You can choose between Tai Chi,
+                waving, flashing and wiping your forehead.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose one of the predefined animations.</li>
+            </ul>
+        </div>
+        <div id="naoActions_autonomous" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»turnautonomousbehaviour...«[Expert-Block]">»turn autonomous behaviour ... «
+                <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can enable or disable the autonomous behaviour of your robot. With the autonomous
+                behaviour switched on, the robot will not run into walls, for example.</p>
+            <p><span>Options:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose between turning to autonomous behaviour on or
+                    off.</li>
+            </ul>
+        </div>
+        <div id="naoActions_pointLookAt" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»point/lookatframe...x...y...z...speed%...«[Expert-Block]">»point/look at frame
+                ... x ... y ... z ... speed % ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can point your robot to any place in the room. You can choose from three coordinate
+                systems. The coordinate system "upper body" starts from the upper body of your robot, the coordinate
+                system "world" refers to the whole room and the coordinate system "robot" starts from the center of your
+                robot.</p>
+            <p><span>Options and Input values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose between the robot pointing or looking at the
+                    spot.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the coordinate system.</li>
+                <li class="typcn typcn-arrow-left">Number, die x coordinate of the spot.</li>
+                <li class="typcn typcn-arrow-left">Number, die y coordinate of the spot.</li>
+                <li class="typcn typcn-arrow-left">Number,die z coordinate of the spot.</li>
+                <li class="typcn typcn-arrow-left">Number, the speed with which the robot shall move. Number between 1
+                    and 100.</li>
+            </ul>
+        </div>
+        <div id="robActions_sayText" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»say...«">»say ... «</h3>
+            <p>With this block you can control the voice output of your robot. The robot will use the set language,
+                which you can also change with the block »set language ...«.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, text your robot shall say.</li>
+            </ul>
+        </div>
+        <div id="robActions_sayText_parameters" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»say...voicespeed...voicepitch...«[Expert-Block]">»say ... voice speed ...
+                voice pitch ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can control the voice output including the voice pitch and speaking speed of your
+                robot. The robot will use the set language, which you can also change with the block »set language ...«.
+            </p>
+            <p><span>Input values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, text your robot shall say.</li>
+                <li class="typcn typcn-arrow-left">Number,the voice speed of your robot, between 1 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, the voice pitch of your robot, between 1 and 100.</li>
+            </ul>
+        </div>
+        <div id="naoActions_getLanguage" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»getlanguage«[Expert-Block]">»get language « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can display the currently set language.</p>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the currently selected language.</li>
+            </ul>
+        </div>
+        <div id="robActions_setLanguage" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»setlanguage...«">»set language ... «</h3>
+            <p>With this block you can change the language of your robot for voice output.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the desired language.</li>
+            </ul>
+        </div>
+        <div id="naoActions_getVolume" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»getvolume«">»get volume «</h3>
+            <p>With this block you can display the current volume of your robot.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the current volume of the robot.</li>
+            </ul>
+        </div>
+        <div id="naoActions_setVolume" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»setvolume...«">»set volume ... «</h3>
+            <p>With this block you can adjust the volume of your robot.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the desired volume of the robot, between 1 and 100.</li>
+            </ul>
+        </div>
+        <div id="naoActions_learnFace" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»learnfaceof...«[Expert-Block]">»learn face of ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can control the face recognition of your robot. The robot recognizes the current face
+                and remembers it together with the entered name.</p>
+            <p><span>Input values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, name to be connected to the face.</li>
+            </ul><br>
+            <p><span class="auto-cursor-target">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, true if a face has been regonized, false otherwise.</li>
+            </ul>
+        </div>
+        <div id="naoActions_forgetFace" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»forgetfaceof...«[Expert-Block]">»forget face of ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can forget a face you have already memorized so that your robot will not recognize it
+                anymore.</p>
+            <p><span>Input values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">String, name connected to the face that you want forgotten.
+                </li>
+            </ul>
+        </div>
+        <div id="naoActions_takePicture" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»takepicturecamera...filename...«[Expert-Block]">»take picture camera ...
+                filename ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can take a photo with one of your robot's cameras and save it.</p>
+            <p><span>Options and Input values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose which camera to use.</li>
+                <li class="typcn typcn-arrow-left">String, filename for the photo.</li>
+            </ul>
+        </div>
+        <div id="naoActions_recordVideo" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»recordvideowithresolution...camera...durationms...filename...«[Expert-Block]">
+                »record video with resolution ... camera ... duration ms ... filename ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can record and save a video with one of your robot's cameras.</p>
+            <p><span>Options and Input values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the resolution of the video.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose which camera to use.</li>
+                <li class="typcn typcn-arrow-left">Number, the duration of the video in milliseconds.</li>
+                <li class="typcn typcn-arrow-left">String, filename for the video.</li>
+            </ul>
+        </div>
+        <div id="naoActions_rgbLeds" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»LED...colour...«">»LED ... colour ... «</h3>
+            <p>With this block you can control a color LED of your robot and change its color.</p>
+            <p>Options and Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the LED you want to control.</li>
+                <li class="typcn typcn-arrow-left">Colour, the new colour of the LED.</li>
+            </ul>
+        </div>
+        <div id="naoActions_setIntensity" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»LED...intensity...«">»LED ... intensity ... «</h3>
+            <p>With this block you can control the intensity, i.e. the brightness, of one or more LEDs of your robot.
+            </p>
+            <p>Options and Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the LED you want to control.</li>
+                <li class="typcn typcn-arrow-left">Number, the intensity of the LED, between 0 and 100.</li>
+            </ul>
+        </div>
+        <div id="naoActions_ledOff" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»LED...off«">»LED ... off«</h3>
+            <p>With this block you can switch off one or more LEDs of your robot.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option,choose the LED you want to turn off.</li>
+            </ul>
+        </div>
+        <div id="naoActions_ledReset" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»LED...reset«[Expert-Block]">»LED ... reset« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can reset one or more LEDs of your robot. The LEDs are reset to the state at program
+                start.</p>
+            <p><span>Options:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the LED you want to reset.</li>
+            </ul>
+        </div>
+        <div id="naoActions_randomEyes" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»randomeyesdurationms...«">»random eyes duration ms ... «</h3>
+            <p>With this block you can make the eyes of your robot show a randomly selected animation. You can control
+                the duration of the animation.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, duration of the animation in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="naoActions_rasta" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»rastadurationms...«">»rasta duration ms ... «</h3>
+            <p>With this block you can play a ready-made animation on all LEDs of your robot. You can choose the
+                duration of the animation, but not which animation is played.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, duration of the animation in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robSensors_touch_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»touchsensor......pressed?«">»touch sensor ... ... pressed?«</h3>
+            <p>With this sensor you can query one of your robot's touch sensors. The block returns "true" when the
+                sensor is pressed, otherwise "false".</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option,select the area for the sensor.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, select the specific sensor you want to query.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean, the state of the sensor.</li>
+            </ul>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»getdistancecmultrasonicsensor«">»get distance cm ultrasonic sensor«</h3>
+            <p>With this block you can query the ultrasonic sensor of your robot and determine the distance to the next
+                object.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, distance to the nearest object in centimeter.</li>
+            </ul>
+        </div>
+        <div id="robSensors_detectmark_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»get...NAOMarkSensor«">»get ... NAO Mark Sensor «</h3>
+            <p>With this block you can query the NAO Mark Sensor. This sensor is able to recognize premade images and
+                assigns them a special ID. This ID can be queried with this block.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option,select whether you want to query a single ID or a list
+                    of IDs.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number or List of Numbers, depending on your choice above.</li>
+            </ul>
+        </div>
+        <div id="naoSensors_getMarkInformation" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»getinformationNAOMarkSensorabout...«">»get information NAO Mark Sensor about
+                ... «</h3>
+            <p>With this block you can get more information about a detected pattern of the NAO Mark Sensor. This
+                information is the angles in x and y direction, the size in x and y direction and the orientation of the
+                image.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of Numbers,this list contains all the above mentioned
+                    information on that order.</li>
+            </ul>
+        </div>
+        <div id="robSensors_detectface_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»get...facedetector«">»get ... face detector«</h3>
+            <p>With this block you can query the face recognition of your robot. You can query either the name of the
+                current face or a list of names of the current face.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose between a single name or a list of names.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String or List of Strings, the name or list of names of the
+                    recognized face.</li>
+            </ul>
+        </div>
+        <div id="naoSensors_getFaceInformation" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»getinformationfacedetectorabout...«">»get information face detector about ...
+                «</h3>
+            <p>Use this block to request more information about faces already saved. This information includes the
+                angles in x and y direction, the size in x and y direction and the orientation of the image.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List von Numbers, the list contains all the above mentioned
+                    information in that order.</li>
+            </ul>
+        </div>
+        <div id="naoSensors_recognizeWord" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»getwordspeechrecognizerof...«">»get word speech recognizer of ... «</h3>
+            <p>With this block you can query the voice recognition of your robot. However, you can only recognize words
+                that you give this block as input value.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the word you want your robot to recognize.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the recognized word.</li>
+            </ul>
+        </div>
+        <div id="robSensors_gyro_getSample" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»getanglegyroscope...«[Expert-Block]">»get angle gyroscope ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can query the gyro sensor of your robot. This sensor measures how much your robot has
+                turned in one direction.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select the rotation axis for which you want to query
+                    the rotation.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the angle the robot rotated for.</li>
+            </ul>
+        </div>
+        <div id="robSensors_accelerometer_getSample" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»getvaluemilli-gaccelerometer...«[Expert-Block]">»get value milli-g
+                accelerometer ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can query the acceleration sensor of your robot. This sensor measures the
+                acceleration the robot experiences in one direction.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select the direction in which the acceleration is to
+                    be measured.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the measured acceleration in milli-g. 1000 milli-g
+                    correspond to one g, i.e. the acceleration due to gravity.</li>
+            </ul>
+        </div>
+        <div id="robSensors_fsr_getSample" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»getvalueNforce-sensingresistor...«[Expert-Block]">»get value N force-sensing
+                resistor ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this sensor you can query the pressure sensor of your robot. This sensor measures the applied
+                pressure and can calculate the applied force from that.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose which sensor to query.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the measured force in Newtowns.</li>
+            </ul>
+        </div>
+        <div id="robSensors_electriccurrent_getSample" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»getvalueAcurrentsensor......«[Expert-Block]">»get value A current sensor ...
+                ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can query the current sensor of your robot. This sensor measures the current flow
+                through a motor and returns it.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose which motor's current to measure.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the measured current in Ampere.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="ProgrammingblocksNAO-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue
+                with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammingblocksNAO-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="ProgrammingblocksNAO-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»mathematicalfunction«[Expert-block]">»mathematical function« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksNAO-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingblocksNAO-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingblocksNAO-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="ProgrammingblocksNAO-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammingblocksNAO-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="ProgrammingblocksNAO-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksNAO-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingblocksNAO-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingblocksNAO-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number«
+                <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksNAO-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksNAO-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksNAO-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksNAO-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksNAO-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksNAO-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksNAO-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksNAO-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingblocksNAO-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingblocksNAO-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammingblocksNAO-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingblocksNAO-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ...
+                green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="ProgrammingblocksNAO-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ...
+                blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingblocksNAO-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green
+                ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammingblocksNAO-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function
+                blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function
+                blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="ProgrammingblocksNAO-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with
+                return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="ProgrammingblocksNAO-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function
+                with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammingblocksNAO-»functioncallwithoutreturnvalue«">»function call without return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingblocksNAO-»functioncallwithreturnvalue«">»function call with
+                return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_nxt_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nxt_de.html
@@ -1,430 +1,1706 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»Programmstart«"><span style="color: rgb(0,0,0);">»Programmstart«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Jedes Programm beginnt mit dem »Programmstart-Block« und kann nicht gelöscht werden. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am Programmstart-Block. Sequenzverbindung bezeichnet das kleine Dreieck am unteren Ende des Blocks. Dieses Dreieck wird gelb markiert, sobald ein geeigneter Block in seiner Nähe ist.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li><li class="typcn typcn-input-checked">autonomes Verhalten - Du kannst hier einstellen, ob sich der Roboter autonom, also selbstständig, bewegen soll.</li>
-</ul><br><p>Wenn globale Variablen erzeugt wurden:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variablen.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
-</ul><br></div><div id="robActions_motor_on" class="help expert"><h3 id="ProgrammierBlöckeNXT-»MotorPort...anTempo...«[Experten-Block]"><span style="color: rgb(0,0,0);">»Motor Port ... an Tempo  ... « </span><span class="typcn typcn-star"></span></h3><p>Mit dem Block »Motor Port ... an« programmierst du das Tempo (Geschwindigkeit) eines Motors. Dein Roboter startet den gewählten Motor, bis er gestoppt wird oder ein anderer Block zum Fahren verwendet wird.</p><p>Einstellmöglichkeiten und EIngabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor Port, wähle den Motor Port aus, an dem der Motor angeschlossen ist.</li><li class="typcn typcn-arrow-left">Tempo, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li>
-</ul><br></div><div id="robActions_motor_on_for" class="help expert"><h3 id="ProgrammierBlöckeNXT-»MotorPort...anTempo...fürUmdrehungen/Grad...«[Experten-Block]"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Motor Port ... an  Tempo ... für Umdrehungen/Grad ... « <span class="typcn typcn-star"></span></span><br></span></h3><p>Mit dem Block »Motor Port ... an Tempo ... Umdrehungen/Grad« stellst du das Tempo (Geschwindigkeit) eines Motors ein. Dein Roboter startet den gewählten Motor, bis er die eingestellte Anzahl Umdrehungen bzw. Winkelgrade gemacht hat.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor Port, wähle den Motorport aus, an dem der Motor angeschlossen ist.</li><li class="typcn typcn-arrow-left">Tempo,  Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li><li class="typcn typcn-arrow-sorted-down">Umdrehungen oder Grad. 1 Umdrehung entspricht 360 Grad.</li><li class="typcn typcn-arrow-left">Zahl, Anzahl der Umdrehungen bzw. Winkelgrade. Es sind nur positive Zahlen zugelassen.</li>
-</ul><br></div><div id="robActions_motor_getPower" class="help expert"><h3 id="ProgrammierBlöckeNXT-»GibTempoMotorPort...«[Experten-Block]"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Gib Tempo Motor Port ...« <span class="typcn typcn-star"></span></span><br></span></h3><p>Der Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Gib Tempo Motor Port</span></span>« liest das Tempo (Geschwindigkeit) eines Motors aus.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, dessen Tempo gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl; Geschwindigkeit , die am ausgewählten Motor Port eingestellt ist.</li>
-</ul><br></div><div id="robActions_motor_setPower" class="help expert"><h3 id="ProgrammierBlöckeNXT-»SetzeMotorPort...Tempo...«[Experten-Block]"><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Setze Motor Port ... <span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Tempo ...</span></span>« <span class="typcn typcn-star"></span></span><br></span></h3><p>Der Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Setze Motor Port <span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">... Tempo</span></span></span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);"><span> </span><span> </span>« setzt </span></span>das Tempo (Geschwindigkeit) eines Motors auf einen neuen Wert.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, für den dasTempo eingestellt werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li>
-</ul><br></div><div id="robActions_motor_stop" class="help expert"><h3 id="ProgrammierBlöckeNXT-»StoppeMotorPort...«[Experten-Block]"><span style="color: rgb(0,0,255);"> <span style="color: rgb(0,0,0);">»Stoppe Motor Port ... « <span class="typcn typcn-star"></span></span><br></span></h3><p>Mit dem Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Stoppe Motor Port</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);"><span> </span>« schaltet den </span></span>Motor an einem ausgewählten Motor-Port aus. Du kannst einstellen, ob der Motor langsam ausläuft oder gebremst wird.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motorport aus, der ausgeschaltet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Option; »auslaufen<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">«</span></span> sorgt dafür, dass der Motor langsam ausläuft; »bremsen<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">«</span></span> sorgt dafür, dass der Motor abrupt abgebremst wird.</li>
-</ul><br></div><div id="robActions_motorDiff_on" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»Fahre...Tempo...«">»Fahre ... Tempo ...«</h3><p>Mit dem Block »Fahre ... Tempo« kannst du die Richtung und das Tempo (Geschwindigkeit) deines Roboters programmieren. Dein Roboter fährt so lange vorwärts oder rückwärts, bis er gestoppt wird oder ein anderer Block zum Fahren verwendet wird.</p><p>»Fahre« steuert beide Motoren des Roboters gleichzeitig.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die gewünschte Fahrrichtung aus.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen sich die Motoren rückwärts.</li>
-</ul><br></div><div id="robActions_motorDiff_on_for" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»Fahre...Tempo...Strecke...«">»Fahre ... Tempo ... Strecke ...«</h3><p>Mit dem Block »Fahre ... Tempo Strecke« kannst du zusätzlich zu Richtung und Tempo auch die Fahrstrecke des Roboters programmieren. Dein Roboter fährt so lange, bis die eingestellte Strecke gefahren ist. Die Geschwindigkeit kannst du im Feld Tempo einstellen. Wenn dieser Block »zu Ende« ist, stoppen die Motoren automatisch.</p><p>»Fahre« steuert beide Motoren des Roboters gleichzeitig.</p><p>Wenn die eingestellten Werte der Aktionen mit der Programmausführung nicht übereinstimmen, prüfe die Roboter-Konfiguration, insbesondere den Raddurchmesser.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die gewünschte Fahrtrichtung.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen sich die Motoren rückwärts.</li><li class="typcn typcn-arrow-left">Zahl, Länge für die Strecke in cm.</li>
-</ul><br></div><div id="robActions_motorDiff_stop" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»Stoppe«">»Stoppe«</h3><p>Mit dem Block »Stoppe« werden die Motoren deines Roboters gestoppt. Das bedeutet, dein Roboter hält an.</p></div><div id="robActions_motorDiff_turn" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»Drehe...Tempo...«">»Drehe ... Tempo ... «</h3><p>Mit dem Block »Drehe ...  Tempo... « kannst du die Richtung (rechts/links), in der sich der Roboter drehen soll, programmieren. Dein Roboter dreht sich so lange auf der Stelle, bis er gestoppt wird oder ein anderer Block zum Fahren verwendet wird. Die Geschwindigkeit kannst Du im Feld »Tempo« einstellen. »Drehe« steuert beide Motoren des Roboters gleichzeitig in entgegengesetzten Richtungen, dadurch dreht sich der Roboter auf der Stelle.</p><p>Wenn die eingestellten Werte der Aktionen mit der Programmausführung nicht übereinstimmen, prüfe die Roboter-Konfiguration, insbesondere den Raddurchmesser und die Spurbreite.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die gewünschte Drehrichtung aus.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen sich die Motoren rückwärts.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><p>Falls sich dein Roboter in die falsche Richtung dreht, sind die Motoren an die falschen Ports angeschlossen. Es genügt dann, die Ports zu tauschen, damit der Roboter in die richtige Richtung dreht.</p></div></div></div><div id="robActions_motorDiff_turn_for" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»Drehe...Tempo...Grad...«">»Drehe ... Tempo ... Grad ...«</h3><p>Mit dem Block »Drehe ... Tempo ... Grad« kannst du die Richtung (rechts/links), in der sich der Roboter um die eigene Achse drehen soll, programmieren. Zusätzlich zur Richtung kann noch im Feld »Grad« angegeben werden, um wie viel Grad sich dein Roboter (um die eigene Achse) drehen soll. Dies bedeutet, dass du beispielsweise mit der Einstellung 360 Grad deinen Roboter einmal um die eigene Achse drehen lassen kannst. Der Block »Drehe ... Tempo ... Grad« steuert beide Motoren des Roboters, damit sich der Roboter um die eigene Achse dreht.</p><p>Wenn die eingestellten Werte der Aktionen mit der Programmausführung nicht übereinstimmen, prüfe die Roboter-Konfiguration, insbesondere den Raddurchmesser und die Spurbreite.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die gewünschte Drehrichtung aus.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen sich die Motoren rückwärts.</li><li class="typcn typcn-arrow-left">Zahl, Gradzahl um die der Roboter sich drehen soll. Negative Zahlen sind nicht zugelassen.</li>
-</ul><br></div><div id="robActions_motorDiff_curve" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»Steure...Tempolinks...Temporechts...«">»Steure ... Tempo links ... Tempo rechts ...«</h3><p>Mit dem Block »Steure ... Tempo links ... Tempo rechts ...« kannst du den Roboter so programmieren, dass er eine Kurve fährt, indem du das Tempo für den linken und den rechten Motor auf unterschiedliche Werte setzt. Die Roboterkonfiguration beeinflusst den Radius der Kurve in Abhängigkeit von Radabstand und Raddurchmesser. Mit der Drehrichtung legst du die Fahrtrichtung fest.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Drehrichtung, wähle die gewünschte Drehrichtung aus.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den linken Motor. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den link rechten Motor. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li>
-</ul><br></div><div id="robActions_motorDiff_curve_for" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»Steure...Tempolinks...Temporechts...Strecke...«">»Steure ... Tempo links ... Tempo rechts ... Strecke ...«</h3><p>Mit dem Block »Steure ... Tempo links ... Tempo rechts ... Strecke ...« kannst du den Roboter so programmieren, dass er eine vorgegebene Strecke als Kurve fährt, indem du das Tempo für den linken und den rechten Motor auf unterschiedliche Werte setzt. Die Strecke bezieht sich auf die Mitte zwischen beiden Rädern. Die Roboterkonfiguration beeinflusst den Radius der Kurve in Abhängigkeit von Radabstand und Raddurchmesser. Mit der Richtung legst du die Fahrtrichtung fest.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Richtung, wähle die gewünschte Fahrtrichtung aus.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den linken Motor. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li><li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den rechten Motor. Wenn die Zahl negativ ist, dreht sich der Motor rückwärts.</li><li class="typcn typcn-arrow-left">Zahl, Strecke in Zentimetern, die zurückgelegt werden soll.</li>
-</ul><br></div><div id="robActions_display_text" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»ZeigeText«">»Zeige Text«</h3><p>Mit dem Block »Zeige Text« kannst du Text und Zahlen auf dem Display deines Roboters anzeigen lassen. Dabei kannst du zusätzlich noch bestimmen, in welcher Spalte und in welcher Zeile der Text auf dem NXT-Bildschirm erscheinen soll.</p><p>Das Display eines NXT ist für Texte in 8 Zeilen (Zeilennummern 1 bis 8) und 16 Spalten (Spaltennummern 0 bis 15) eingeteilt.</p><p>Wenn zuvor schon etwas auf dem Display angezeigt war, werden nur die Stellen überschrieben, in die der Text geschrieben wird.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li><li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li><li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
-</ul><br></div><div id="robActions_display_clear" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»LöscheBildschirm«">»Lösche Bildschirm«</h3><p>Mit dem Block »Lösche Bildschirm« kannst du Text und Zahlen auf dem Display deines Roboters löschen. Das Display ist anschließend leer.</p></div><div id="robActions_play_tone" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»SpieleFrequenz...Dauer...«">»Spiele Frequenz ... Dauer ...«</h3><p>Mit dem Block »Spiele Frequenz ... Dauer« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie lange der Ton gespielt wird) programmieren. Der Ton wird über den eingebauten Lautsprecher deines LEGO MINDSTORMS Steins abgespielt, bis die eingestellte Dauer erreicht ist.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Bitte beachte, dass das menschliche Gehör Frequenzen zwischen ca. 30 Hz bis ca. 15.000 Hz (15 kHz) wahrnehmen kann - je nach Mensch und Alter kann dies unterschiedlich sein.</p></div></div><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, gewünschte Frequenz in Hz (Hertz) eingeben.</li><li class="typcn typcn-arrow-left"> Zahl, gewünschte Dauer des Tons in Millisekunden (ms) eingeben.</li>
-</ul><br></div><div id="mbedActions_play_note" class="help beginner"><p><span style="color: rgb(85,85,85);font-size: 16.0px;font-weight: bold;letter-spacing: -0.006em;">»Spiele ... Note ... «</span></p><p>Mit diesem Block kann dein Roboter eine Note anspielen. Du kannst dabei sowohl die Note selbst, als auch die Länge der Note wählen.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Dauer der Note aus,</li><li class="typcn typcn-arrow-sorted-down">Option, wähle die Note, die du abspielen möchtest.</li>
-</ul><br></div><div id="robActions_play_setVolume" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»SetzeLautstärke...«">»Setze Lautstärke ...«</h3><p>Mit dem Block »Setze Lautstärke« kannst du die Lautstärke eines Tons programmieren. Die Lautstärke kann von 0 (kein Ton) bis 100 (volle Lautstärke) eingestellt werden. Die Lautstärke bleibt so lange eingestellt, bis du sie mit einem anderen Block »Setze Lautstärke« neu programmierst.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl für die Lautstärke.</li>
-</ul><br></div><div id="robActions_play_getVolume" class="help expert"><h3 id="ProgrammierBlöckeNXT-»GibLautstärke«[Experten-Block]">»Gib Lautstärke« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »Gib Lautstärke« kannst du die aktuell eingestellte Lautstärke auslesen. 0 = kein Ton, 100 = maximale Lautstärke.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, aktuell eingestellter Lautstärkewert.</li>
-</ul><br></div><div id="robActions_sensorLight_on" class="help expert"><h3 id="ProgrammierBlöckeNXT-»SetzeFarbsensor«[Experten-Block]">»Setze Farbsensor« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »Setze Farbsensor« in der Kategorie »Statusleuchte« kannst du den Farbsensor in einer der drei Farben rot, grün oder blau leuchten lassen.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Farbe, wähle eine Farbe aus.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle, ob das Licht an- oder ausgeschaltet sein soll..</li><li class="typcn typcn-arrow-sorted-down">Option, wähle den Port, an dem der Farbsensor angeschlossen ist.</li>
-</ul><br></div><div id="robSensors_touch_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeNXT-»Berührungssensor«">»Berührungssensor«</h3><p>Mit dem Block »Berührungssensor« kannst du einem anderen Block »mitteilen«,  ob der Berührungssensor gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>wahr = gedrückt</em> oder <em>falsch = nicht gedrückt</em> zurück.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle den Sensorport aus, an dem dein Berührungssensor angeschlossen ist.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn der Berührungssensor gedrückt ist, sonst »falsch«.</li>
-</ul><br> </div><div id="robSensors_sound_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeNXT-»GibWertGeräuschsensor«">»Gib Wert Geräuschsensor«</h3><p>Mit dem Block »Gib Wert Geräuschsensor« kannst du einem anderen Block »mitteilen«, welche Lautstärke der Geräuschsensor misst. Der Wert liegt zwischen 0 und 100.</p><br><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle den Sensorport aus, an dem dein Geräuschsensor angeschlossen ist.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Wert zwischen 0 und 100.</li>
-</ul><br> </div><div id="robSensors_light_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeNXT-»Gib...LichtsensorPort...«">»Gib ... Lichtsensor Port ...«</h3><p>Mit dem Block »Gib Licht« kannst du einem anderen Block »mitteilen«, welchen Lichtwert der Lichtsensor misst.</p><p>Im Modus »Licht« sendet der Lichtsensor eigenes Licht aus und misst das reflektierte Licht.</p><p>Im Modus »Umgebungslicht« misst der Lichtsensor die Helligkeit des Umgebunglichts. Die Werte liegen zwischen 0 und 100.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle aus, was gemessen werden soll: (reflektiertes) Licht oder Umgebungslicht</li><li class="typcn typcn-arrow-sorted-down"> Port, wähle den Sensorport aus, an dem dein Lichtsensor/Farbsensor angeschlossen ist.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Lichtwert zwischen 0 und 100.</li>
-</ul><br> </div><div id="robSensors_colour_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeNXT-»Gib...FarbsensorPort...«">»Gib ... Farbsensor Port ...«</h3><p>Mit dem Block »Gib Farbe« kannst du einem anderen Block »mitteilen«, welche Farbe der Farbsensor misst. Die Farbe wird als Datentyp »Farbe« übermittelt. Zudem kann dieser Block im Auswahlmenü auf »Licht« und »Umgebungslicht« gestellt werden. Diese zusätzlichen Typen übermitteln jeweils den Datentyp »Zahl«. Die Zahlenwerte liegen je nach gewählter Messmethode zwischen 0 und 255. Mit diesen verschiedenen Einstellung kann dieser Block je nach Anforderung eingestellt werden.</p><p>Im Modus »Farbe« sendet der Farbsensor Licht aus und erkennt, welche Grundfarbe unter dem Sensor erkannt wurde. Die Grundfarbwerte sind BLACK, WHITE, RED, GREEN, BLUE, YELLOW.</p><p>Im Modus »Licht« sendet der Farbsensor mittels seiner roten LED Licht aus und misst die reflektierte Lichtstärke auf einer Skala von 0 bis 100.</p><p>Im Modus »Umgebungslicht« wird dieselbe Skala (0-100) wie im Modus Licht verwendet. Dabei wird das ins Sensorfenster einfallende Umgebungslicht gemessen.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle aus, was gemessen werden soll.</li><li class="typcn typcn-arrow-sorted-down"> Port, wähle den Sensorport aus, an dem dein Lichtsensor/Farbsensor angeschlossen ist.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Je nach gewählter Messmethode werden die zugehörigen Werte ausgegeben.</li>
-</ul><br> </div><div id="robSensors_ultrasonic_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeNXT-»GibAbstand«Ultraschallsensor">»Gib Abstand« Ultraschallsensor</h3><p>Mit dem Block »Gib Abstand« für den Ultraschallsensor kannst du einem anderen Block »mitteilen«, welchen Abstand der Ultraschallsensor misst.</p><p>Im Modus »Abstand« wird der Abstand in Zentimetern gemessen. Der Maximalwert ist 255. Der Wert 255 kann auch bedeuten, dass der Abstand größer als 255 cm ist.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle aus, an welchem Port der Infrarotsensor angeschlossen ist.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Abstand in Zentimetern; maximal 255.</li>
-</ul><br> </div><div id="robSensors_encoder_reset" class="help beginner"> <h3 id="ProgrammierBlöckeNXT-»SetzeDrehsensorzurück«">»Setze Drehsensor zurück«</h3><p>Mit dem Block »Setze Drehsensor zurück« kann der interne Sensor (Motor-Encoder) eines Motors auf den Wert 0 zurückgesetzt werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, wähle aus, an welchem Port der Drehsensor/Motor angeschlossen ist.</li>
-</ul><br> </div><div id="robSensors_encoder_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeNXT-»GibUmdrehungen/Grad/Abstand«Drehsensor">»Gib Umdrehungen/Grad/Abstand« Drehsensor</h3><p>Mit dem Block »Gib Umdrehungen/Grad/Abstand« kannst du einem anderen Block die Motorumdrehungen »mitteilen«.</p><p>Wenn »Umdrehungen« eingestellt wurde, wird die Zahl der Umdrehungen ausgegeben.</p><p>Wenn »Grad« eingestellt wurde, wird die Gradzahl aller Umdrehungen ausgegeben, wobei eine volle Umdrehung genau 360 Grad entspricht.</p><p>Wenn »Abstand« eingestellt wurde, wird berechnet, welche Strecke das Rad des Motors zurückgelegt hat. Das ist natürlich abhängig davon, wie groß das Rad in der Roboterkonfiguration eingestellt ist.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Messmethode, stelle ein, wie gemessen werden soll.</li><li class="typcn typcn-arrow-sorted-down">Port, stelle ein, an welchem Port der Drehsensor bzw. Motor angeschlossen ist.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die je nach eingestellter Messmethode entweder die Umdrehungszahl, die Gradzahl oder die zurückgelegte Strecke darstellt.</li>
-</ul><br> </div><div id="robSensors_key_getSample" class="help beginner">  <h3 id="ProgrammierBlöckeNXT-»Taste«NXT-Tasten">»Taste« NXT-Tasten</h3><p>Mit dem Block »Taste« kannst du einem anderen Block "mitteilen" , ob die ausgewählte Taste gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>true = gedrückt</em> oder <em>false = nicht gedrückt</em> zurück. Auswahl aus »Mitte« / »Rechts« / »Links«.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Taste, die du überprüfen möchtest.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »true«, wenn die gewählte Taste gedrückt ist, sonst »false«.</li>
-</ul><br> </div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»GibWert«Zeitgeber">»Gib Wert« Zeitgeber</h3><p>Mit dem Block »Gib Wert« kannst du einem anderen Block den aktuellen Stand des internen Zeitgebers in Millisekunden "mitteilen". Der Zeitgeber wird automatisch mit dem Beginn eines Programms gestartet. Es steht 1 Zeitgeber zur Verfügung.</p><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl Millisekunden, die seit dem Programmstart oder dem letzten Zurücksetzen des Zeitgebers vergangen sind.</li>
-</ul><br></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»SetzeZeitgeber«">»Setze Zeitgeber«</h3><p>Mit dem Block »Setze Zeitgeber« kann der interne Zeitgeber auf den Wert 0 zurückgesetzt werden.</p></div><div id="robSensors_htcolour_getSample" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierBlöckeNXT-»Gib...HTFarbsensorPort...«[Expert-Block]">»Gib ... HT Farbsensor Port ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du den HT Farbsensor deines Roboters abfragen. Dieser Sensor kann die Farbe des Untergrunds, die Helligkeit des Lichts und der Umgebung und die Aufteilung der gemessenen Farbe in die Grundfarben Rot,Grün und Blau messen. Der Rückgabewert dieses Blocks hängt von der gemessenen Eigenschaft ab.</p><p>Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle welche Eigenschaft gemessen werden soll.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle an welchem Port der Sensor angeschlossen ist.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die Farbe des Untergrunds.</li><li class="typcn typcn-arrow-right">Zahl, Helligkeit des Lichts oder der Umgebung in Prozent. Zahl zwischen 0 und 100.</li><li class="typcn typcn-arrow-right">Liste, Aufspaltung der gemessenen Farbe in Rot, Grün und Blau.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammierBlöckeNXT-»Wartebis...«">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wartems...«">»Warte ms ... «</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wartebis...«.1">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Zufallszahl«">»Zufallszahl« </h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeNXT-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeNXT-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt werden soll. Zahl zwischen 0 und 255.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeNXT-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von der verwendeten Programmiersprache des Roboters abhängt. </span><span style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt, sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der Zeichenkette »52abcd« die Zahl 52.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammierBlöckeNXT-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li><li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte das die Nummerierung bei 0 anfängt.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeNXT-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeNXT-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeNXT-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeNXT-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeNXT-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeNXT-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeNXT-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="ProgrammierBlöckeNXT-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammierBlöckeNXT-»Farbwahl«">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammierBlöckeNXT-»Farbwahl«.1">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammierBlöckeNXT-»Farbwahl«.2">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierBlöckeNXT-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, die  Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierBlöckeNXT-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 class="auto-cursor-target" id="ProgrammierBlöckeNXT-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="ProgrammierBlöckeNXT-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammierBlöckeNXT-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammierBlöckeNXT-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammierBlöckeNXT-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="ProgrammierBlöckeNXT-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="ProgrammierBlöckeNXT-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammierBlöckeNXT-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen Wert zurück.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierBlöckeNXT-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit Rückgabewert «</h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
-</ul><br></div><div id="robCommunication_connection" class="help expert"><h3 id="ProgrammierBlöckeNXT-Verbindungsblock[Experten-Block]">Verbindungsblock <span class="typcn typcn-star"></span></h3><p>Der Verbindungsaufbau wird von einem NXT-Roboter initiiert, wie z.B. ein Telefonanruf von einem Anrufer. Im Display des NXT ist jeweils an der Kommunikationsnummer erkennbar, über welche Verbindung die Kommunikation läuft.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Verbindungsname, wähle einen der 4 angebotenen Namen aus.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Verbindungsobjekt.</li>
-</ul><br></div><div id="robCommunication_sendBlock" class="help expert"><h3 id="ProgrammierBlöckeNXT-SendeNachrichtüberVerbindung[Experten-Block]">Sende Nachricht über Verbindung <span class="typcn typcn-star"></span></h3><p>Eine Nachricht wird an den ausgewählten Roboter übermittelt. Die Nachricht wird über einen Block eingegeben, der dem Nachrichtentyp entspricht (Zahl, logischer Wert oder Zeichenkette).</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Nachrichtentyp, »Zahl«, »logischer Wert« oder »Zeichenkette«.</li><li class="typcn typcn-arrow-left">Nachricht, die übermittelt werden soll.</li><li class="typcn typcn-arrow-sorted-down">Verbindungsmedium, »Bluetooth«.</li><li class="typcn typcn-arrow-sorted-down">Kanal, über den die Kommunikation laufen soll.</li><li class="typcn typcn-arrow-left">Verbindung, über die die Kommunikation erfolgt.</li>
-</ul><br></div><div id="robCommunication_receiveBlock" class="help expert"><h3 id="ProgrammierBlöckeNXT-EmpfangeNachrichtüberVerbindung[Experten-Block]">Empfange Nachricht über Verbindung <span class="typcn typcn-star"></span></h3><p>Eine Nachricht wird über eine Verbindung übermittelt. Die Nachricht wird an einen Block übergeben, z.B. an eine Variable.</p><p>Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Nachrichtentyp, »Zahl«, »logischer Wert« oder »Zeichenkette«.</li><li class="typcn typcn-arrow-sorted-down">Verbindungsmedium, »Bluetooth«.</li><li class="typcn typcn-arrow-sorted-down">Kanal, über den die Kommunikation laufen soll.</li><li class="typcn typcn-arrow-left">Verbindung, über die die Kommunikation erfolgt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Nachricht, Inhalt der empfangenen Nachricht.</li>
-</ul><br></div><div id="robCommunication_checkConnection" class="help expert"><h3 id="ProgrammierBlöckeNXT-»connectiontorobot«-PrüfeVerbindung[Experten-Block]">»connection to robot« - Prüfe Verbindung <span class="typcn typcn-star"></span></h3><p>Die Verbindung zwischen zwei NXT-Robotern erfolgt über eine Verbingungsnummer. Der Block »connection to robot« prüft, ob eine Verbindung »steht«.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Verbindung, über die die Kommunikation erfolgt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »true« wenn eine Verbindung besteht, »false« sonst.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»Programmstart«"><span style="color: rgb(0,0,0);">»Programmstart«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Programmstart-Block« und kann nicht gelöscht werden. Den ersten Block,
+                den man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am Programmstart-Block.
+                Sequenzverbindung bezeichnet das kleine Dreieck am unteren Ende des Blocks. Dieses Dreieck wird gelb
+                markiert, sobald ein geeigneter Block in seiner Nähe ist.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
+                <li class="typcn typcn-input-checked">autonomes Verhalten - Du kannst hier einstellen, ob sich der
+                    Roboter autonom, also selbstständig, bewegen soll.</li>
+            </ul><br>
+            <p>Wenn globale Variablen erzeugt wurden:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variablen.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-»MotorPort...anTempo...«[Experten-Block]"><span
+                    style="color: rgb(0,0,0);">»Motor Port ... an Tempo ... « </span><span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »Motor Port ... an« programmierst du das Tempo (Geschwindigkeit) eines Motors. Dein Roboter
+                startet den gewählten Motor, bis er gestoppt wird oder ein anderer Block zum Fahren verwendet wird.</p>
+            <p>Einstellmöglichkeiten und EIngabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor Port, wähle den Motor Port aus, an dem der Motor
+                    angeschlossen ist.</li>
+                <li class="typcn typcn-arrow-left">Tempo, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
+                    sich der Motor rückwärts.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on_for" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-»MotorPort...anTempo...fürUmdrehungen/Grad...«[Experten-Block]"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Motor Port ... an Tempo ... für
+                        Umdrehungen/Grad ... « <span class="typcn typcn-star"></span></span><br></span></h3>
+            <p>Mit dem Block »Motor Port ... an Tempo ... Umdrehungen/Grad« stellst du das Tempo (Geschwindigkeit) eines
+                Motors ein. Dein Roboter startet den gewählten Motor, bis er die eingestellte Anzahl Umdrehungen bzw.
+                Winkelgrade gemacht hat.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor Port, wähle den Motorport aus, an dem der Motor
+                    angeschlossen ist.</li>
+                <li class="typcn typcn-arrow-left">Tempo, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
+                    sich der Motor rückwärts.</li>
+                <li class="typcn typcn-arrow-sorted-down">Umdrehungen oder Grad. 1 Umdrehung entspricht 360 Grad.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anzahl der Umdrehungen bzw. Winkelgrade. Es sind nur positive
+                    Zahlen zugelassen.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_getPower" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-»GibTempoMotorPort...«[Experten-Block]"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Gib Tempo Motor Port ...« <span
+                            class="typcn typcn-star"></span></span><br></span></h3>
+            <p>Der Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Gib Tempo Motor
+                        Port</span></span>« liest das Tempo (Geschwindigkeit) eines Motors aus.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, dessen Tempo gelesen werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl; Geschwindigkeit , die am ausgewählten Motor Port eingestellt
+                    ist.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_setPower" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-»SetzeMotorPort...Tempo...«[Experten-Block]"><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">»Setze Motor Port ... <span
+                            style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Tempo ...</span></span>« <span
+                            class="typcn typcn-star"></span></span><br></span></h3>
+            <p>Der Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Setze Motor Port <span
+                            style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">...
+                                Tempo</span></span></span></span><span style="color: rgb(0,0,255);"><span
+                        style="color: rgb(0,0,0);"><span> </span><span> </span>« setzt </span></span>das Tempo
+                (Geschwindigkeit) eines Motors auf einen neuen Wert.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, für den dasTempo eingestellt
+                    werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
+                    sich der Motor rückwärts.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_stop" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-»StoppeMotorPort...«[Experten-Block]"><span style="color: rgb(0,0,255);"> <span
+                        style="color: rgb(0,0,0);">»Stoppe Motor Port ... « <span
+                            class="typcn typcn-star"></span></span><br></span></h3>
+            <p>Mit dem Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Stoppe Motor
+                        Port</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);"><span>
+                        </span>« schaltet den </span></span>Motor an einem ausgewählten Motor-Port aus. Du kannst
+                einstellen, ob der Motor langsam ausläuft oder gebremst wird.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motorport aus, der ausgeschaltet werden soll.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Option; »auslaufen<span style="color: rgb(0,0,255);"><span
+                            style="color: rgb(0,0,0);">«</span></span> sorgt dafür, dass der Motor langsam ausläuft;
+                    »bremsen<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">«</span></span> sorgt
+                    dafür, dass der Motor abrupt abgebremst wird.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_on" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»Fahre...Tempo...«">»Fahre ... Tempo ...«</h3>
+            <p>Mit dem Block »Fahre ... Tempo« kannst du die Richtung und das Tempo (Geschwindigkeit) deines Roboters
+                programmieren. Dein Roboter fährt so lange vorwärts oder rückwärts, bis er gestoppt wird oder ein
+                anderer Block zum Fahren verwendet wird.</p>
+            <p>»Fahre« steuert beide Motoren des Roboters gleichzeitig.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die gewünschte Fahrrichtung aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
+                    sich die Motoren rückwärts.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_on_for" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»Fahre...Tempo...Strecke...«">»Fahre ... Tempo ... Strecke ...«</h3>
+            <p>Mit dem Block »Fahre ... Tempo Strecke« kannst du zusätzlich zu Richtung und Tempo auch die Fahrstrecke
+                des Roboters programmieren. Dein Roboter fährt so lange, bis die eingestellte Strecke gefahren ist. Die
+                Geschwindigkeit kannst du im Feld Tempo einstellen. Wenn dieser Block »zu Ende« ist, stoppen die Motoren
+                automatisch.</p>
+            <p>»Fahre« steuert beide Motoren des Roboters gleichzeitig.</p>
+            <p>Wenn die eingestellten Werte der Aktionen mit der Programmausführung nicht übereinstimmen, prüfe die
+                Roboter-Konfiguration, insbesondere den Raddurchmesser.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die gewünschte Fahrtrichtung.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
+                    sich die Motoren rückwärts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Länge für die Strecke in cm.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_stop" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»Stoppe«">»Stoppe«</h3>
+            <p>Mit dem Block »Stoppe« werden die Motoren deines Roboters gestoppt. Das bedeutet, dein Roboter hält an.
+            </p>
+        </div>
+        <div id="robActions_motorDiff_turn" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»Drehe...Tempo...«">»Drehe ... Tempo ... «</h3>
+            <p>Mit dem Block »Drehe ... Tempo... « kannst du die Richtung (rechts/links), in der sich der Roboter drehen
+                soll, programmieren. Dein Roboter dreht sich so lange auf der Stelle, bis er gestoppt wird oder ein
+                anderer Block zum Fahren verwendet wird. Die Geschwindigkeit kannst Du im Feld »Tempo« einstellen.
+                »Drehe« steuert beide Motoren des Roboters gleichzeitig in entgegengesetzten Richtungen, dadurch dreht
+                sich der Roboter auf der Stelle.</p>
+            <p>Wenn die eingestellten Werte der Aktionen mit der Programmausführung nicht übereinstimmen, prüfe die
+                Roboter-Konfiguration, insbesondere den Raddurchmesser und die Spurbreite.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die gewünschte Drehrichtung aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
+                    sich die Motoren rückwärts.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <p>Falls sich dein Roboter in die falsche Richtung dreht, sind die Motoren an die falschen Ports
+                        angeschlossen. Es genügt dann, die Ports zu tauschen, damit der Roboter in die richtige Richtung
+                        dreht.</p>
+                </div>
+            </div>
+        </div>
+        <div id="robActions_motorDiff_turn_for" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»Drehe...Tempo...Grad...«">»Drehe ... Tempo ... Grad ...«</h3>
+            <p>Mit dem Block »Drehe ... Tempo ... Grad« kannst du die Richtung (rechts/links), in der sich der Roboter
+                um die eigene Achse drehen soll, programmieren. Zusätzlich zur Richtung kann noch im Feld »Grad«
+                angegeben werden, um wie viel Grad sich dein Roboter (um die eigene Achse) drehen soll. Dies bedeutet,
+                dass du beispielsweise mit der Einstellung 360 Grad deinen Roboter einmal um die eigene Achse drehen
+                lassen kannst. Der Block »Drehe ... Tempo ... Grad« steuert beide Motoren des Roboters, damit sich der
+                Roboter um die eigene Achse dreht.</p>
+            <p>Wenn die eingestellten Werte der Aktionen mit der Programmausführung nicht übereinstimmen, prüfe die
+                Roboter-Konfiguration, insbesondere den Raddurchmesser und die Spurbreite.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die gewünschte Drehrichtung aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
+                    sich die Motoren rückwärts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Gradzahl um die der Roboter sich drehen soll. Negative Zahlen
+                    sind nicht zugelassen.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_curve" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»Steure...Tempolinks...Temporechts...«">»Steure ... Tempo links ... Tempo
+                rechts ...«</h3>
+            <p>Mit dem Block »Steure ... Tempo links ... Tempo rechts ...« kannst du den Roboter so programmieren, dass
+                er eine Kurve fährt, indem du das Tempo für den linken und den rechten Motor auf unterschiedliche Werte
+                setzt. Die Roboterkonfiguration beeinflusst den Radius der Kurve in Abhängigkeit von Radabstand und
+                Raddurchmesser. Mit der Drehrichtung legst du die Fahrtrichtung fest.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Drehrichtung, wähle die gewünschte Drehrichtung aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den linken Motor. Wenn die Zahl
+                    negativ ist, dreht sich der Motor rückwärts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den link rechten Motor. Wenn die
+                    Zahl negativ ist, dreht sich der Motor rückwärts.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_curve_for" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»Steure...Tempolinks...Temporechts...Strecke...«">»Steure ... Tempo links ...
+                Tempo rechts ... Strecke ...«</h3>
+            <p>Mit dem Block »Steure ... Tempo links ... Tempo rechts ... Strecke ...« kannst du den Roboter so
+                programmieren, dass er eine vorgegebene Strecke als Kurve fährt, indem du das Tempo für den linken und
+                den rechten Motor auf unterschiedliche Werte setzt. Die Strecke bezieht sich auf die Mitte zwischen
+                beiden Rädern. Die Roboterkonfiguration beeinflusst den Radius der Kurve in Abhängigkeit von Radabstand
+                und Raddurchmesser. Mit der Richtung legst du die Fahrtrichtung fest.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Richtung, wähle die gewünschte Fahrtrichtung aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den linken Motor. Wenn die Zahl
+                    negativ ist, dreht sich der Motor rückwärts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den rechten Motor. Wenn die Zahl
+                    negativ ist, dreht sich der Motor rückwärts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Strecke in Zentimetern, die zurückgelegt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_display_text" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»ZeigeText«">»Zeige Text«</h3>
+            <p>Mit dem Block »Zeige Text« kannst du Text und Zahlen auf dem Display deines Roboters anzeigen lassen.
+                Dabei kannst du zusätzlich noch bestimmen, in welcher Spalte und in welcher Zeile der Text auf dem
+                NXT-Bildschirm erscheinen soll.</p>
+            <p>Das Display eines NXT ist für Texte in 8 Zeilen (Zeilennummern 1 bis 8) und 16 Spalten (Spaltennummern 0
+                bis 15) eingeteilt.</p>
+            <p>Wenn zuvor schon etwas auf dem Display angezeigt war, werden nur die Stellen überschrieben, in die der
+                Text geschrieben wird.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_display_clear" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»LöscheBildschirm«">»Lösche Bildschirm«</h3>
+            <p>Mit dem Block »Lösche Bildschirm« kannst du Text und Zahlen auf dem Display deines Roboters löschen. Das
+                Display ist anschließend leer.</p>
+        </div>
+        <div id="robActions_play_tone" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»SpieleFrequenz...Dauer...«">»Spiele Frequenz ... Dauer ...«</h3>
+            <p>Mit dem Block »Spiele Frequenz ... Dauer« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie
+                lange der Ton gespielt wird) programmieren. Der Ton wird über den eingebauten Lautsprecher deines LEGO
+                MINDSTORMS Steins abgespielt, bis die eingestellte Dauer erreicht ist.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Bitte beachte, dass das menschliche Gehör Frequenzen zwischen ca. 30 Hz bis ca. 15.000 Hz (15
+                        kHz) wahrnehmen kann - je nach Mensch und Alter kann dies unterschiedlich sein.</p>
+                </div>
+            </div>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, gewünschte Frequenz in Hz (Hertz) eingeben.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, gewünschte Dauer des Tons in Millisekunden (ms) eingeben.</li>
+            </ul><br>
+        </div>
+        <div id="mbedActions_play_note" class="help beginner">
+            <p><span style="color: rgb(85,85,85);font-size: 16.0px;font-weight: bold;letter-spacing: -0.006em;">»Spiele
+                    ... Note ... «</span></p>
+            <p>Mit diesem Block kann dein Roboter eine Note anspielen. Du kannst dabei sowohl die Note selbst, als auch
+                die Länge der Note wählen.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Dauer der Note aus,</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Note, die du abspielen möchtest.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_play_setVolume" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»SetzeLautstärke...«">»Setze Lautstärke ...«</h3>
+            <p>Mit dem Block »Setze Lautstärke« kannst du die Lautstärke eines Tons programmieren. Die Lautstärke kann
+                von 0 (kein Ton) bis 100 (volle Lautstärke) eingestellt werden. Die Lautstärke bleibt so lange
+                eingestellt, bis du sie mit einem anderen Block »Setze Lautstärke« neu programmierst.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl für die Lautstärke.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_play_getVolume" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-»GibLautstärke«[Experten-Block]">»Gib Lautstärke« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »Gib Lautstärke« kannst du die aktuell eingestellte Lautstärke auslesen. 0 = kein Ton, 100
+                = maximale Lautstärke.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, aktuell eingestellter Lautstärkewert.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_sensorLight_on" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-»SetzeFarbsensor«[Experten-Block]">»Setze Farbsensor« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »Setze Farbsensor« in der Kategorie »Statusleuchte« kannst du den Farbsensor in einer der
+                drei Farben rot, grün oder blau leuchten lassen.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Farbe, wähle eine Farbe aus.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle, ob das Licht an- oder ausgeschaltet sein soll..
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Port, an dem der Farbsensor angeschlossen
+                    ist.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_touch_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»Berührungssensor«">»Berührungssensor«</h3>
+            <p>Mit dem Block »Berührungssensor« kannst du einem anderen Block »mitteilen«, ob der Berührungssensor
+                gedrückt wurde oder nicht. Dieser Block gibt die logischen Werte <em>wahr = gedrückt</em> oder
+                <em>falsch = nicht gedrückt</em> zurück.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle den Sensorport aus, an dem dein Berührungssensor
+                    angeschlossen ist.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn der Berührungssensor gedrückt ist,
+                    sonst »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_sound_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»GibWertGeräuschsensor«">»Gib Wert Geräuschsensor«</h3>
+            <p>Mit dem Block »Gib Wert Geräuschsensor« kannst du einem anderen Block »mitteilen«, welche Lautstärke der
+                Geräuschsensor misst. Der Wert liegt zwischen 0 und 100.</p><br>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle den Sensorport aus, an dem dein Geräuschsensor
+                    angeschlossen ist.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Wert zwischen 0 und 100.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»Gib...LichtsensorPort...«">»Gib ... Lichtsensor Port ...«</h3>
+            <p>Mit dem Block »Gib Licht« kannst du einem anderen Block »mitteilen«, welchen Lichtwert der Lichtsensor
+                misst.</p>
+            <p>Im Modus »Licht« sendet der Lichtsensor eigenes Licht aus und misst das reflektierte Licht.</p>
+            <p>Im Modus »Umgebungslicht« misst der Lichtsensor die Helligkeit des Umgebunglichts. Die Werte liegen
+                zwischen 0 und 100.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle aus, was gemessen werden soll: (reflektiertes)
+                    Licht oder Umgebungslicht</li>
+                <li class="typcn typcn-arrow-sorted-down"> Port, wähle den Sensorport aus, an dem dein
+                    Lichtsensor/Farbsensor angeschlossen ist.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Lichtwert zwischen 0 und 100.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_colour_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»Gib...FarbsensorPort...«">»Gib ... Farbsensor Port ...«</h3>
+            <p>Mit dem Block »Gib Farbe« kannst du einem anderen Block »mitteilen«, welche Farbe der Farbsensor misst.
+                Die Farbe wird als Datentyp »Farbe« übermittelt. Zudem kann dieser Block im Auswahlmenü auf »Licht« und
+                »Umgebungslicht« gestellt werden. Diese zusätzlichen Typen übermitteln jeweils den Datentyp »Zahl«. Die
+                Zahlenwerte liegen je nach gewählter Messmethode zwischen 0 und 255. Mit diesen verschiedenen
+                Einstellung kann dieser Block je nach Anforderung eingestellt werden.</p>
+            <p>Im Modus »Farbe« sendet der Farbsensor Licht aus und erkennt, welche Grundfarbe unter dem Sensor erkannt
+                wurde. Die Grundfarbwerte sind BLACK, WHITE, RED, GREEN, BLUE, YELLOW.</p>
+            <p>Im Modus »Licht« sendet der Farbsensor mittels seiner roten LED Licht aus und misst die reflektierte
+                Lichtstärke auf einer Skala von 0 bis 100.</p>
+            <p>Im Modus »Umgebungslicht« wird dieselbe Skala (0-100) wie im Modus Licht verwendet. Dabei wird das ins
+                Sensorfenster einfallende Umgebungslicht gemessen.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle aus, was gemessen werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down"> Port, wähle den Sensorport aus, an dem dein
+                    Lichtsensor/Farbsensor angeschlossen ist.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Je nach gewählter Messmethode werden die zugehörigen Werte
+                    ausgegeben.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»GibAbstand«Ultraschallsensor">»Gib Abstand« Ultraschallsensor</h3>
+            <p>Mit dem Block »Gib Abstand« für den Ultraschallsensor kannst du einem anderen Block »mitteilen«, welchen
+                Abstand der Ultraschallsensor misst.</p>
+            <p>Im Modus »Abstand« wird der Abstand in Zentimetern gemessen. Der Maximalwert ist 255. Der Wert 255 kann
+                auch bedeuten, dass der Abstand größer als 255 cm ist.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle aus, an welchem Port der Infrarotsensor
+                    angeschlossen ist.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Abstand in Zentimetern; maximal 255.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_encoder_reset" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»SetzeDrehsensorzurück«">»Setze Drehsensor zurück«</h3>
+            <p>Mit dem Block »Setze Drehsensor zurück« kann der interne Sensor (Motor-Encoder) eines Motors auf den Wert
+                0 zurückgesetzt werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, wähle aus, an welchem Port der Drehsensor/Motor
+                    angeschlossen ist.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_encoder_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»GibUmdrehungen/Grad/Abstand«Drehsensor">»Gib Umdrehungen/Grad/Abstand«
+                Drehsensor</h3>
+            <p>Mit dem Block »Gib Umdrehungen/Grad/Abstand« kannst du einem anderen Block die Motorumdrehungen
+                »mitteilen«.</p>
+            <p>Wenn »Umdrehungen« eingestellt wurde, wird die Zahl der Umdrehungen ausgegeben.</p>
+            <p>Wenn »Grad« eingestellt wurde, wird die Gradzahl aller Umdrehungen ausgegeben, wobei eine volle Umdrehung
+                genau 360 Grad entspricht.</p>
+            <p>Wenn »Abstand« eingestellt wurde, wird berechnet, welche Strecke das Rad des Motors zurückgelegt hat. Das
+                ist natürlich abhängig davon, wie groß das Rad in der Roboterkonfiguration eingestellt ist.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Messmethode, stelle ein, wie gemessen werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, stelle ein, an welchem Port der Drehsensor bzw. Motor
+                    angeschlossen ist.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die je nach eingestellter Messmethode entweder die
+                    Umdrehungszahl, die Gradzahl oder die zurückgelegte Strecke darstellt.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»Taste«NXT-Tasten">»Taste« NXT-Tasten</h3>
+            <p>Mit dem Block »Taste« kannst du einem anderen Block "mitteilen" , ob die ausgewählte Taste gedrückt wurde
+                oder nicht. Dieser Block gibt die logischen Werte <em>true = gedrückt</em> oder <em>false = nicht
+                    gedrückt</em> zurück. Auswahl aus »Mitte« / »Rechts« / »Links«.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Taste, die du überprüfen möchtest.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »true«, wenn die gewählte Taste gedrückt ist, sonst
+                    »false«.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»GibWert«Zeitgeber">»Gib Wert« Zeitgeber</h3>
+            <p>Mit dem Block »Gib Wert« kannst du einem anderen Block den aktuellen Stand des internen Zeitgebers in
+                Millisekunden "mitteilen". Der Zeitgeber wird automatisch mit dem Beginn eines Programms gestartet. Es
+                steht 1 Zeitgeber zur Verfügung.</p>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl Millisekunden, die seit dem Programmstart oder dem
+                    letzten Zurücksetzen des Zeitgebers vergangen sind.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»SetzeZeitgeber«">»Setze Zeitgeber«</h3>
+            <p>Mit dem Block »Setze Zeitgeber« kann der interne Zeitgeber auf den Wert 0 zurückgesetzt werden.</p>
+        </div>
+        <div id="robSensors_htcolour_getSample" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeNXT-»Gib...HTFarbsensorPort...«[Expert-Block]">»Gib ...
+                HT Farbsensor Port ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du den HT Farbsensor deines Roboters abfragen. Dieser Sensor kann die Farbe des
+                Untergrunds, die Helligkeit des Lichts und der Umgebung und die Aufteilung der gemessenen Farbe in die
+                Grundfarben Rot,Grün und Blau messen. Der Rückgabewert dieses Blocks hängt von der gemessenen
+                Eigenschaft ab.</p>
+            <p>Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle welche Eigenschaft gemessen werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle an welchem Port der Sensor angeschlossen ist.
+                </li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die Farbe des Untergrunds.</li>
+                <li class="typcn typcn-arrow-right">Zahl, Helligkeit des Lichts oder der Umgebung in Prozent. Zahl
+                    zwischen 0 und 100.</li>
+                <li class="typcn typcn-arrow-right">Liste, Aufspaltung der gemessenen Farbe in Rot, Grün und Blau.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wennmachesonst«">»Wenn mache sonst«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«
+            </h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wiederholenmal«">»Wiederhole n mal«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole
+                solange/bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»FürWertausderListe«[Experten-Block]">»Für Wert aus
+                der Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="ProgrammierBlöckeNXT-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeNXT-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wartems...«">»Warte ms ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wartebis...«.1">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»MathematischeFunktionen«[Experten-Block]">
+                »Mathematische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»TrigonometrischeFunktionen«[Experten-Block]">
+                »Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Konstanten«[Experten-Block]">»Konstanten« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Zahleneigenschaft«[Experten-Block]">
+                »Zahleneigenschaft« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»runden«[Experten-Block]">»runden« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Listeauswerten«[Experten-Block]">»Liste auswerten«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Restvon«[Experten-Block]">»Rest von« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Begrenze«[Experten-Block]">»Begrenze« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»GanzzahligeZufallswerte«[Experten-Block]">
+                »Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Zufallszahl«">»Zufallszahl« </h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeNXT-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette«
+                <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeNXT-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»ErstelleText«[Experten-Block]">»Erstelle Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeNXT-»Textanhängen«[Experten-Block]">»Text anhängen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeNXT-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeNXT-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an
+                Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeNXT-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeNXT-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeNXT-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeNXT-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeNXT-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeNXT-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeNXT-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammierBlöckeNXT-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammierBlöckeNXT-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammierBlöckeNXT-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammierBlöckeNXT-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeNXT-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün
+                ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeNXT-»FarbemitRot...Grün...Blau...«[Experten-Block]">
+                »Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeNXT-»FarbemitRot...Grün...Blau...«[Experten-Block].1">
+                »Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammierBlöckeNXT-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb
+                einer Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="ProgrammierBlöckeNXT-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="ProgrammierBlöckeNXT-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne
+                Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeNXT-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf
+                mit Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_connection" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-Verbindungsblock[Experten-Block]">Verbindungsblock <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Verbindungsaufbau wird von einem NXT-Roboter initiiert, wie z.B. ein Telefonanruf von einem Anrufer.
+                Im Display des NXT ist jeweils an der Kommunikationsnummer erkennbar, über welche Verbindung die
+                Kommunikation läuft.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Verbindungsname, wähle einen der 4 angebotenen Namen aus.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Verbindungsobjekt.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_sendBlock" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-SendeNachrichtüberVerbindung[Experten-Block]">Sende Nachricht über Verbindung
+                <span class="typcn typcn-star"></span></h3>
+            <p>Eine Nachricht wird an den ausgewählten Roboter übermittelt. Die Nachricht wird über einen Block
+                eingegeben, der dem Nachrichtentyp entspricht (Zahl, logischer Wert oder Zeichenkette).</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Nachrichtentyp, »Zahl«, »logischer Wert« oder »Zeichenkette«.
+                </li>
+                <li class="typcn typcn-arrow-left">Nachricht, die übermittelt werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Verbindungsmedium, »Bluetooth«.</li>
+                <li class="typcn typcn-arrow-sorted-down">Kanal, über den die Kommunikation laufen soll.</li>
+                <li class="typcn typcn-arrow-left">Verbindung, über die die Kommunikation erfolgt.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_receiveBlock" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-EmpfangeNachrichtüberVerbindung[Experten-Block]">Empfange Nachricht über
+                Verbindung <span class="typcn typcn-star"></span></h3>
+            <p>Eine Nachricht wird über eine Verbindung übermittelt. Die Nachricht wird an einen Block übergeben, z.B.
+                an eine Variable.</p>
+            <p>Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Nachrichtentyp, »Zahl«, »logischer Wert« oder »Zeichenkette«.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Verbindungsmedium, »Bluetooth«.</li>
+                <li class="typcn typcn-arrow-sorted-down">Kanal, über den die Kommunikation laufen soll.</li>
+                <li class="typcn typcn-arrow-left">Verbindung, über die die Kommunikation erfolgt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Nachricht, Inhalt der empfangenen Nachricht.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_checkConnection" class="help expert">
+            <h3 id="ProgrammierBlöckeNXT-»connectiontorobot«-PrüfeVerbindung[Experten-Block]">»connection to robot« -
+                Prüfe Verbindung <span class="typcn typcn-star"></span></h3>
+            <p>Die Verbindung zwischen zwei NXT-Robotern erfolgt über eine Verbingungsnummer. Der Block »connection to
+                robot« prüft, ob eine Verbindung »steht«.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Verbindung, über die die Kommunikation erfolgt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »true« wenn eine Verbindung besteht, »false« sonst.
+                </li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_nxt_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nxt_en.html
@@ -1,424 +1,1622 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="ProgrammingBlocksNXT-»Programstart«"><span style="color: rgb(0,0,0);">»Program start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Each program starts with the red »Program start« block.</p><p>This block is always available in the Open Roberta Lab and cannot be deleted. The little triangle below the start block is called  »sequence connector«. The first block you want to use will be connected by using the »sequence connector« at the start block.  The sequence connector color changes to yellow when a suitable block comes into its range.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">create a new global variable</li><li class="typcn typcn-minus">delete the global variable</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable</li><li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«, »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li><li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial value of the variable.</li>
-</ul><br></div><div id="robActions_motor_on" class="help expert"><h3 id="ProgrammingBlocksNXT-»motorport...onspeed...«[Expertblock]"><span style="color: rgb(0,0,0);">»motor port ... on speed ...</span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span></h3><p>With the »motor port ... on« block you can program the speed (velocity) of the selected motor. Your robot starts the selected motor, until it is stopped or another block specifies new moving parameters.</p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">motor port, choose the port where the motor is connected to.</li><li class="typcn typcn-arrow-left">value, speed between -100 to 100. Negative values let the motor turn backwards.</li>
-</ul><br></div><div id="robActions_motor_on_for" class="help expert"><h3 id="ProgrammingBlocksNXT-»motorport...onspeed...for...«[Expertblock]"><span style="color: rgb(0,0,0);">»motor port ... on speed ... for ...</span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span></h3><p>With the »motor port ... rotation« block you can program the speed (velocity) of the selected motor. Your robot starts the selected motor and rotates the motor until the specified number of rotations or degrees is done. </p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">motor port, choose the one where the motor that you want to program is connected to.</li><li class="typcn typcn-arrow-left">number, spped between -100 and 100. 100 is the maximum speed. Negative values lets the motor rotate into the other direction.</li><li class="typcn typcn-arrow-sorted-down">rotation or degree. Choose the one which fits best. 1 rotation is the same than 360 degrees.</li><li class="typcn typcn-arrow-left">number, rotations or degrees, only positive numbers are allowed.</li>
-</ul><br></div><div id="robActions_motor_getPower" class="help expert"><h3 id="ProgrammingBlocksNXT-»getspeedmotorport...«[Expertblock]"><span style="color: rgb(0,0,0);">»get speed motor port ... </span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span></h3><p>The block »<span style="color: rgb(0,0,0);">get speed motor port</span><span style="color: rgb(0,0,0);"> </span>« reads the speed (velocity) of the selected motor. The motor can have a speed from -100 (rotating backwards) to 100.</p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">motor port, choose the port where the motor is connected to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">number, the current speed of the motor.</li>
-</ul><br></div><div id="robActions_motor_setPower" class="help expert"><h3 id="ProgrammingBlocksNXT-»setmotorport...speed...«[Expertblock]"><span style="color: rgb(0,0,0);">»set motor port ... <span>speed ... </span></span><span style="color: rgb(0,0,0);">«  <span class="typcn typcn-star"></span></span></h3><p>The block »s<span style="color: rgb(0,0,0);">et motor port ... </span><span style="color: rgb(0,0,0);">speed</span>« sets the speed (velocity) of one selected motor to a new value. </p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">motor port, choose the port where the motor is connected to.</li><li class="typcn typcn-arrow-left">number, speed between -100 and 100. Negative values let the motor run backwards.</li>
-</ul><br></div><div id="robActions_motor_stop" class="help expert"><h3 id="ProgrammingBlocksNXT-»stopmotorport...«[Expertblock]"><span style="color: rgb(0,0,0);">»stop motor port ... </span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span></h3><p>Using the block »s<span>top motor port</span><span> </span>« switches off one selected motor. You can decide the motor to run out slowly (float) or to break immediately</p><p>Setting options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">motor port, <span>choose the port where the motor is connected to.</span></li><li class="typcn typcn-arrow-sorted-down">float or brake; make your choice.</li>
-</ul><br></div><div id="robActions_motorDiff_on" class="help beginner"><h3 id="ProgrammingBlocksNXT-»drive...speed...«">»drive... speed ... «</h3><p>With the »drive« block you can program the direction and also the speed (velocity) of your robot. <span>Your robot moves  until it is stopped or another block specifies new driving parameters. The driving speed can be set in the field  »speed«.</span></p><p>Options and Arguments:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">direction, forwards or backwards. Choose the direction.</li><li class="typcn typcn-arrow-left"><span>number, speed between -100 to 100. 100 is the maximum speed. Negative values lets the motor rotate into the other direction.</span></li>
-</ul><br></div><div id="robActions_motorDiff_on_for" class="help beginner"><h3 id="ProgrammingBlocksNXT-»drive...speed...distance...«">»drive ... speed ... distance ... «</h3><p>With the »drive distance« block you can program the direction and the speed of the robot. The speed of your robot is set in the »speed« parameter. Once the block has been executed the motors stop automatically.</p><p>»drive distance« controls both motors of the robot at the same time, meaning that the settings you make here apply to both motors of the robot. If the robot's actions don't correspond with the block's settings when running the program, check the robot configuration settings, especially the wheel diameter and the track width.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Drive, »forwards« or »backwards«. Select a direction.</li><li class="typcn typcn-arrow-left">Number, speed between  -100 and 100. If the number is negative, the motors will rotate backwards.</li><li class="typcn typcn-arrow-left">Number, the distance to drive in cm.</li>
-</ul><br></div><div id="robActions_motorDiff_stop" class="help beginner"><h3 id="ProgrammingBlocksNXT-»stop«">»stop«</h3><p>The »stop« block stops the motors immediately.</p></div><div id="robActions_motorDiff_turn" class="help beginner"><h3 id="ProgrammingBlocksNXT-»turn...speed...«">»turn ... speed ... «</h3><p>With the »turn« block you set the direction (right/left) which the robot will turn. Your robot turns until it is stopped or another block is used for driving. You can set the speed in the block parameter field »speed«.</p><p>»turn« controls both motors of the robot at the same time, therefore the robot turns on the spot. If the NXT Robot's actions don't correspond with the block's settings when running the program, check the NXT robot configuration settings, especially the wheel diameter and the track width.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Turn, »right« or »left«. Select the desired direction for turning.</li><li class="typcn typcn-arrow-left">Number, speed between  -100 and 100. If the number is negative, the motors will rotate backwards.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><p>If your robot turns into the wrong direction, then the motors are connected to the wrong ports. Just swap the ports and your robot will turn into the right way.</p></div></div></div><div id="robActions_motorDiff_turn_for" class="help beginner"><h3 id="ProgrammingBlocksNXT-»turn...speed...degree...«">»turn ... speed ... degree ...«</h3><p>With the »turn degree« block you program the direction (right/left) that your robot will turn. In addition to the direction you can also program the »degrees«, allowing you to program how many degrees your robot should rotate (around its axis). This means that you do a complete rotation by setting a 360 degree turn..</p><p>The »turn degree« block controls both motors of the robot in such a way that the robot turns around its own axis. If the robot's actions don't correspond with the block's settings when running the program, check the NXT robot configuration settings, especially the wheel diameter and the track width.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Turn, »right« or »left«. Select the desired direction for turning.</li><li class="typcn typcn-arrow-left">Number, speed between  -100 and 100. If the number is negative, the motors will rotate backwards.</li><li class="typcn typcn-arrow-left">Number, degrees the robot shall turn. Degree of 360 will perform a full turn around. Negative numbers are not allowed.</li>
-</ul><br></div><div id="robActions_motorDiff_curve" class="help beginner"><h3 style="text-align: left;" id="ProgrammingBlocksNXT-»steer...speedleft...speedright...«">»steer ... speed left ... speed right ...«</h3><p style="text-align: left;">The block »steer ... speed left ... speed right ...« programs the robot to drive a curve by setting different speeds for the left and right motor. The robot configuration influences the radius of the curve depending from wheel distance and wheel diameter. The turning direction will define the driving direction.</p><p style="text-align: left;">Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Turning direction, »forwards« or »backwards«. Select your desired moving direction.</li><li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number is negative the motor will run backwards.</li><li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number is negative the motor will run backwards.</li>
-</ul></div><div id="robActions_motorDiff_curve_for" class="help beginner"><h3 style="text-align: left;" id="ProgrammingBlocksNXT-»steer...speedleft...speedright...distance...«">»steer ... speed left ... speed right ... distance ...«</h3><p style="text-align: left;">The block »steer ... speed left ... speed right ... distance ...« programs the robot to drive a curve by setting different speeds for the left and right motor and also a distance related to the middle between both wheels. The robot configuration influences the radius of the curve depending from wheel distance and wheel diameter. The turning direction will define the driving direction.</p><p style="text-align: left;">Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Turning direction, »forwards« or »backwards«. Select your desired moving direction.</li><li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number is negative the motor will run backwards.</li><li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number is negative the motor will run backwards.</li><li class="typcn typcn-arrow-left">Number, the distance in cm to be driven.</li>
-</ul></div><div id="robActions_display_text" class="help beginner"><h3 id="ProgrammingBlocksNXT-»showtext«">»show text«</h3><p>With the »show text« block you can display text and numbers on the display of your robot. You can also specify in which column and row the text or numbers should be desplayed on the robot screen.</p><p>The NXT display contains 8 rows with row numbers from 1 to 8, and 16 columns with column numbers from 0 to 15.</p><p>If there was text on the display prior to the show text block then the former text will be overwritten.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, input of a text string to be shown in the display.</li><li class="typcn typcn-arrow-left">Number, column for the text to start.</li><li class="typcn typcn-arrow-left">Number, line for the text to start.</li>
-</ul><br></div><div id="robActions_display_clear" class="help beginner"><h3 id="ProgrammingBlocksNXT-»cleardisplay«">»clear display«</h3><p>With the »clear display« block you can delete text and numbers on the display of your robot, therefore nothing appears on your display.</p></div><div id="robActions_play_tone" class="help beginner"><h3 id="ProgrammingBlocksNXT-»playfrequency«">»play frequency«</h3><p>With the »play frequency« block you can program the frequency (pitch level) and the time (how long the sound should be played) that a sound is played. The sound is played by the built-in speaker of your LEGO MINDSTORMS NXT brick for a defined of time. The frequency setting corresponds directly to the frequency in Hertz, for example, setting the frequency to 400 corresponds to 400 Hertz. Example: 261 = C.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p><span>Note that the human ear can perceive frequencies from about 30Hz to about 15,000Hz (15kHz). This can vary depending on the person and their age.</span></p></div></div><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, desired frequency in Hz (Hertz) .</li><li class="typcn typcn-arrow-left">Number, desired duration in milliseconds (ms).</li>
-</ul><br></div><div id="mbedActions_play_note" class="help beginner"><h3 id="ProgrammingBlocksNXT-»Playnote...«">»Play note ... «</h3><p>With this block your robot can play a note. You can choose the note itself as well as the duration of the note.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option,  choose the duration of the note.</li><li class="typcn typcn-arrow-sorted-down">Option, choose which note you want to play.</li>
-</ul><br></div><div id="robActions_play_setVolume" class="help beginner"><h3 id="ProgrammingBlocksNXT-»setvolume«">»set volume«</h3><p>With the »set volume« block you can program the sound volume played. The volume ranges from 0 (no sound) to 100 (full volume). The volume setting remains unchanged until you change it with another »set volume« block.</p><p>Setting:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, volume for loudness. 0 = no tone, 100 = maximum volume.</li>
-</ul><br></div><div id="robActions_play_getVolume" class="help expert"><h3 id="ProgrammingBlocksNXT-»getvolume«[Expertblock]">»get volume« <span class="typcn typcn-star"></span></h3><p>With the »get volume« block you can read the currend sound volume level.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, currently adjusted volume. 0 = no tone, 100 = maximum volume</li>
-</ul><br></div><div id="robActions_sensorLight_on" class="help expert"><h3 id="ProgrammingBlocksNXT-»setcoloursensor«[Expertblock]">»set colour sensor« <span class="typcn typcn-star"></span></h3><p>With the »set colour sensor« from the category »status light« you can program the colour sensor light with one of the colours red, green, or blue.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Colour, select a colour.</li><li class="typcn typcn-arrow-sorted-down">Switch, choose the light to be on or off.</li><li class="typcn typcn-arrow-sorted-down">Port, choose the port where the light sensor is connected.</li>
-</ul><br></div><div id="robSensors_touch_getSample" class="help beginner"> <h3 id="ProgrammingBlocksNXT-»touchsensorport...pressed?«">»touch sensor port ... pressed?«</h3><p>With the block »touch sensor« you can "tell" another block whether the touch sensor is pressed or not. This block returns the logical values <em>true = pressed</em> or <em>false = not pressed</em>. This block can only be used in conjunction with another block which requires a logical value as an input parameter, for example together with the »if then« block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your touch sensor is connected.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value: »true«, if the touch sensor is pressed, otherwise »false«.</li>
-</ul><br> </div><div id="robSensors_sound_getSample" class="help beginner"> <h3 id="ProgrammingBlocksNXT-»getvaluesoundsensor«">»get value sound sensor«</h3><p>With the block »get value sound sensor« you "tell" another block the current loudness measures by the sensor. The value is between 0 and 100. </p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, choose the port where the sound sensor is connected.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, some value between 0 and 100.</li>
-</ul><br> </div><div id="robSensors_light_getSample" class="help beginner"> <h3 id="ProgrammingBlocksNXT-»getlight«">»get light«</h3><p>Using the block »get light« you can tell another block a light value measured by the light sensor.</p><p>In mode »light« the light sensor emits some light and measures the reflected light.</p><p>In mode »ambient light« the light sensor measures the ambient light.</p><p>Light values are between 0 and 100.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode, choose how to measure - (reflected) light intensity or ambient light.</li><li class="typcn typcn-arrow-sorted-down"> Port, choose the port number where the light sensor is connected.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, light value between 0 and 100.</li>
-</ul><br> </div><div id="robSensors_colour_getSample" class="help beginner"> <h3 id="ProgrammingBlocksNXT-»getcolour«coloursensor">»get colour« colour sensor</h3><p>With the block »get colour« you can "tell" another block which color the colour sensor measures. The color is transmitted as type »colour« . In addition, this block provides within the drop down menu the settings »light« and »ambient light«. These additional settings transmit all the same type »number«. The numerical values are between 0 (black) to 100(white). With these various settings this block can be configured according to the specific requirements.</p><p>In mode »colour« the light sensor emits light and detects the basic colour under the sensor. Values for basic colours are BLACK, WHITE, RED, GREEN, BLUE, YELLOW.</p><p>In mode »light« the light sensor emits light with its red LED and measures the light intensity of the reflected light on a scale of 0 to 100.</p><p>In mode »ambient light« the same scale (0-100) as in the mode light is used. Here, the ambient light incidenting the sensor is measured.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode, select the mode of measurement.</li><li class="typcn typcn-arrow-sorted-down"> Port, select the sensor port where your colour sensor is connected.</li>
-</ul> <p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, depending on the selected mode of measurement.</li>
-</ul><br> </div><div id="robSensors_ultrasonic_getSample" class="help beginner"> <h3 id="ProgrammingBlocksNXT-»getdistanceultrasonicsensorport...«">»get distance ultrasonic sensor port ... «</h3><p>With the block »get distance« using the ultrasonic sensor you can "tell" another block which distance the sensor measures.</p><p>Working in the "distance" mode the distance in centimeters is given with values between 0 and 255. The maximum value is 255. This value also may indicate that the distance is more than 255 cm.</p><p>Settins:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, select the sensor port number where your ultrasonic sensor is connected.</li>
-</ul> <p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>»Distance« mode: number indicating the distance in cm, maximalum distance is 70 cm.</p><p>»Presence« mode: list of numbers.</p></li>
-</ul><br> </div><div id="robSensors_encoder_reset" class="help beginner"> <h3 id="ProgrammingBlocksNXT-»resetencoder«">»reset encoder«</h3><p>With the block »reset encoder« the internal sensor (motor encoder) of a motor can be reset to 0 .</p><p>Setting:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your motor is connected.</li>
-</ul>     </div><div id="robSensors_encoder_getSample" class="help beginner"> <h3 id="ProgrammingBlocksNXT-»getrotation/degree«rotationsensor">»get rotation/degree« rotation sensor</h3><p>With the block »get rotation/degree« you can "tell" another block the rotation of the motor. The distance is transmitted as a number (in cm). In addition, this block can be set to »degree« in the drop down menu. With this setting the number of degrees is transmitted instead of cm. This block can only be used in conjunction with another block, which requires a number as an input parameter.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Measurement mode, »rotation«, »degree« or»distance«. Select your mode of measurement.</li><li class="typcn typcn-arrow-sorted-down">Encoder port, select the sensor port where your motor/encoder is connected.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, that indicates according to the measurement mode the number of rotations, the degrees, or the distance in cm.</li>
-</ul><br> </div><div id="robSensors_key_getSample" class="help beginner">  <h3 id="ProgrammingBlocksNXT-»button...pressed?«">»button ... pressed? «</h3><p>With the »button« block you can "tell" another block whether the selected button is pressed or not. Available buttons are »enter« / »left« / »right«. This block returns logical values <em>true = pressed or false = not pressed</em>.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select the button you want to check.</li>
-</ul><br><p>Return value
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true«, if the selected button has been pressed, »false« otherwise.</li>
-</ul><br> </div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="ProgrammingBlocksNXT-»getvalue«timer">»get value« timer</h3><p>With the block »get value« you can "tell" another block the current time in milliseconds of the internal timer. The internal timer is automatically started at program start and can be reset with the »reset timer « block.</p><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, milliseconds since program start or since the last reset of the selected timer.</li>
-</ul><br> </div><div id="robSensors_timer_reset" class="help beginner"><h3 id="ProgrammingBlocksNXT-»resettimer«">»reset timer«</h3><p>With the block »reset timer« the internal timer can be reset to the value 0.</p> </div><div id="robSensors_htcolour_getSample" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingBlocksNXT-»get...HTcoloursensorport...«[Expertblock]">»get ... HT colour sensor port ... « <span class="typcn typcn-star"></span></h3><p>With this block you can query the HT colour sensor of your robot. This sensor can measure the color of the background, the brightness of the light and the environment and the distribution of the measured color into the primary colors red, green and blue. The return value of this block depends on the measured property.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the characteristic that you want to measure.</li><li class="typcn typcn-arrow-sorted-down">Option, choose the port of the sensor.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Colour, the colour of the ground.</li><li class="typcn typcn-arrow-right">Number, brightness of the light or the surroundings.</li><li class="typcn typcn-arrow-right">List of Numbers, distribution of the measured colour into Red, Green and Blue.</li>
-</ul><br></div><div id="robControls_if" class="help beginner"><h3 id="ProgrammingBlocksNXT-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="ProgrammingBlocksNXT-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="ProgrammingBlocksNXT-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="ProgrammingBlocksNXT-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="ProgrammingBlocksNXT-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="ProgrammingBlocksNXT-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="ProgrammingBlocksNXT-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="ProgrammingBlocksNXT-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="ProgrammingBlocksNXT-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="ProgrammingBlocksNXT-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="ProgrammingBlocksNXT-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="ProgrammingBlocksNXT-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="ProgrammingBlocksNXT-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="ProgrammingBlocksNXT-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="ProgrammingBlocksNXT-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="ProgrammingBlocksNXT-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="ProgrammingBlocksNXT-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="ProgrammingBlocksNXT-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="ProgrammingBlocksNXT-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="ProgrammingBlocksNXT-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="ProgrammingBlocksNXT-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="ProgrammingBlocksNXT-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="ProgrammingBlocksNXT-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="ProgrammingBlocksNXT-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="ProgrammingBlocksNXT-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksNXT-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="ProgrammingBlocksNXT-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="ProgrammingBlocksNXT-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="ProgrammingBlocksNXT-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="ProgrammingBlocksNXT-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksNXT-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksNXT-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="ProgrammingBlocksNXT-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammingBlocksNXT-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="ProgrammingBlocksNXT-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksNXT-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksNXT-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingBlocksNXT-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksNXT-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksNXT-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksNXT-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksNXT-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksNXT-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksNXT-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksNXT-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="ProgrammingBlocksNXT-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingBlocksNXT-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammingBlocksNXT-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammingBlocksNXT-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingBlocksNXT-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="ProgrammingBlocksNXT-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="ProgrammingBlocksNXT-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammingBlocksNXT-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="ProgrammingBlocksNXT-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammingBlocksNXT-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammingBlocksNXT-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammingBlocksNXT-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="ProgrammingBlocksNXT-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="ProgrammingBlocksNXT-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammingBlocksNXT-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingBlocksNXT-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div><div id="robCommunication_connection" class="help expert"><h3 style="color: rgb(51,153,102);" id="ProgrammingBlocksNXT-Connectionblock[Expertblock]"><span style="color: rgb(0,0,0);">Connection block</span> <span class="typcn typcn-star"></span></h3><p>A message interchange connection is initiated by one NXT robot, like a telephone call that is initiated by the caller. You need to know the name of the communication partner. In the NXT monitor the connection number is shown which is used for the communication.</p><p>Setting:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Connection name, choose one of the 4 available names.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Connection object.</li>
-</ul><br></div><div id="robCommunication_sendBlock" class="help expert"><h3 id="ProgrammingBlocksNXT-Sendamessageviaconnection[Expertblock]">Send a message via connection <span class="typcn typcn-star"></span></h3><p>A message will be transferred to a selected robot. The message will be entered from a suitable block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Message data type, »Number«, »Boolean«, or »String«.</li><li class="typcn typcn-arrow-left">Message, message to be sent.</li><li class="typcn typcn-arrow-sorted-down">Connection type, »Bluetooth«.</li><li class="typcn typcn-arrow-sorted-down">Channel, select a communication channel.</li><li class="typcn typcn-arrow-left">Connection, select a communication name.</li>
-</ul><br></div><div id="robCommunication_receiveBlock" class="help expert"><h3 id="ProgrammingBlocksNXT-Datareceivedviaconnection[Expertblock]">Data received via connection <span class="typcn typcn-star"></span></h3><p>A text message will be transferred using a global connection variable. The text message will be transferred into a text block. To give the connection information to the EV3 robot the value of the global connection variable will be read.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Message data type, »String«.</li><li class="typcn typcn-arrow-sorted-down">Connection type, »Bluetooth«.</li><li class="typcn typcn-arrow-left">Connection variable, established for the connection.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, content of the received message.</li>
-</ul><br></div><div id="robCommunication_checkConnection" class="help expert"><h3 id="ProgrammingBlocksNXT-Checkconnection[Expertblock]">Check connection <span class="typcn typcn-star"></span></h3><p>A communication connection between two NXT robots is managed using a connection number. The block »connection to robot« checks whether the connection is established.</p><p>Setting:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Communication connection, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, true, if the connection is established, otherwise false.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»Programstart«"><span style="color: rgb(0,0,0);">»Program start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Each program starts with the red »Program start« block.</p>
+            <p>This block is always available in the Open Roberta Lab and cannot be deleted. The little triangle below
+                the start block is called »sequence connector«. The first block you want to use will be connected by
+                using the »sequence connector« at the start block. The sequence connector color changes to yellow when a
+                suitable block comes into its range.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">create a new global variable</li>
+                <li class="typcn typcn-minus">delete the global variable</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«,
+                    »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li>
+                <li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial
+                    value of the variable.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»motorport...onspeed...«[Expertblock]"><span style="color: rgb(0,0,0);">»motor
+                    port ... on speed ...</span><span style="color: rgb(0,0,0);">« <span
+                        class="typcn typcn-star"></span></span></h3>
+            <p>With the »motor port ... on« block you can program the speed (velocity) of the selected motor. Your robot
+                starts the selected motor, until it is stopped or another block specifies new moving parameters.</p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">motor port, choose the port where the motor is connected to.
+                </li>
+                <li class="typcn typcn-arrow-left">value, speed between -100 to 100. Negative values let the motor turn
+                    backwards.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_on_for" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»motorport...onspeed...for...«[Expertblock]"><span
+                    style="color: rgb(0,0,0);">»motor port ... on speed ... for ...</span><span
+                    style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span></h3>
+            <p>With the »motor port ... rotation« block you can program the speed (velocity) of the selected motor. Your
+                robot starts the selected motor and rotates the motor until the specified number of rotations or degrees
+                is done. </p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">motor port, choose the one where the motor that you want to
+                    program is connected to.</li>
+                <li class="typcn typcn-arrow-left">number, spped between -100 and 100. 100 is the maximum speed.
+                    Negative values lets the motor rotate into the other direction.</li>
+                <li class="typcn typcn-arrow-sorted-down">rotation or degree. Choose the one which fits best. 1 rotation
+                    is the same than 360 degrees.</li>
+                <li class="typcn typcn-arrow-left">number, rotations or degrees, only positive numbers are allowed.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_getPower" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»getspeedmotorport...«[Expertblock]"><span style="color: rgb(0,0,0);">»get
+                    speed motor port ... </span><span style="color: rgb(0,0,0);">« <span
+                        class="typcn typcn-star"></span></span></h3>
+            <p>The block »<span style="color: rgb(0,0,0);">get speed motor port</span><span style="color: rgb(0,0,0);">
+                </span>« reads the speed (velocity) of the selected motor. The motor can have a speed from -100
+                (rotating backwards) to 100.</p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">motor port, choose the port where the motor is connected to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">number, the current speed of the motor.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_setPower" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»setmotorport...speed...«[Expertblock]"><span style="color: rgb(0,0,0);">»set
+                    motor port ... <span>speed ... </span></span><span style="color: rgb(0,0,0);">« <span
+                        class="typcn typcn-star"></span></span></h3>
+            <p>The block »s<span style="color: rgb(0,0,0);">et motor port ... </span><span
+                    style="color: rgb(0,0,0);">speed</span>« sets the speed (velocity) of one selected motor to a new
+                value. </p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">motor port, choose the port where the motor is connected to.
+                </li>
+                <li class="typcn typcn-arrow-left">number, speed between -100 and 100. Negative values let the motor run
+                    backwards.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motor_stop" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»stopmotorport...«[Expertblock]"><span style="color: rgb(0,0,0);">»stop motor
+                    port ... </span><span style="color: rgb(0,0,0);">« <span class="typcn typcn-star"></span></span>
+            </h3>
+            <p>Using the block »s<span>top motor port</span><span> </span>« switches off one selected motor. You can
+                decide the motor to run out slowly (float) or to break immediately</p>
+            <p>Setting options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">motor port, <span>choose the port where the motor is connected
+                        to.</span></li>
+                <li class="typcn typcn-arrow-sorted-down">float or brake; make your choice.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_on" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»drive...speed...«">»drive... speed ... «</h3>
+            <p>With the »drive« block you can program the direction and also the speed (velocity) of your robot.
+                <span>Your robot moves until it is stopped or another block specifies new driving parameters. The
+                    driving speed can be set in the field »speed«.</span></p>
+            <p>Options and Arguments:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">direction, forwards or backwards. Choose the direction.</li>
+                <li class="typcn typcn-arrow-left"><span>number, speed between -100 to 100. 100 is the maximum speed.
+                        Negative values lets the motor rotate into the other direction.</span></li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_on_for" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»drive...speed...distance...«">»drive ... speed ... distance ... «</h3>
+            <p>With the »drive distance« block you can program the direction and the speed of the robot. The speed of
+                your robot is set in the »speed« parameter. Once the block has been executed the motors stop
+                automatically.</p>
+            <p>»drive distance« controls both motors of the robot at the same time, meaning that the settings you make
+                here apply to both motors of the robot. If the robot's actions don't correspond with the block's
+                settings when running the program, check the robot configuration settings, especially the wheel diameter
+                and the track width.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Drive, »forwards« or »backwards«. Select a direction.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100. If the number is negative, the
+                    motors will rotate backwards.</li>
+                <li class="typcn typcn-arrow-left">Number, the distance to drive in cm.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_stop" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»stop«">»stop«</h3>
+            <p>The »stop« block stops the motors immediately.</p>
+        </div>
+        <div id="robActions_motorDiff_turn" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»turn...speed...«">»turn ... speed ... «</h3>
+            <p>With the »turn« block you set the direction (right/left) which the robot will turn. Your robot turns
+                until it is stopped or another block is used for driving. You can set the speed in the block parameter
+                field »speed«.</p>
+            <p>»turn« controls both motors of the robot at the same time, therefore the robot turns on the spot. If the
+                NXT Robot's actions don't correspond with the block's settings when running the program, check the NXT
+                robot configuration settings, especially the wheel diameter and the track width.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Turn, »right« or »left«. Select the desired direction for
+                    turning.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100. If the number is negative, the
+                    motors will rotate backwards.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <p>If your robot turns into the wrong direction, then the motors are connected to the wrong ports.
+                        Just swap the ports and your robot will turn into the right way.</p>
+                </div>
+            </div>
+        </div>
+        <div id="robActions_motorDiff_turn_for" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»turn...speed...degree...«">»turn ... speed ... degree ...«</h3>
+            <p>With the »turn degree« block you program the direction (right/left) that your robot will turn. In
+                addition to the direction you can also program the »degrees«, allowing you to program how many degrees
+                your robot should rotate (around its axis). This means that you do a complete rotation by setting a 360
+                degree turn..</p>
+            <p>The »turn degree« block controls both motors of the robot in such a way that the robot turns around its
+                own axis. If the robot's actions don't correspond with the block's settings when running the program,
+                check the NXT robot configuration settings, especially the wheel diameter and the track width.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Turn, »right« or »left«. Select the desired direction for
+                    turning.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100. If the number is negative, the
+                    motors will rotate backwards.</li>
+                <li class="typcn typcn-arrow-left">Number, degrees the robot shall turn. Degree of 360 will perform a
+                    full turn around. Negative numbers are not allowed.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_motorDiff_curve" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammingBlocksNXT-»steer...speedleft...speedright...«">»steer ... speed
+                left ... speed right ...«</h3>
+            <p style="text-align: left;">The block »steer ... speed left ... speed right ...« programs the robot to
+                drive a curve by setting different speeds for the left and right motor. The robot configuration
+                influences the radius of the curve depending from wheel distance and wheel diameter. The turning
+                direction will define the driving direction.</p>
+            <p style="text-align: left;">Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Turning direction, »forwards« or »backwards«. Select your
+                    desired moving direction.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
+                    is negative the motor will run backwards.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
+                    is negative the motor will run backwards.</li>
+            </ul>
+        </div>
+        <div id="robActions_motorDiff_curve_for" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammingBlocksNXT-»steer...speedleft...speedright...distance...«">
+                »steer ... speed left ... speed right ... distance ...«</h3>
+            <p style="text-align: left;">The block »steer ... speed left ... speed right ... distance ...« programs the
+                robot to drive a curve by setting different speeds for the left and right motor and also a distance
+                related to the middle between both wheels. The robot configuration influences the radius of the curve
+                depending from wheel distance and wheel diameter. The turning direction will define the driving
+                direction.</p>
+            <p style="text-align: left;">Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Turning direction, »forwards« or »backwards«. Select your
+                    desired moving direction.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
+                    is negative the motor will run backwards.</li>
+                <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
+                    is negative the motor will run backwards.</li>
+                <li class="typcn typcn-arrow-left">Number, the distance in cm to be driven.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_text" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»showtext«">»show text«</h3>
+            <p>With the »show text« block you can display text and numbers on the display of your robot. You can also
+                specify in which column and row the text or numbers should be desplayed on the robot screen.</p>
+            <p>The NXT display contains 8 rows with row numbers from 1 to 8, and 16 columns with column numbers from 0
+                to 15.</p>
+            <p>If there was text on the display prior to the show text block then the former text will be overwritten.
+            </p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, input of a text string to be shown in the display.</li>
+                <li class="typcn typcn-arrow-left">Number, column for the text to start.</li>
+                <li class="typcn typcn-arrow-left">Number, line for the text to start.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_display_clear" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»cleardisplay«">»clear display«</h3>
+            <p>With the »clear display« block you can delete text and numbers on the display of your robot, therefore
+                nothing appears on your display.</p>
+        </div>
+        <div id="robActions_play_tone" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»playfrequency«">»play frequency«</h3>
+            <p>With the »play frequency« block you can program the frequency (pitch level) and the time (how long the
+                sound should be played) that a sound is played. The sound is played by the built-in speaker of your LEGO
+                MINDSTORMS NXT brick for a defined of time. The frequency setting corresponds directly to the frequency
+                in Hertz, for example, setting the frequency to 400 corresponds to 400 Hertz. Example: 261 = C.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p><span>Note that the human ear can perceive frequencies from about 30Hz to about 15,000Hz (15kHz).
+                            This can vary depending on the person and their age.</span></p>
+                </div>
+            </div>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, desired frequency in Hz (Hertz) .</li>
+                <li class="typcn typcn-arrow-left">Number, desired duration in milliseconds (ms).</li>
+            </ul><br>
+        </div>
+        <div id="mbedActions_play_note" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»Playnote...«">»Play note ... «</h3>
+            <p>With this block your robot can play a note. You can choose the note itself as well as the duration of the
+                note.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the duration of the note.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose which note you want to play.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_play_setVolume" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»setvolume«">»set volume«</h3>
+            <p>With the »set volume« block you can program the sound volume played. The volume ranges from 0 (no sound)
+                to 100 (full volume). The volume setting remains unchanged until you change it with another »set volume«
+                block.</p>
+            <p>Setting:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, volume for loudness. 0 = no tone, 100 = maximum volume.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_play_getVolume" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»getvolume«[Expertblock]">»get volume« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>With the »get volume« block you can read the currend sound volume level.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, currently adjusted volume. 0 = no tone, 100 = maximum volume
+                </li>
+            </ul><br>
+        </div>
+        <div id="robActions_sensorLight_on" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»setcoloursensor«[Expertblock]">»set colour sensor« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the »set colour sensor« from the category »status light« you can program the colour sensor light
+                with one of the colours red, green, or blue.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Colour, select a colour.</li>
+                <li class="typcn typcn-arrow-sorted-down">Switch, choose the light to be on or off.</li>
+                <li class="typcn typcn-arrow-sorted-down">Port, choose the port where the light sensor is connected.
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_touch_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»touchsensorport...pressed?«">»touch sensor port ... pressed?«</h3>
+            <p>With the block »touch sensor« you can "tell" another block whether the touch sensor is pressed or not.
+                This block returns the logical values <em>true = pressed</em> or <em>false = not pressed</em>. This
+                block can only be used in conjunction with another block which requires a logical value as an input
+                parameter, for example together with the »if then« block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your touch sensor is
+                    connected.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value: »true«, if the touch sensor is pressed, otherwise
+                    »false«.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_sound_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»getvaluesoundsensor«">»get value sound sensor«</h3>
+            <p>With the block »get value sound sensor« you "tell" another block the current loudness measures by the
+                sensor. The value is between 0 and 100. </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, choose the port where the sound sensor is connected.
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, some value between 0 and 100.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»getlight«">»get light«</h3>
+            <p>Using the block »get light« you can tell another block a light value measured by the light sensor.</p>
+            <p>In mode »light« the light sensor emits some light and measures the reflected light.</p>
+            <p>In mode »ambient light« the light sensor measures the ambient light.</p>
+            <p>Light values are between 0 and 100.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode, choose how to measure - (reflected) light intensity or
+                    ambient light.</li>
+                <li class="typcn typcn-arrow-sorted-down"> Port, choose the port number where the light sensor is
+                    connected.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, light value between 0 and 100.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_colour_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»getcolour«coloursensor">»get colour« colour sensor</h3>
+            <p>With the block »get colour« you can "tell" another block which color the colour sensor measures. The
+                color is transmitted as type »colour« . In addition, this block provides within the drop down menu the
+                settings »light« and »ambient light«. These additional settings transmit all the same type »number«. The
+                numerical values are between 0 (black) to 100(white). With these various settings this block can be
+                configured according to the specific requirements.</p>
+            <p>In mode »colour« the light sensor emits light and detects the basic colour under the sensor. Values for
+                basic colours are BLACK, WHITE, RED, GREEN, BLUE, YELLOW.</p>
+            <p>In mode »light« the light sensor emits light with its red LED and measures the light intensity of the
+                reflected light on a scale of 0 to 100.</p>
+            <p>In mode »ambient light« the same scale (0-100) as in the mode light is used. Here, the ambient light
+                incidenting the sensor is measured.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode, select the mode of measurement.</li>
+                <li class="typcn typcn-arrow-sorted-down"> Port, select the sensor port where your colour sensor is
+                    connected.</li>
+            </ul>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, depending on the selected mode of measurement.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»getdistanceultrasonicsensorport...«">»get distance ultrasonic sensor port ...
+                «</h3>
+            <p>With the block »get distance« using the ultrasonic sensor you can "tell" another block which distance the
+                sensor measures.</p>
+            <p>Working in the "distance" mode the distance in centimeters is given with values between 0 and 255. The
+                maximum value is 255. This value also may indicate that the distance is more than 255 cm.</p>
+            <p>Settins:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, select the sensor port number where your ultrasonic
+                    sensor is connected.</li>
+            </ul>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>»Distance« mode: number indicating the distance in cm, maximalum distance is 70 cm.</p>
+                    <p>»Presence« mode: list of numbers.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_encoder_reset" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»resetencoder«">»reset encoder«</h3>
+            <p>With the block »reset encoder« the internal sensor (motor encoder) of a motor can be reset to 0 .</p>
+            <p>Setting:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Port, select the sensor port where your motor is connected.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_encoder_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»getrotation/degree«rotationsensor">»get rotation/degree« rotation sensor</h3>
+            <p>With the block »get rotation/degree« you can "tell" another block the rotation of the motor. The distance
+                is transmitted as a number (in cm). In addition, this block can be set to »degree« in the drop down
+                menu. With this setting the number of degrees is transmitted instead of cm. This block can only be used
+                in conjunction with another block, which requires a number as an input parameter.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Measurement mode, »rotation«, »degree« or»distance«. Select
+                    your mode of measurement.</li>
+                <li class="typcn typcn-arrow-sorted-down">Encoder port, select the sensor port where your motor/encoder
+                    is connected.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, that indicates according to the measurement mode the number
+                    of rotations, the degrees, or the distance in cm.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»button...pressed?«">»button ... pressed? «</h3>
+            <p>With the »button« block you can "tell" another block whether the selected button is pressed or not.
+                Available buttons are »enter« / »left« / »right«. This block returns logical values <em>true = pressed
+                    or false = not pressed</em>.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select the button you want to check.</li>
+            </ul><br>
+            <p>Return value
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true«, if the selected button has been pressed,
+                    »false« otherwise.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»getvalue«timer">»get value« timer</h3>
+            <p>With the block »get value« you can "tell" another block the current time in milliseconds of the internal
+                timer. The internal timer is automatically started at program start and can be reset with the »reset
+                timer « block.</p>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, milliseconds since program start or since the last reset of
+                    the selected timer.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»resettimer«">»reset timer«</h3>
+            <p>With the block »reset timer« the internal timer can be reset to the value 0.</p>
+        </div>
+        <div id="robSensors_htcolour_getSample" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksNXT-»get...HTcoloursensorport...«[Expertblock]">»get ...
+                HT colour sensor port ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can query the HT colour sensor of your robot. This sensor can measure the color of
+                the background, the brightness of the light and the environment and the distribution of the measured
+                color into the primary colors red, green and blue. The return value of this block depends on the
+                measured property.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the characteristic that you want to measure.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the port of the sensor.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Colour, the colour of the ground.</li>
+                <li class="typcn typcn-arrow-right">Number, brightness of the light or the surroundings.</li>
+                <li class="typcn typcn-arrow-right">List of Numbers, distribution of the measured colour into Red, Green
+                    and Blue.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="ProgrammingBlocksNXT-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue
+                with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammingBlocksNXT-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="ProgrammingBlocksNXT-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»mathematicalfunction«[Expert-block]">»mathematical function« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksNXT-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksNXT-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksNXT-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="ProgrammingBlocksNXT-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksNXT-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="ProgrammingBlocksNXT-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksNXT-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksNXT-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingBlocksNXT-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number«
+                <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksNXT-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksNXT-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksNXT-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksNXT-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksNXT-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksNXT-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksNXT-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingBlocksNXT-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingBlocksNXT-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingBlocksNXT-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammingBlocksNXT-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingBlocksNXT-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ...
+                green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="ProgrammingBlocksNXT-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ...
+                blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingBlocksNXT-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green
+                ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammingBlocksNXT-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function
+                blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function
+                blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="ProgrammingBlocksNXT-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with
+                return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="ProgrammingBlocksNXT-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function
+                with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-»functioncallwithoutreturnvalue«">»function call without return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksNXT-»functioncallwithreturnvalue«">»function call with
+                return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul>
+        </div>
+        <div id="robCommunication_connection" class="help expert">
+            <h3 style="color: rgb(51,153,102);" id="ProgrammingBlocksNXT-Connectionblock[Expertblock]"><span
+                    style="color: rgb(0,0,0);">Connection block</span> <span class="typcn typcn-star"></span></h3>
+            <p>A message interchange connection is initiated by one NXT robot, like a telephone call that is initiated
+                by the caller. You need to know the name of the communication partner. In the NXT monitor the connection
+                number is shown which is used for the communication.</p>
+            <p>Setting:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Connection name, choose one of the 4 available names.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Connection object.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_sendBlock" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-Sendamessageviaconnection[Expertblock]">Send a message via connection <span
+                    class="typcn typcn-star"></span></h3>
+            <p>A message will be transferred to a selected robot. The message will be entered from a suitable block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Message data type, »Number«, »Boolean«, or »String«.</li>
+                <li class="typcn typcn-arrow-left">Message, message to be sent.</li>
+                <li class="typcn typcn-arrow-sorted-down">Connection type, »Bluetooth«.</li>
+                <li class="typcn typcn-arrow-sorted-down">Channel, select a communication channel.</li>
+                <li class="typcn typcn-arrow-left">Connection, select a communication name.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_receiveBlock" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-Datareceivedviaconnection[Expertblock]">Data received via connection <span
+                    class="typcn typcn-star"></span></h3>
+            <p>A text message will be transferred using a global connection variable. The text message will be
+                transferred into a text block. To give the connection information to the EV3 robot the value of the
+                global connection variable will be read.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Message data type, »String«.</li>
+                <li class="typcn typcn-arrow-sorted-down">Connection type, »Bluetooth«.</li>
+                <li class="typcn typcn-arrow-left">Connection variable, established for the connection.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, content of the received message.</li>
+            </ul><br>
+        </div>
+        <div id="robCommunication_checkConnection" class="help expert">
+            <h3 id="ProgrammingBlocksNXT-Checkconnection[Expertblock]">Check connection <span
+                    class="typcn typcn-star"></span></h3>
+            <p>A communication connection between two NXT robots is managed using a connection number. The block
+                »connection to robot« checks whether the connection is established.</p>
+            <p>Setting:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Communication connection, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, true, if the connection is established, otherwise false.
+                </li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_sensebox_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_sensebox_de.html
@@ -1,423 +1,1580 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start_ardu" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am »Wiederhole unendlich oft«-Block.</p><p>Für Systeme, die auf einem Arduino oder einem ähnlichen Mikrocontroller basieren, ist hier immer eine »Wiederhole unendlich oft«-Schleife mit dem Start-Block verbunden, die ebenfalls nicht entfernt werden kann. Dies liegt daran, dass solche Mikrocontroller meistens für genau eine Aufgabe programmiert werden, die dann immer wieder ausgeführt werden soll. Wenn du nur einen Durchlauf des Programm möchtest, kannst du den Roboter am Ende der Schleife einfach für eine sehr lange Zeit warten lassen.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
-</ul><p class="auto-cursor-target">Wenn globale Variablen erzeugt wurden:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variablen.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
-</ul></div><div id="robActions_serial_print" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»ZeigeaufSerialMonitor...«">»Zeige auf Serial Monitor ... «</h3><p>Mit diesem Block kannst du einen Text per Serial Port an deinen Computer schicken. Dazu muss deine senseBox per USB mit deinem Computer verbunden sein. Wie du einen Serial Monitor installierst, kannst du <a href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo/Open+Roberta+Connector">hier </a>nachlesen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, Text den du auf deinem angeschlossenen Computer sichtbar machen möchtest.</li>
-</ul></div><div id="robActions_display_text_i2c" class="help beginner"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»OLEDBildschirmI²C...ZeigeText...inSpalte...Zeile...«">»OLED Bildschirm I²C ... Zeige Text ... in Spalte ... Zeile ... «</h3><p>Mit diesem Block kannst du einen Text auf dem OLED-Display darstellen. Das OLED-Display musst du an einen der »I²C-Ports« deiner senseBox anschließen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, Text, den du auf dem Display darstellen möchtest.</li><li class="typcn typcn-arrow-left">Zahl, Spalte in der der Text dargestellt werden soll. Zahl zwischen 0 und 100.</li><li class="typcn typcn-arrow-left">Zahl, Zeile in der der Text dargestellt werden soll. Zahl zwischen 0 und 50.</li>
-</ul></div><div id="robActions_display_clear_i2c" class="help beginner"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»LöscheOLEDBildschirmI²C«">»Lösche OLED Bildschirm I²C «</h3><p>Mit diesem Block kannst das angeschlossene Display löschen, also zurücksetzen.</p></div><div id="robActions_play_tone" class="help beginner"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»SpieleFrequenzHz...Dauerms...«">»Spiele Frequenz Hz ... Dauer ms ... «</h3><p>Mit diesem Block kann deine senseBox einen Ton für eine gewisse Zeit wiedergeben.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Frequenz des Tons, der gespielt werden soll. Nur Töne zwischen 20 und 20000 Hertz sind für das menschliche Gehör hörbar.</li><li class="typcn typcn-arrow-left">Zahl, Dauer für die der Ton gespielt werden soll in Millisekunden.</li>
-</ul></div><div id="robActions_brickLight_on" class="help beginner"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»SchalteLEDan...«">»Schalte LED an ... «</h3><p>Mit diesem Block kannst du eine LED deiner senseBox oder eine LED, die an deiner senseBox angeschlossen ist, steuern.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Name der LED, die du steuern möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, Status der LED, an oder aus.</li>
-</ul></div><div id="robActions_led_on" class="help expert"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»SchalteLEDan...Farbe...«[Experten-Block]">»Schalte LED an ... Farbe ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine Farb-LED steuern, die du an deine senseBox angeschlossen hast.</p><p>Einstellungen und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Port bzw. Name der LED, die du steuern möchtest.</li><li class="typcn typcn-arrow-left">Farbe, Farbe in der deine LED leuchten soll.</li>
-</ul></div><div id="robActions_led_off" class="help expert"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»SchalteLEDaus«[Experten-Block]">»Schalte LED aus « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine Farb-LED, die du an deine senseBox angeschlossen hast, ausschalten.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Port bzw. Name der LED, die du ausschalten möchtest.</li>
-</ul></div><div id="robActions_sendData" class="help beginner"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»SendeDatenan...Phänomen...«">»Sende Daten an ... Phänomen ... «</h3><p>Mit diesem Block kannst du deine Daten entweder per W-LAN an »OpenSenseMap« oder an deine SD-Karte senden, um diese Daten zu dokumentieren.</p><p>Einstellungen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Ziel deiner Daten, entweder OpenSenseMap oder deine lokale SD-Karte</li><li class="typcn typcn-arrow-left">Zahl, Daten die du speichern bzw. weitergeben möchtest.</li>
-</ul></div><div id="robActions_plot_clear" class="help expert"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»LöschedasDiagramm...«[Experten-Block]">»Lösche das Diagramm ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du den Graphen auf einem Display zurücksetzen.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Display, dass zurückgesetzt werden soll.</li>
-</ul></div><div id="robActions_plot_point" class="help expert"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»ZeichneeinenPunktan...Wert...andenTeilstrich...«[Experten-Block]">»Zeichne einen Punkt an ... Wert ... an den Teilstrich ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du einen Punkt eines Graphen zeichnen. Dabei ist »Teilstrich« die x-Koordinate und der Wert die y-Koordinate.</p><p>Einstellungen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Display auf dem der Punkt dargestellt werden soll.</li><li class="typcn typcn-arrow-left">Zahl, Wert der dargestellt werden soll. Dies entspricht der y-Koordinate des Punkts.</li><li class="typcn typcn-arrow-left">Zahl, x-Koordinate des Punkts, der dargestellt werden soll.</li>
-</ul></div><div id="robActions_write_pin" class="help expert"><h3 id="BlockbeschreibungsenseBox-»Schreibe...WertAktor...«[Experten-Block]">»Schreibe ... Wert Aktor ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du einen einzelnen Pin deiner senseBox steuern und entweder einen digitalen oder analogen Wert an diesen Pin anlegen. Wenn du digital auswählst, liegt entweder eine Spannung von 3,3V oder 0V an dem Pin an, bei analog kann jeder Wert zwischen 0V und 3,3V anliegen.</p><p>Optionen und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle ob du einen analogen oder digitalen Wert anlegen möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle den Aktor aus, an dem du die Spannung anlegen möchtest.</li><li class="typcn typcn-arrow-left">Zahl, wähle die Spannung, die du anlegen möchtest. Wenn du digital ausgewählt hast entweder 0 oder 1, bei einem analogen Wert eine Zahl zwischen 0 und 1023.</li>
-</ul></div><div id="robSensors_out_getSample" class="help expert"><h3 id="BlockbeschreibungsenseBox-»Gib...WertSensor...«[Experten-Block]">»Gib ... Wert Sensor ... « <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du den Wert eines angeschlossenen Sensors abfragen. Dabei kannst du zwischen analogen und digitalen Sensoren unterscheiden. Bei analogen Sensoren misst der Roboter die Spannung an dem eingestellten Anschluss. Bei einem digitalen Sensor misst der Roboter ob eine Grenzspannung am Anschluss überschritten ist oder nicht.</span></p><p><span style="letter-spacing: -0.006em;">Optionen:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle ob du einen digitalen oder analogen Sensor abfragen möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, wähle den Sensor, den du abfragen möchtest.</li>
-</ul><br><p><span class="auto-cursor-target" style="letter-spacing: -0.006em;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, entweder eine 0 oder 1 bei einem, digitalen Wert oder eine Zahl zwischen 0 und 1023 bei einem analogen Wert.</li>
-</ul></div><div id="robSensors_key_getSample" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»Taste...gedrückt?«">»Taste ... gedrückt?«</h3><p>Mit diesem Block kannst du den Zustand einer Taste deiner senseBox abfragen.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des Tasters.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">logischer Wert, »wahr«, wenn der Taster gedrückt ist, sonst »falsch«.</li>
-</ul><br></div><div id="robSensors_light_getSample" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»GibLicht%Lichtsensor...«">»Gib Licht % Lichtsensor ... «</h3><p>Mit diesem Block kannst du den eingebauten Lichtsensor deiner senseBox abfragen. Dieser Sensor misst die Helligkeit des einfallenden Lichts.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des Lichtsensors.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gemessener Lichteinfall in Prozent. je höher die zahl, desto heller ist die Umgebung.</li>
-</ul><br></div><div id="robSensors_potentiometer_getSample" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»GibWertVPotentiometer...«">»Gib Wert V Potentiometer ... «</h3><p>Mit diesem Block kannst du die Spannung eines angeschlossenen Potentiometer messen.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des angeschlossenen Potentiometers.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gemessene Spannung in Volt.</li>
-</ul><br></div><div id="robSensors_sound_getSample" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»GibGeräusch%Geräuschsensor...«">»Gib Geräusch % Geräuschsensor ... «</h3><p>Mit diesem Block kannst du den eingebauten Geräuschsensor deiner senseBox abfragen.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des Geräuschsensors.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gemessene Lautstärke in einem Bereich von 0 bis 1023. Je höher diese zahl ist, desto höher ist die Lautstärke.</li>
-</ul><br></div><div id="robSensors_ultrasonic_getSample" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»GibAbstandcmUltraschallsensor...«">»Gib Abstand cm Ultraschallsensor ... «</h3><p>Mit diesem Block kannst du den Ultraschallsensor deiner senseBox abfragen. Dieser Sensor misst den Abstand zum nächsten Hindernis, indem er Ultraschallwellen aussendet und misst, wie lange diese benötigen um zurück zu kehren.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des angeschlossenen Sensors.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Abstand zum nächsten Hindernis in Zentimetern. Die Messungenauigkeit liegt bei etwa 3 Zentimetern.</li>
-</ul><br></div><div id="robSensors_humidity_getSample" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»Gib...Luftfeuchtigkeit/TemperaturSensorHDC1080...«">»Gib ... Luftfeuchtigkeit/ Temperatur Sensor HDC1080 ... «</h3><p>Mit diesem Block kannst den HDC1080-Sensor an deiner senseBox steuern. Dieser Sensor kann sowohl die Temperatur als auch die Luftfeuchtigkeit messen.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Eigenschaft die gemessen werden soll. Entweder Temperatur oder Luftfeuchtigkeit.</li><li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des angeschlossenen Sensors.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gemessene Temperatur in °C oder Luftfeuchtigkeit in Prozent</li>
-</ul><br></div><div id="robSensors_temperature_getSample" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»Gib..Temperatur/LuftdruckSensorBMP280...«">»Gib .. Temperatur/ Luftdruck Sensor BMP280...  «</h3><p>Mit diesem Block kannst du den BMP280-Sensor steuern. Dieser Sensor kann sowohl die Temperatur als auch den Luftdruck messen.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Eigenschaft, die gemessen werden soll. Entweder Luftdruck oder Temperatur.</li>
-<ul style="margin-top: 0; margin-bottom: 10px">
-Option, Name bzw. Port des angeschlossenen Sensors.
-</ul>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Temperatur in °C und Luftdruck in Pascal.</li>
-</ul><br></div><div id="robSensors_lightveml_getSample" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»Gib...%sichtbares/UVLichtSensor...«">»Gib ... % sichtbares/UV Licht Sensor ... «</h3><p>Mit diesem Block kannst du den Licht-/UV-Sensor deiner senseBox abfragen. Dieser Sensor kann sowohl Licht im sichtbaren als auch im UV-Bereich messen.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Auswahl des Lichts, das gemessen werden soll.</li><li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des Sensors.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die gemessene Lichtstärke in Lux für sichtbares Licht und in Mikrowatt pro Quadratzentimeter für UV-Licht.</li>
-</ul><br></div><div id="robSensors_accelerometer_getSample" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»Gib...gBeschleunigungssensor...«">»Gib ... g Beschleunigungssensor ... «</h3><p>Mit diesem Block kannst du den Beschleunigungssensor deiner senseBox abfragen. Dieser Sensor misst die Beschleunigung deiner senseBox in die gewählte Richtung.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Achse bzw. Richtung die gemessen werden soll.</li><li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des Sensors.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Wert der Beschleunigung in die gewählte Richtung verglichen mit der Standard-Erdbeschleunigung.</li>
-</ul><br></div><div id="robSensors_particle_getSample" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»Gib...KonzentrationSDS011Feinstaubsensor«">»Gib ... Konzentration SDS011 Feinstaubsensor«</h3><p>Mit diesem Block kannst du den Feinstaubsensor deiner senseBox abfragen. Der Feinstaubsensor kann entweder Partikel mit einem Durchmesser von 2,5 Mikrometer oder 10 Mikrometer messen.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Größe der Partikel, die du messen möchtest.</li><li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des Feinstaubsensors..</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Konzentration der gewählten Partikel in Mikrogramm/m^3.</li>
-</ul><br></div><div id="robSensors_gps_getSample" class="help expert"><h3 id="BlockbeschreibungsenseBox-»Gib...GPS-Empfänger...«[Experten-Block]">»Gib ... GPS-Empfänger ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du einen angeschlossenen GPS-Empfänger abfragen. Der GPS-Empfänger kann verschiedene Werte wie Position, Geschwindigkeit und Höhe des Empfängers messen.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Eigenschaft die gemessen werden soll. Zur Auswahl stehen Breiten- und Längengrad, Höhe, Geschwindigkeit, Datum und Zeit.</li><li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des GPS-Empfängers.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Wert der ausgewählten Eigenschaft.</li>
-</ul><br></div><div id="robSensors_environmental_getSample" class="help expert"><h3 id="BlockbeschreibungsenseBox-»gib...UmweltsensorBME680«[Experten-Block]">»gib ... Umweltsensor BME680 « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du einen Umweltsensor abfragen, den du an einen der I²C-Anschlüsse der senseBox angeschlossen hast. Dieser Sensor kann eine Vielzahl verschiedener Eigenschaften deiner Umwelt messen. Dazu gehören u.a. die Temperatur, die Luftfeuchtigkeit, der Luftdruck und die Luftqualität.</p><p>Die Innenraum-Luftqualität (IAQ) wird in sieben Bereiche unterteilt. Dabei gilt</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="normalBullet"><strong>IAQ &lt; 50 :  </strong>reine Luft, keine Verunreinigungen feststellbar.</li><li class="normalBullet"><strong>51 &lt; IAQ &lt; 100 :  </strong>Fast reine Luft, wenige Verunreinigungen feststellbar.</li><li class="normalBullet"><strong>101 &lt; IAQ &lt; 150 :  </strong>leicht verschmutzte Luft, Lüften wird empfohlen.</li><li class="normalBullet"><strong>151 &lt; IAQ &lt; 200:  </strong>mittlere Verschmutzung der Luft, Lüften mit frischer Luft wird empfohlen.</li><li class="normalBullet"><strong>201 &lt; IAQ &lt; 250 :  </strong>schwere Verunreinigung der Luft, alle Fenster und Türen sollten geöffnet werden.</li><li class="normalBullet"><strong>251 &lt; IAQ &lt; 350 :  </strong>sehr schwere Verunreinigung der Luft, die Ursache sollte identifiziert und behoben werden.</li><li class="normalBullet"><strong>351 &lt; IAQ: </strong>Extrem verunreinigte Luft, es wird empfohlen den Raum umgehend zu verlassen und die Ursache der Verschmutzung zu beheben.</li>
-</ul><br><p>Des weiteren kann der Sensor aus der Verschmutzung der Umgebungsluft die Äquivalenzwerte in CO2 und Atemluft bestimmen. Diese werden in ppm, also Parts Per Million angegeben. Dies beschreibt ein Gasatom pro eine Millionen normaler Luftatome. Diese Daten stellen allerdings nur einen Schätzwert da, da der Sensor diese nicht direkt messen kann.</p><p>Zuletzt kann der Sensor einen Kalibrierungswert ausgeben. Dieser zeigt an, wie genau die Messung der IAQ ist. Nur wenn dieser Kalibrierungswert 3 zurück gibt, ist die Messung genau. Zu Beginn einer Messung der IAQ muss der Sensor zunächst etwa 25 min kalibriert werden. Dies geschieht automatisch, allerdings sind Messungen erst nach diesen 25 min präzise.</p><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><p>Der Gassensor des Umweltsensors kann nicht gleichzeitig mit dem BMP280 Luftdrucksensor verwendet werden.</p></div></div><p class="auto-cursor-target">Optionen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Eigenschaft aus, die du messen möchtest. Du kannst hier wählen zwischen Temperatur, Luftdruck, Luftfeuchtigkeit, Luftqualität (IAQ), Kalibrierungswert, CO2 Äquivalent und VOC Atemluft Äquivalent.</li>
-</ul>Rückgabewerte:
-<ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Temperatur der Umgebung in °C</li><li class="typcn typcn-arrow-right">Zahl, Luftdruck der Umgebung in hPa.</li><li class="typcn typcn-arrow-right">Zahl, Luftfeuchtigkeit der Umgebung in %.</li><li class="typcn typcn-arrow-right">Zahl, Innenraumluftqualität (IAQ), Zahl zwischen 0 und 500. </li><li class="typcn typcn-arrow-right">Zahl, Kalibrierungswert, ganze Zahl zwischen 0 und 3.</li><li class="typcn typcn-arrow-right">Zahl, CO2 Äquivalent aus der Luftverschmutzung, angegeben in Parts Per Million (ppm). </li><li class="typcn typcn-arrow-right">Zahl, Atemluft Äquivalent der Luftverschmutzung, angegeben in Parts Per Million (ppm).</li>
-</ul></div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»GibWertmsZeitgeber...«">»Gib Wert ms Zeitgeber ... «</h3><p>Mit diesem Block kannst du den momentanen Wert eines Zeitgebers abfragen.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Nummer des Zeitgebers, den du abfragen möchtest.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Zeit seit der letzten Rücksetzung des Zeitgebers in Millisekunden.</li>
-</ul><br></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück «</h3><p>Mit diesem Block kannst du einen der Zeitgeber zurücksetzen bzw. neu starten.</p><p>Einstellungen:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Nummer des Zeitgebers, den du zurücksetzen möchtest.</li>
-</ul><br></div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»Wartebis...«">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wartems...«">»Warte ms ... «</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wartebis...«.1">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Zufallszahl«">»Zufallszahl« </h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungsenseBox-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungsenseBox-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt werden soll. Zahl zwischen 0 und 255.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungsenseBox-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von der verwendeten Programmiersprache des Roboters abhängt. </span><span style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt, sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der Zeichenkette »52abcd« die Zahl 52.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt werden soll.</li>
-</ul><br><p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockbeschreibungsenseBox-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3><p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p><p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li><li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte das die Nummerierung bei 0 anfängt.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungsenseBox-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungsenseBox-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungsenseBox-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungsenseBox-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungsenseBox-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungsenseBox-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="BlockbeschreibungsenseBox-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="BlockbeschreibungsenseBox-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockbeschreibungsenseBox-»Farbwahl«">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="BlockbeschreibungsenseBox-»Farbwahl«.1">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="BlockbeschreibungsenseBox-»Farbwahl«.2">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, die  Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="BlockbeschreibungsenseBox-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="BlockbeschreibungsenseBox-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="BlockbeschreibungsenseBox-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="BlockbeschreibungsenseBox-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="BlockbeschreibungsenseBox-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="BlockbeschreibungsenseBox-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="BlockbeschreibungsenseBox-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen Wert zurück.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit Rückgabewert «</h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start_ardu" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den
+                man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am »Wiederhole unendlich
+                oft«-Block.</p>
+            <p>Für Systeme, die auf einem Arduino oder einem ähnlichen Mikrocontroller basieren, ist hier immer eine
+                »Wiederhole unendlich oft«-Schleife mit dem Start-Block verbunden, die ebenfalls nicht entfernt werden
+                kann. Dies liegt daran, dass solche Mikrocontroller meistens für genau eine Aufgabe programmiert werden,
+                die dann immer wieder ausgeführt werden soll. Wenn du nur einen Durchlauf des Programm möchtest, kannst
+                du den Roboter am Ende der Schleife einfach für eine sehr lange Zeit warten lassen.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
+            </ul>
+            <p class="auto-cursor-target">Wenn globale Variablen erzeugt wurden:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variablen.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
+            </ul>
+        </div>
+        <div id="robActions_serial_print" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»ZeigeaufSerialMonitor...«">»Zeige auf Serial Monitor ... «</h3>
+            <p>Mit diesem Block kannst du einen Text per Serial Port an deinen Computer schicken. Dazu muss deine
+                senseBox per USB mit deinem Computer verbunden sein. Wie du einen Serial Monitor installierst, kannst du
+                <a href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo/Open+Roberta+Connector">hier </a>nachlesen.
+            </p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, Text den du auf deinem angeschlossenen Computer
+                    sichtbar machen möchtest.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_text_i2c" class="help beginner">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungsenseBox-»OLEDBildschirmI²C...ZeigeText...inSpalte...Zeile...«">»OLED Bildschirm
+                I²C ... Zeige Text ... in Spalte ... Zeile ... «</h3>
+            <p>Mit diesem Block kannst du einen Text auf dem OLED-Display darstellen. Das OLED-Display musst du an einen
+                der »I²C-Ports« deiner senseBox anschließen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, Text, den du auf dem Display darstellen möchtest.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Spalte in der der Text dargestellt werden soll. Zahl zwischen 0
+                    und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeile in der der Text dargestellt werden soll. Zahl zwischen 0
+                    und 50.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear_i2c" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»LöscheOLEDBildschirmI²C«">»Lösche OLED
+                Bildschirm I²C «</h3>
+            <p>Mit diesem Block kannst das angeschlossene Display löschen, also zurücksetzen.</p>
+        </div>
+        <div id="robActions_play_tone" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»SpieleFrequenzHz...Dauerms...«">»Spiele
+                Frequenz Hz ... Dauer ms ... «</h3>
+            <p>Mit diesem Block kann deine senseBox einen Ton für eine gewisse Zeit wiedergeben.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Frequenz des Tons, der gespielt werden soll. Nur Töne zwischen
+                    20 und 20000 Hertz sind für das menschliche Gehör hörbar.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Dauer für die der Ton gespielt werden soll in Millisekunden.
+                </li>
+            </ul>
+        </div>
+        <div id="robActions_brickLight_on" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»SchalteLEDan...«">»Schalte LED an ... «</h3>
+            <p>Mit diesem Block kannst du eine LED deiner senseBox oder eine LED, die an deiner senseBox angeschlossen
+                ist, steuern.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Name der LED, die du steuern möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, Status der LED, an oder aus.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_on" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»SchalteLEDan...Farbe...«[Experten-Block]">
+                »Schalte LED an ... Farbe ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine Farb-LED steuern, die du an deine senseBox angeschlossen hast.</p>
+            <p>Einstellungen und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Port bzw. Name der LED, die du steuern möchtest.</li>
+                <li class="typcn typcn-arrow-left">Farbe, Farbe in der deine LED leuchten soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_off" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»SchalteLEDaus«[Experten-Block]">»Schalte LED
+                aus « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine Farb-LED, die du an deine senseBox angeschlossen hast, ausschalten.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Port bzw. Name der LED, die du ausschalten möchtest.
+                </li>
+            </ul>
+        </div>
+        <div id="robActions_sendData" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»SendeDatenan...Phänomen...«">»Sende Daten an
+                ... Phänomen ... «</h3>
+            <p>Mit diesem Block kannst du deine Daten entweder per W-LAN an »OpenSenseMap« oder an deine SD-Karte
+                senden, um diese Daten zu dokumentieren.</p>
+            <p>Einstellungen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Ziel deiner Daten, entweder OpenSenseMap oder deine
+                    lokale SD-Karte</li>
+                <li class="typcn typcn-arrow-left">Zahl, Daten die du speichern bzw. weitergeben möchtest.</li>
+            </ul>
+        </div>
+        <div id="robActions_plot_clear" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»LöschedasDiagramm...«[Experten-Block]">»Lösche
+                das Diagramm ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du den Graphen auf einem Display zurücksetzen.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Display, dass zurückgesetzt werden soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_plot_point" class="help expert">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungsenseBox-»ZeichneeinenPunktan...Wert...andenTeilstrich...«[Experten-Block]">
+                »Zeichne einen Punkt an ... Wert ... an den Teilstrich ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du einen Punkt eines Graphen zeichnen. Dabei ist »Teilstrich« die x-Koordinate
+                und der Wert die y-Koordinate.</p>
+            <p>Einstellungen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Display auf dem der Punkt dargestellt werden soll.
+                </li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert der dargestellt werden soll. Dies entspricht der
+                    y-Koordinate des Punkts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, x-Koordinate des Punkts, der dargestellt werden soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_write_pin" class="help expert">
+            <h3 id="BlockbeschreibungsenseBox-»Schreibe...WertAktor...«[Experten-Block]">»Schreibe ... Wert Aktor ... «
+                <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du einen einzelnen Pin deiner senseBox steuern und entweder einen digitalen oder
+                analogen Wert an diesen Pin anlegen. Wenn du digital auswählst, liegt entweder eine Spannung von 3,3V
+                oder 0V an dem Pin an, bei analog kann jeder Wert zwischen 0V und 3,3V anliegen.</p>
+            <p>Optionen und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob du einen analogen oder digitalen Wert anlegen
+                    möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Aktor aus, an dem du die Spannung anlegen
+                    möchtest.</li>
+                <li class="typcn typcn-arrow-left">Zahl, wähle die Spannung, die du anlegen möchtest. Wenn du digital
+                    ausgewählt hast entweder 0 oder 1, bei einem analogen Wert eine Zahl zwischen 0 und 1023.</li>
+            </ul>
+        </div>
+        <div id="robSensors_out_getSample" class="help expert">
+            <h3 id="BlockbeschreibungsenseBox-»Gib...WertSensor...«[Experten-Block]">»Gib ... Wert Sensor ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Mit diesem Block kannst du den Wert eines angeschlossenen Sensors
+                    abfragen. Dabei kannst du zwischen analogen und digitalen Sensoren unterscheiden. Bei analogen
+                    Sensoren misst der Roboter die Spannung an dem eingestellten Anschluss. Bei einem digitalen Sensor
+                    misst der Roboter ob eine Grenzspannung am Anschluss überschritten ist oder nicht.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle ob du einen digitalen oder analogen Sensor
+                    abfragen möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle den Sensor, den du abfragen möchtest.</li>
+            </ul><br>
+            <p><span class="auto-cursor-target" style="letter-spacing: -0.006em;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, entweder eine 0 oder 1 bei einem, digitalen Wert oder eine
+                    Zahl zwischen 0 und 1023 bei einem analogen Wert.</li>
+            </ul>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»Taste...gedrückt?«">»Taste ... gedrückt?«</h3>
+            <p>Mit diesem Block kannst du den Zustand einer Taste deiner senseBox abfragen.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des Tasters.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">logischer Wert, »wahr«, wenn der Taster gedrückt ist, sonst
+                    »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»GibLicht%Lichtsensor...«">»Gib Licht % Lichtsensor ... «</h3>
+            <p>Mit diesem Block kannst du den eingebauten Lichtsensor deiner senseBox abfragen. Dieser Sensor misst die
+                Helligkeit des einfallenden Lichts.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des Lichtsensors.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gemessener Lichteinfall in Prozent. je höher die zahl, desto
+                    heller ist die Umgebung.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_potentiometer_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»GibWertVPotentiometer...«">»Gib Wert V Potentiometer ... «</h3>
+            <p>Mit diesem Block kannst du die Spannung eines angeschlossenen Potentiometer messen.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des angeschlossenen Potentiometers.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gemessene Spannung in Volt.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_sound_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»GibGeräusch%Geräuschsensor...«">»Gib Geräusch % Geräuschsensor ... «</h3>
+            <p>Mit diesem Block kannst du den eingebauten Geräuschsensor deiner senseBox abfragen.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des Geräuschsensors.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gemessene Lautstärke in einem Bereich von 0 bis 1023. Je höher
+                    diese zahl ist, desto höher ist die Lautstärke.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»GibAbstandcmUltraschallsensor...«">»Gib Abstand cm Ultraschallsensor ...
+                «</h3>
+            <p>Mit diesem Block kannst du den Ultraschallsensor deiner senseBox abfragen. Dieser Sensor misst den
+                Abstand zum nächsten Hindernis, indem er Ultraschallwellen aussendet und misst, wie lange diese
+                benötigen um zurück zu kehren.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des angeschlossenen Sensors.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Abstand zum nächsten Hindernis in Zentimetern. Die
+                    Messungenauigkeit liegt bei etwa 3 Zentimetern.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_humidity_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»Gib...Luftfeuchtigkeit/TemperaturSensorHDC1080...«">»Gib ...
+                Luftfeuchtigkeit/ Temperatur Sensor HDC1080 ... «</h3>
+            <p>Mit diesem Block kannst den HDC1080-Sensor an deiner senseBox steuern. Dieser Sensor kann sowohl die
+                Temperatur als auch die Luftfeuchtigkeit messen.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Eigenschaft die gemessen werden soll. Entweder
+                    Temperatur oder Luftfeuchtigkeit.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des angeschlossenen Sensors.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gemessene Temperatur in °C oder Luftfeuchtigkeit in Prozent
+                </li>
+            </ul><br>
+        </div>
+        <div id="robSensors_temperature_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»Gib..Temperatur/LuftdruckSensorBMP280...«">»Gib .. Temperatur/ Luftdruck
+                Sensor BMP280... «</h3>
+            <p>Mit diesem Block kannst du den BMP280-Sensor steuern. Dieser Sensor kann sowohl die Temperatur als auch
+                den Luftdruck messen.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Eigenschaft, die gemessen werden soll. Entweder
+                    Luftdruck oder Temperatur.</li>
+                <ul style="margin-top: 0; margin-bottom: 10px">
+                    Option, Name bzw. Port des angeschlossenen Sensors.
+                </ul>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Temperatur in °C und Luftdruck in Pascal.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_lightveml_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»Gib...%sichtbares/UVLichtSensor...«">»Gib ... % sichtbares/UV Licht
+                Sensor ... «</h3>
+            <p>Mit diesem Block kannst du den Licht-/UV-Sensor deiner senseBox abfragen. Dieser Sensor kann sowohl Licht
+                im sichtbaren als auch im UV-Bereich messen.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Auswahl des Lichts, das gemessen werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des Sensors.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die gemessene Lichtstärke in Lux für sichtbares Licht und in
+                    Mikrowatt pro Quadratzentimeter für UV-Licht.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_accelerometer_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»Gib...gBeschleunigungssensor...«">»Gib ... g Beschleunigungssensor ... «
+            </h3>
+            <p>Mit diesem Block kannst du den Beschleunigungssensor deiner senseBox abfragen. Dieser Sensor misst die
+                Beschleunigung deiner senseBox in die gewählte Richtung.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Achse bzw. Richtung die gemessen werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des Sensors.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Wert der Beschleunigung in die gewählte Richtung verglichen
+                    mit der Standard-Erdbeschleunigung.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_particle_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»Gib...KonzentrationSDS011Feinstaubsensor«">»Gib ... Konzentration SDS011
+                Feinstaubsensor«</h3>
+            <p>Mit diesem Block kannst du den Feinstaubsensor deiner senseBox abfragen. Der Feinstaubsensor kann
+                entweder Partikel mit einem Durchmesser von 2,5 Mikrometer oder 10 Mikrometer messen.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Größe der Partikel, die du messen möchtest.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des Feinstaubsensors..</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Konzentration der gewählten Partikel in Mikrogramm/m^3.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_gps_getSample" class="help expert">
+            <h3 id="BlockbeschreibungsenseBox-»Gib...GPS-Empfänger...«[Experten-Block]">»Gib ... GPS-Empfänger ... «
+                <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du einen angeschlossenen GPS-Empfänger abfragen. Der GPS-Empfänger kann
+                verschiedene Werte wie Position, Geschwindigkeit und Höhe des Empfängers messen.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Eigenschaft die gemessen werden soll. Zur Auswahl
+                    stehen Breiten- und Längengrad, Höhe, Geschwindigkeit, Datum und Zeit.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, Name bzw. Port des GPS-Empfängers.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Wert der ausgewählten Eigenschaft.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_environmental_getSample" class="help expert">
+            <h3 id="BlockbeschreibungsenseBox-»gib...UmweltsensorBME680«[Experten-Block]">»gib ... Umweltsensor BME680 «
+                <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du einen Umweltsensor abfragen, den du an einen der I²C-Anschlüsse der senseBox
+                angeschlossen hast. Dieser Sensor kann eine Vielzahl verschiedener Eigenschaften deiner Umwelt messen.
+                Dazu gehören u.a. die Temperatur, die Luftfeuchtigkeit, der Luftdruck und die Luftqualität.</p>
+            <p>Die Innenraum-Luftqualität (IAQ) wird in sieben Bereiche unterteilt. Dabei gilt</p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="normalBullet"><strong>IAQ &lt; 50 : </strong>reine Luft, keine Verunreinigungen feststellbar.
+                </li>
+                <li class="normalBullet"><strong>51 &lt; IAQ &lt; 100 : </strong>Fast reine Luft, wenige
+                    Verunreinigungen feststellbar.</li>
+                <li class="normalBullet"><strong>101 &lt; IAQ &lt; 150 : </strong>leicht verschmutzte Luft, Lüften wird
+                    empfohlen.</li>
+                <li class="normalBullet"><strong>151 &lt; IAQ &lt; 200: </strong>mittlere Verschmutzung der Luft, Lüften
+                    mit frischer Luft wird empfohlen.</li>
+                <li class="normalBullet"><strong>201 &lt; IAQ &lt; 250 : </strong>schwere Verunreinigung der Luft, alle
+                    Fenster und Türen sollten geöffnet werden.</li>
+                <li class="normalBullet"><strong>251 &lt; IAQ &lt; 350 : </strong>sehr schwere Verunreinigung der Luft,
+                    die Ursache sollte identifiziert und behoben werden.</li>
+                <li class="normalBullet"><strong>351 &lt; IAQ: </strong>Extrem verunreinigte Luft, es wird empfohlen den
+                    Raum umgehend zu verlassen und die Ursache der Verschmutzung zu beheben.</li>
+            </ul><br>
+            <p>Des weiteren kann der Sensor aus der Verschmutzung der Umgebungsluft die Äquivalenzwerte in CO2 und
+                Atemluft bestimmen. Diese werden in ppm, also Parts Per Million angegeben. Dies beschreibt ein Gasatom
+                pro eine Millionen normaler Luftatome. Diese Daten stellen allerdings nur einen Schätzwert da, da der
+                Sensor diese nicht direkt messen kann.</p>
+            <p>Zuletzt kann der Sensor einen Kalibrierungswert ausgeben. Dieser zeigt an, wie genau die Messung der IAQ
+                ist. Nur wenn dieser Kalibrierungswert 3 zurück gibt, ist die Messung genau. Zu Beginn einer Messung der
+                IAQ muss der Sensor zunächst etwa 25 min kalibriert werden. Dies geschieht automatisch, allerdings sind
+                Messungen erst nach diesen 25 min präzise.</p>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <p>Der Gassensor des Umweltsensors kann nicht gleichzeitig mit dem BMP280 Luftdrucksensor verwendet
+                        werden.</p>
+                </div>
+            </div>
+            <p class="auto-cursor-target">Optionen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Eigenschaft aus, die du messen möchtest. Du
+                    kannst hier wählen zwischen Temperatur, Luftdruck, Luftfeuchtigkeit, Luftqualität (IAQ),
+                    Kalibrierungswert, CO2 Äquivalent und VOC Atemluft Äquivalent.</li>
+            </ul>Rückgabewerte:
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Temperatur der Umgebung in °C</li>
+                <li class="typcn typcn-arrow-right">Zahl, Luftdruck der Umgebung in hPa.</li>
+                <li class="typcn typcn-arrow-right">Zahl, Luftfeuchtigkeit der Umgebung in %.</li>
+                <li class="typcn typcn-arrow-right">Zahl, Innenraumluftqualität (IAQ), Zahl zwischen 0 und 500. </li>
+                <li class="typcn typcn-arrow-right">Zahl, Kalibrierungswert, ganze Zahl zwischen 0 und 3.</li>
+                <li class="typcn typcn-arrow-right">Zahl, CO2 Äquivalent aus der Luftverschmutzung, angegeben in Parts
+                    Per Million (ppm). </li>
+                <li class="typcn typcn-arrow-right">Zahl, Atemluft Äquivalent der Luftverschmutzung, angegeben in Parts
+                    Per Million (ppm).</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»GibWertmsZeitgeber...«">»Gib Wert ms Zeitgeber ... «</h3>
+            <p>Mit diesem Block kannst du den momentanen Wert eines Zeitgebers abfragen.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Nummer des Zeitgebers, den du abfragen möchtest.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Zeit seit der letzten Rücksetzung des Zeitgebers in
+                    Millisekunden.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»SetzeZeitgeber...zurück«">»Setze Zeitgeber ... zurück «</h3>
+            <p>Mit diesem Block kannst du einen der Zeitgeber zurücksetzen bzw. neu starten.</p>
+            <p>Einstellungen:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Nummer des Zeitgebers, den du zurücksetzen möchtest.
+                </li>
+            </ul><br>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wennmachesonst«">»Wenn mache sonst«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wiederholeunendlichoft«">»Wiederhole unendlich
+                oft«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wiederholenmal«">»Wiederhole n mal«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wiederholesolange/bis«[Experten-Block]">
+                »Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»FürWertausderListe«[Experten-Block]">»Für Wert
+                aus der Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Zählevonbis«[Experten-Block]">»Zähle von bis«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="BlockbeschreibungsenseBox-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wartems...«">»Warte ms ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wartebis...«.1">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»MathematischeFunktionen«[Experten-Block]">
+                »Mathematische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»TrigonometrischeFunktionen«[Experten-Block]">
+                »Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Konstanten«[Experten-Block]">»Konstanten« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Zahleneigenschaft«[Experten-Block]">
+                »Zahleneigenschaft« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»runden«[Experten-Block]">»runden« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Listeauswerten«[Experten-Block]">»Liste
+                auswerten« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Restvon«[Experten-Block]">»Rest von« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Begrenze«[Experten-Block]">»Begrenze« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»GanzzahligeZufallswerte«[Experten-Block]">
+                »Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Zufallszahl«">»Zufallszahl« </h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungsenseBox-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in
+                Zeichenkette« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungsenseBox-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»ErstelleText«[Experten-Block]">»Erstelle Text«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="BlockbeschreibungsenseBox-»Textanhängen«[Experten-Block]">»Text anhängen«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungsenseBox-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungsenseBox-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ...
+                an Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungsenseBox-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungsenseBox-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste«
+                <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungsenseBox-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungsenseBox-»istleer?«[Experten-Block]">»ist leer?« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungsenseBox-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungsenseBox-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockbeschreibungsenseBox-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="BlockbeschreibungsenseBox-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockbeschreibungsenseBox-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="BlockbeschreibungsenseBox-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="BlockbeschreibungsenseBox-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungsenseBox-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ...
+                Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungsenseBox-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün
+                ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungsenseBox-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün
+                ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="BlockbeschreibungsenseBox-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="BlockbeschreibungsenseBox-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="BlockbeschreibungsenseBox-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="BlockbeschreibungsenseBox-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb
+                einer Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="BlockbeschreibungsenseBox-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="BlockbeschreibungsenseBox-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage
+                innerhalb einer Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="BlockbeschreibungsenseBox-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne
+                Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungsenseBox-»FunktionsaufrufmitRückgabewert«">
+                »Funktionsaufruf mit Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_sensebox_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_sensebox_en.html
@@ -1,415 +1,1491 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start_ardu" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Programstart«"><span style="color: rgb(0,0,0);">»Program start«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Each program starts with the »Start« block, which cannot be deleted. The first block you want to use is connected directly to the »Sequence connection« on the »Repeat indefinitely« block.</p><p>For systems based on an Arduino or similar microcontroller, there is always a »repeat indefinitely« loop connected to the start block, which also cannot be removed. This is due to the fact that such microcontrollers are usually programmed for exactly one task, which then has to be executed again and again. If you only want one run of the program, you can simply make the robot wait at the end of the loop for a very long time.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">create a new global variable</li><li class="typcn typcn-minus">delete the global variable</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable</li><li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«, »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li><li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial value of the variable.</li>
-</ul></div><div id="robActions_serial_print" class="help beginner"><h3 id="BlockdescriptionsenseBox-»ShowonSerialMonitor...«">»Show on Serial Monitor ... «</h3><p>With this block you can send a text via serial port to your computer. Your senseBox must be connected to your computer via USB. You can read how to install a Serial Monitor here.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, text you want to send to the connected computer.</li>
-</ul></div><div id="robActions_display_text_i2c" class="help beginner"><h3 id="BlockdescriptionsenseBox-»OLEDDisplayI²C...showtext...«">»OLED Display I²C ... show text ... «</h3><p>With this block you can display a text on the OLED display. You have to connect the OLED display to one of the »I²C ports« of your senseBox.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, text you want to display on the display.</li><li class="typcn typcn-arrow-left">Number, column in which the text should be displayed. Number between 0 and 100.</li><li class="typcn typcn-arrow-left">Number, line in which the text is to be displayed. Number between 0 and 50.</li>
-</ul></div><div id="robActions_display_clear_i2c" class="help beginner"><h3 id="BlockdescriptionsenseBox-»ClearOLEDDisplayI²C«">»Clear OLED Display I²C «</h3><p>With this block you can delete the connected display, i.e. reset it.</p></div><div id="robActions_play_tone" class="help beginner"><br><h3 id="BlockdescriptionsenseBox-»PlayfrequencyHz...durationms...«">»Play frequency Hz ... duration ms ... «</h3><p>With this block you can set a buzzer to play a tone of the selected frequency for the selected time. Be aware though that the human ear can only hear tones with a frequency between 20 and 20000 Hz.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, desired frequency of the tone.</li><li class="typcn typcn-arrow-left">Number, duration for the tone to be played for in milliseconds.</li>
-</ul></div><div id="robActions_brickLight_on" class="help beginner"><h3 id="BlockdescriptionsenseBox-»TurnLED...«">»Turn LED ... «</h3><p>With this block you can control a LED, which is connected to your senseBox.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose the LED you want to control.</li><li class="typcn typcn-arrow-sorted-down">Option, choose between turning the LED on or off.</li>
-</ul><br></div><div id="robActions_led_on" class="help expert"><h3 id="BlockdescriptionsenseBox-»TurnLEDoncolour...«[Expert-block]">»Turn LED on colour ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control a RGB LED that you have connected to your senseBox.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, port or name of the LED you want to control.</li><li class="typcn typcn-arrow-left">Colour, the colour in which your LED should light.</li>
-</ul></div><div id="robActions_led_off" class="help expert"><h3 id="BlockdescriptionsenseBox-»TurnLEDoff«[Expert-block]">»Turn LED off « <span class="typcn typcn-star"></span></h3><p>With this block you can switch off a colour LED that you have connected to your senseBox.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, Port or Name of the LED you want to turn off.</li>
-</ul></div><div id="robActions_sendData" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Senddatato...Phenomenon...«">»Send data to ... Phenomenon ... «</h3><p>With this block you can send your data either via WiFi to "OpenSenseMap" or to your SD card to document these data.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, destination of your data, either OpenSenseMap or your local SD card.</li><li class="typcn typcn-arrow-left">Number, data you want to store or share.</li>
-</ul></div><div id="robActions_plot_clear" class="help expert"><h3 id="BlockdescriptionsenseBox-»Cleartheplot«[Expert-block]">»Clear the plot « <span class="typcn typcn-star"></span></h3><p>With this block you can reset the graph on a display.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, display to be reset.</li>
-</ul></div><div id="robActions_plot_point" class="help expert"><h3 id="BlockdescriptionsenseBox-»Plotapointon...value...attickmark...«[Expert-block]">»Plot a point on ... value ... at tickmark ... « <span class="typcn typcn-star"></span></h3><p>With this block you can draw a point of a graph. The "tickmark" is the x-coordinate and the value is the y-coordinate.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, display on which the point is to be displayed.</li><li class="typcn typcn-arrow-left">Number, value to be displayed. This corresponds to the y-coordinate of the point.</li><li class="typcn typcn-arrow-left">Number, x-coordinate of the point to be displayed.</li>
-</ul></div><div id="robActions_write_pin" class="help expert"><h3 class="auto-cursor-target" id="BlockdescriptionsenseBox-»write...valueactuator...«[Expert-Block]">»write ... value actuator ... « <span class="typcn typcn-star"></span></h3><p>With this block you can control a single pin of your senseBox and apply either a digital or analog value to that pin. If you select digital, either a 3.3V or 0V voltage is applied to the pin, if analog, any value between 0V and 3.3V can be applied.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose whether you want to apply a digital or analoge value to the actuator.</li><li class="typcn typcn-arrow-sorted-down">Option, choose the actuator to apply the voltage to.</li><li class="typcn typcn-arrow-left">Number, choose the voltage that you want to apply. If you chose digital choose either 0 or 1 as a value, if you chose analoge, choose between 0 and 1023 as a value.</li>
-</ul></div><div id="robSensors_out_getSample" class="help expert"><h3 class="auto-cursor-target" id="BlockdescriptionsenseBox-»Get...valuesensor...«[Expert-Block]"><span style="letter-spacing: -0.006em;">»Get ... value sensor ... « </span><span class="typcn typcn-star"></span></h3><p>With this block you can query the value of a connected sensor. You can distinguish between analog and digital sensors. With analog sensors, the robot measures the voltage at the set connection. With a digital sensor, the robot measures whether a limit voltage at the connection has been exceeded or not.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, choose between a digital or analoge value.</li><li class="typcn typcn-arrow-sorted-down">Option, choose the sensor that you want to query.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, either 0 or 1 for a digital value or a number between 0 and 1023 for an analoge value.</li>
-</ul></div><div id="robSensors_key_getSample" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Button..pressed?«">»Button .. pressed? «</h3><p>With this block you can check the state of a key of your senseBox.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, name or port of the button.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">logical value, "true" if the button is pressed, otherwise "false".</li>
-</ul></div><div id="robSensors_light_getSample" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Getlight%lightsensorport...«">»Get light % light sensor port ... «</h3><p>With this block you can query the built-in light sensor of your senseBox. This sensor measures the brightness of the incident light.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, name or port of the light sensor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, measured incidence of light in percent. the higher the number, the brighter the environment.</li>
-</ul></div><div id="robSensors_potentiometer_getSample" class="help beginner"><h3 id="BlockdescriptionsenseBox-»GetvalueVpotentiometerport...«">»Get value V potentiometer port ... «</h3><p>With this block you can measure the voltage of a connected potentiometer.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, name or port of the connected potentiometer.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, measured voltage in volts.</li>
-</ul></div><div id="robSensors_sound_getSample" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Getsound%soundsensorport...«">»Get sound % sound sensor port ... «</h3><p>With this block you can query the built-in sound sensor of your senseBox.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, name or port of the sound sensor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, measured volume in percent. The higher the percentage, the higher the volume.</li>
-</ul></div><div id="robSensors_ultrasonic_getSample" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Getdistancecmultrasonicsensorport...«">»Get distance cm ultrasonic sensor port ... «</h3><p>With this block you can query the ultrasonic sensor of your senseBox. This sensor measures the distance to the next obstacle by emitting ultrasonic waves and measures how long they take to return.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, name or port of the connected sensor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, distance to the next obstacle in centimetres.</li>
-</ul></div><div id="robSensors_humidity_getSample" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Get...humidity/temperaturesensorHDC1080port...«">»Get ... humidity/temperature sensor HDC1080 port ... «</h3><p>With this block you can control the HDC1080 sensor on your senseBox. This sensor can measure both temperature and humidity.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, property to measure. Either temperature or humidity.</li><li class="typcn typcn-arrow-sorted-down">Option, name or port of the connected sensor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, measured temperature in °C or humidity in percent.</li>
-</ul></div><div id="robSensors_temperature_getSample" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Get...temperature/pressuresensorBMP280port...«">»Get ... temperature/pressure sensor BMP280 port ... «</h3><p>With this block you can control the BMP280 sensor. This sensor can measure both temperature and air pressure.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, property to be measured. Either air pressure or temperature.</li><li class="typcn typcn-arrow-sorted-down">Option, name or port of the connected sensor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, temperature in °C and air pressure in Pascal.</li>
-</ul></div><div id="robSensors_lightveml_getSample" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Get...visible/UVlightsensor...«">»Get ... visible/UV light sensor ... «</h3><p>With this block you can check the light/UV sensor of your senseBox. This sensor can measure both visible and UV light.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, selection of the light to be measured.</li><li class="typcn typcn-arrow-sorted-down">Option, name or port of the sensor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, measured luminous intensity in percent.</li>
-</ul></div><div id="robSensors_accelerometer_getSample" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Get...gaccelerometer«">»Get ... g accelerometer «</h3><p>With this block you can query the acceleration sensor of your senseBox. This sensor measures the acceleration of your senseBox in the selected direction.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, axis or direction to be measured.</li><li class="typcn typcn-arrow-sorted-down">Option, name or port of the sensor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, value of the acceleration in the selected direction in relation to the standard earth acceleration.</li>
-</ul></div><div id="robSensors_particle_getSample" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Get...concentrationSDS011particlesensor«">»Get ... concentration SDS011 particle sensor«</h3><p>With this block you can query the particle sensor of your senseBox. The particle sensor can measure either particles with a diameter of 2.5 microns or 10 microns.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, diameter of the particles that you want to measure.</li><li class="typcn typcn-arrow-sorted-down">Option, name or port of the particle sensor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, concentration of the chosen particles in micro gram per cubic metre.</li>
-</ul><br></div><div id="robSensors_gps_getSample" class="help expert"><h3 id="BlockdescriptionsenseBox-»Get...GPSreceiver...«[Expert-Block]">»Get ... GPS receiver ... « <span class="typcn typcn-star"></span></h3><p>With this block you can query a connected GPS receiver. The GPS receiver can measure different values like position, speed and altitude of the receiver.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, value to be measured. You can choose between latitude and longitude, altitude, speed, date and time.</li><li class="typcn typcn-arrow-sorted-down">Option, name or port of the GPS receiver.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, value of the chosen property.</li>
-</ul><br></div><div id="robSensors_environmental_getSample" class="help expert"><h3 id="BlockdescriptionsenseBox-»get...environmentalsensorBME680«[Expert-Block]">»get ... environmental sensor  BME680 « <span class="typcn typcn-star"></span></h3><p>With this block you can query an environmental sensor that you have connected to one of the I²C ports of the senseBox. This sensor can measure a variety of different properties of your environment. These include temperature, humidity, air pressure and air quality.</p><p>The indoor air quality (IAQ) is divided into seven areas. The following applies
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="normalBullet"><strong>IAQ &lt; 50 :  </strong>pure Air, best for your well-being</li><li class="normalBullet"><strong>51 &lt; IAQ &lt; 100 :  </strong>small pollution, no impact on your well-being.</li><li class="normalBullet"><strong>101 &lt; IAQ &lt; 150 :  </strong>lightly polluted, reduction of well-.being possible.</li><li class="normalBullet"><strong>151 &lt; IAQ &lt; 200:  </strong>moderate pollution, more significant impact on your well-being passible.</li><li class="normalBullet"><strong>201 &lt; IAQ &lt; 250 :  </strong>heavy pollution, possible effects include headaches etc.</li><li class="normalBullet"><strong>251 &lt; IAQ &lt; 350 :  </strong>severe pollution, strong negative effects possible.</li><li class="normalBullet"><strong>351 &lt; IAQ: </strong>extrem pollution, strong negative effects possible, leave room immediately. </li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Furthermore, the sensor can determine the equivalent values in CO2 and breathing air from the pollution of the ambient air. These are given in ppm, i.e. Parts Per Million. This describes one gas atom per one million normal air atoms. However, this data is only an estimate, as the sensor cannot measure it directly.</span></p><p>Finally, the sensor can output a calibration value. This shows how accurate the IAQ measurement is. Only if this calibration value returns 3, the measurement is accurate. At the beginning of a measurement of IAQ, the sensor must first be calibrated for about 25 minutes. This is done automatically, but measurements are only accurate after these 25 minutes.</p><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><p>The gas sensor of the environmental sensor cannot be used at the same time as the BMP280 air pressure sensor.</p></div></div><p class="auto-cursor-target"><span style="letter-spacing: 0.0px;">Options:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, select the property you want to measure. You can choose between temperature, air pressure, humidity, air quality (IAQ), calibration value, CO2 equivalent and VOC breathing air equivalent.</li>
-</ul><span style="letter-spacing: 0.0px;">Return value:</span>
-<ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, temperature in °C.</li><li class="typcn typcn-arrow-right">Number, air pressure in hPa.</li><li class="typcn typcn-arrow-right">Number, humidity in %.</li><li class="typcn typcn-arrow-right">Number, indoor air quality (IAQ), number between 0 and 500.</li><li class="typcn typcn-arrow-right">Number, calibration value between 0 and 3.</li><li class="typcn typcn-arrow-right">Number, CO2 equivalent from air pollution, given in Parts Per Million (ppm). </li><li class="typcn typcn-arrow-right">Number, breathing air equivalent of air pollution, given in Parts Per Million (ppm).</li>
-</ul></div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Getvaluemstimer...«">»Get value ms timer ... «</h3><p>With this block you can query the current value of a timer.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, number of the timer you want to query.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, time since the last reset of the timer in milliseconds.</li>
-</ul></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="BlockdescriptionsenseBox-»Resettimer...«">»Reset timer ... «</h3><p>With this block you can reset or restart one of the timers.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, number of the timer you want to reset.</li>
-</ul></div><div id="robControls_if" class="help beginner"><h3 id="BlockdescriptionsenseBox-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="BlockdescriptionsenseBox-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="BlockdescriptionsenseBox-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="BlockdescriptionsenseBox-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="BlockdescriptionsenseBox-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="BlockdescriptionsenseBox-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="BlockdescriptionsenseBox-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="BlockdescriptionsenseBox-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="BlockdescriptionsenseBox-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="BlockdescriptionsenseBox-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="BlockdescriptionsenseBox-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="BlockdescriptionsenseBox-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="BlockdescriptionsenseBox-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="BlockdescriptionsenseBox-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="BlockdescriptionsenseBox-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="BlockdescriptionsenseBox-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="BlockdescriptionsenseBox-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="BlockdescriptionsenseBox-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="BlockdescriptionsenseBox-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="BlockdescriptionsenseBox-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="BlockdescriptionsenseBox-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="BlockdescriptionsenseBox-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="BlockdescriptionsenseBox-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="BlockdescriptionsenseBox-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="BlockdescriptionsenseBox-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsenseBox-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="BlockdescriptionsenseBox-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="BlockdescriptionsenseBox-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="BlockdescriptionsenseBox-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="BlockdescriptionsenseBox-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionsenseBox-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionsenseBox-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="BlockdescriptionsenseBox-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="BlockdescriptionsenseBox-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="BlockdescriptionsenseBox-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsenseBox-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionsenseBox-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="BlockdescriptionsenseBox-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsenseBox-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsenseBox-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsenseBox-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsenseBox-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsenseBox-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsenseBox-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsenseBox-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="BlockdescriptionsenseBox-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockdescriptionsenseBox-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="BlockdescriptionsenseBox-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="BlockdescriptionsenseBox-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="BlockdescriptionsenseBox-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="BlockdescriptionsenseBox-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="BlockdescriptionsenseBox-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="BlockdescriptionsenseBox-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="BlockdescriptionsenseBox-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="BlockdescriptionsenseBox-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="BlockdescriptionsenseBox-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="BlockdescriptionsenseBox-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="BlockdescriptionsenseBox-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="BlockdescriptionsenseBox-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="BlockdescriptionsenseBox-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="BlockdescriptionsenseBox-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start_ardu" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Programstart«"><span style="color: rgb(0,0,0);">»Program
+                    start«</span><span style="color: rgb(0,0,0);"> </span></h3>
+            <p>Each program starts with the »Start« block, which cannot be deleted. The first block you want to use is
+                connected directly to the »Sequence connection« on the »Repeat indefinitely« block.</p>
+            <p>For systems based on an Arduino or similar microcontroller, there is always a »repeat indefinitely« loop
+                connected to the start block, which also cannot be removed. This is due to the fact that such
+                microcontrollers are usually programmed for exactly one task, which then has to be executed again and
+                again. If you only want one run of the program, you can simply make the robot wait at the end of the
+                loop for a very long time.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">create a new global variable</li>
+                <li class="typcn typcn-minus">delete the global variable</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">If global variables have been created:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable, »Number«, »Boolean«, »String«, »Color«,
+                    »Connection«, »List Number«, »List Boolean«, »List String«, »List Connection«</li>
+                <li class="typcn typcn-arrow-left">Value, that corresponds to the variable type. This is the initial
+                    value of the variable.</li>
+            </ul>
+        </div>
+        <div id="robActions_serial_print" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»ShowonSerialMonitor...«">»Show on Serial Monitor ... «</h3>
+            <p>With this block you can send a text via serial port to your computer. Your senseBox must be connected to
+                your computer via USB. You can read how to install a Serial Monitor here.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, text you want to send to the connected computer.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_text_i2c" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»OLEDDisplayI²C...showtext...«">»OLED Display I²C ... show text ... «</h3>
+            <p>With this block you can display a text on the OLED display. You have to connect the OLED display to one
+                of the »I²C ports« of your senseBox.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, text you want to display on the display.</li>
+                <li class="typcn typcn-arrow-left">Number, column in which the text should be displayed. Number between
+                    0 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, line in which the text is to be displayed. Number between 0
+                    and 50.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear_i2c" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»ClearOLEDDisplayI²C«">»Clear OLED Display I²C «</h3>
+            <p>With this block you can delete the connected display, i.e. reset it.</p>
+        </div>
+        <div id="robActions_play_tone" class="help beginner"><br>
+            <h3 id="BlockdescriptionsenseBox-»PlayfrequencyHz...durationms...«">»Play frequency Hz ... duration ms ... «
+            </h3>
+            <p>With this block you can set a buzzer to play a tone of the selected frequency for the selected time. Be
+                aware though that the human ear can only hear tones with a frequency between 20 and 20000 Hz.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, desired frequency of the tone.</li>
+                <li class="typcn typcn-arrow-left">Number, duration for the tone to be played for in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robActions_brickLight_on" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»TurnLED...«">»Turn LED ... «</h3>
+            <p>With this block you can control a LED, which is connected to your senseBox.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the LED you want to control.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose between turning the LED on or off.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_led_on" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»TurnLEDoncolour...«[Expert-block]">»Turn LED on colour ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can control a RGB LED that you have connected to your senseBox.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, port or name of the LED you want to control.</li>
+                <li class="typcn typcn-arrow-left">Colour, the colour in which your LED should light.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_off" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»TurnLEDoff«[Expert-block]">»Turn LED off « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can switch off a colour LED that you have connected to your senseBox.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, Port or Name of the LED you want to turn off.</li>
+            </ul>
+        </div>
+        <div id="robActions_sendData" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Senddatato...Phenomenon...«">»Send data to ... Phenomenon ... «</h3>
+            <p>With this block you can send your data either via WiFi to "OpenSenseMap" or to your SD card to document
+                these data.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, destination of your data, either OpenSenseMap or your
+                    local SD card.</li>
+                <li class="typcn typcn-arrow-left">Number, data you want to store or share.</li>
+            </ul>
+        </div>
+        <div id="robActions_plot_clear" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»Cleartheplot«[Expert-block]">»Clear the plot « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can reset the graph on a display.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, display to be reset.</li>
+            </ul>
+        </div>
+        <div id="robActions_plot_point" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»Plotapointon...value...attickmark...«[Expert-block]">»Plot a point on ...
+                value ... at tickmark ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can draw a point of a graph. The "tickmark" is the x-coordinate and the value is the
+                y-coordinate.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, display on which the point is to be displayed.</li>
+                <li class="typcn typcn-arrow-left">Number, value to be displayed. This corresponds to the y-coordinate
+                    of the point.</li>
+                <li class="typcn typcn-arrow-left">Number, x-coordinate of the point to be displayed.</li>
+            </ul>
+        </div>
+        <div id="robActions_write_pin" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockdescriptionsenseBox-»write...valueactuator...«[Expert-Block]">»write
+                ... value actuator ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can control a single pin of your senseBox and apply either a digital or analog value
+                to that pin. If you select digital, either a 3.3V or 0V voltage is applied to the pin, if analog, any
+                value between 0V and 3.3V can be applied.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose whether you want to apply a digital or analoge
+                    value to the actuator.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the actuator to apply the voltage to.</li>
+                <li class="typcn typcn-arrow-left">Number, choose the voltage that you want to apply. If you chose
+                    digital choose either 0 or 1 as a value, if you chose analoge, choose between 0 and 1023 as a value.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_out_getSample" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockdescriptionsenseBox-»Get...valuesensor...«[Expert-Block]"><span
+                    style="letter-spacing: -0.006em;">»Get ... value sensor ... « </span><span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can query the value of a connected sensor. You can distinguish between analog and
+                digital sensors. With analog sensors, the robot measures the voltage at the set connection. With a
+                digital sensor, the robot measures whether a limit voltage at the connection has been exceeded or not.
+            </p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, choose between a digital or analoge value.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, choose the sensor that you want to query.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, either 0 or 1 for a digital value or a number between 0 and
+                    1023 for an analoge value.</li>
+            </ul>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Button..pressed?«">»Button .. pressed? «</h3>
+            <p>With this block you can check the state of a key of your senseBox.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, name or port of the button.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">logical value, "true" if the button is pressed, otherwise "false".
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_light_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Getlight%lightsensorport...«">»Get light % light sensor port ... «</h3>
+            <p>With this block you can query the built-in light sensor of your senseBox. This sensor measures the
+                brightness of the incident light.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, name or port of the light sensor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, measured incidence of light in percent. the higher the
+                    number, the brighter the environment.</li>
+            </ul>
+        </div>
+        <div id="robSensors_potentiometer_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»GetvalueVpotentiometerport...«">»Get value V potentiometer port ... «</h3>
+            <p>With this block you can measure the voltage of a connected potentiometer.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, name or port of the connected potentiometer.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, measured voltage in volts.</li>
+            </ul>
+        </div>
+        <div id="robSensors_sound_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Getsound%soundsensorport...«">»Get sound % sound sensor port ... «</h3>
+            <p>With this block you can query the built-in sound sensor of your senseBox.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, name or port of the sound sensor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, measured volume in percent. The higher the percentage, the
+                    higher the volume.</li>
+            </ul>
+        </div>
+        <div id="robSensors_ultrasonic_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Getdistancecmultrasonicsensorport...«">»Get distance cm ultrasonic sensor
+                port ... «</h3>
+            <p>With this block you can query the ultrasonic sensor of your senseBox. This sensor measures the distance
+                to the next obstacle by emitting ultrasonic waves and measures how long they take to return.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, name or port of the connected sensor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, distance to the next obstacle in centimetres.</li>
+            </ul>
+        </div>
+        <div id="robSensors_humidity_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Get...humidity/temperaturesensorHDC1080port...«">»Get ...
+                humidity/temperature sensor HDC1080 port ... «</h3>
+            <p>With this block you can control the HDC1080 sensor on your senseBox. This sensor can measure both
+                temperature and humidity.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, property to measure. Either temperature or humidity.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Option, name or port of the connected sensor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, measured temperature in °C or humidity in percent.</li>
+            </ul>
+        </div>
+        <div id="robSensors_temperature_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Get...temperature/pressuresensorBMP280port...«">»Get ...
+                temperature/pressure sensor BMP280 port ... «</h3>
+            <p>With this block you can control the BMP280 sensor. This sensor can measure both temperature and air
+                pressure.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, property to be measured. Either air pressure or
+                    temperature.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, name or port of the connected sensor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, temperature in °C and air pressure in Pascal.</li>
+            </ul>
+        </div>
+        <div id="robSensors_lightveml_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Get...visible/UVlightsensor...«">»Get ... visible/UV light sensor ... «
+            </h3>
+            <p>With this block you can check the light/UV sensor of your senseBox. This sensor can measure both visible
+                and UV light.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, selection of the light to be measured.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, name or port of the sensor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, measured luminous intensity in percent.</li>
+            </ul>
+        </div>
+        <div id="robSensors_accelerometer_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Get...gaccelerometer«">»Get ... g accelerometer «</h3>
+            <p>With this block you can query the acceleration sensor of your senseBox. This sensor measures the
+                acceleration of your senseBox in the selected direction.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, axis or direction to be measured.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, name or port of the sensor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, value of the acceleration in the selected direction in
+                    relation to the standard earth acceleration.</li>
+            </ul>
+        </div>
+        <div id="robSensors_particle_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Get...concentrationSDS011particlesensor«">»Get ... concentration SDS011
+                particle sensor«</h3>
+            <p>With this block you can query the particle sensor of your senseBox. The particle sensor can measure
+                either particles with a diameter of 2.5 microns or 10 microns.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, diameter of the particles that you want to measure.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Option, name or port of the particle sensor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, concentration of the chosen particles in micro gram per
+                    cubic metre.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_gps_getSample" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»Get...GPSreceiver...«[Expert-Block]">»Get ... GPS receiver ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With this block you can query a connected GPS receiver. The GPS receiver can measure different values
+                like position, speed and altitude of the receiver.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, value to be measured. You can choose between latitude
+                    and longitude, altitude, speed, date and time.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, name or port of the GPS receiver.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, value of the chosen property.</li>
+            </ul><br>
+        </div>
+        <div id="robSensors_environmental_getSample" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»get...environmentalsensorBME680«[Expert-Block]">»get ... environmental
+                sensor BME680 « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can query an environmental sensor that you have connected to one of the I²C ports of
+                the senseBox. This sensor can measure a variety of different properties of your environment. These
+                include temperature, humidity, air pressure and air quality.</p>
+            <p>The indoor air quality (IAQ) is divided into seven areas. The following applies
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="normalBullet"><strong>IAQ &lt; 50 : </strong>pure Air, best for your well-being</li>
+                <li class="normalBullet"><strong>51 &lt; IAQ &lt; 100 : </strong>small pollution, no impact on your
+                    well-being.</li>
+                <li class="normalBullet"><strong>101 &lt; IAQ &lt; 150 : </strong>lightly polluted, reduction of
+                    well-.being possible.</li>
+                <li class="normalBullet"><strong>151 &lt; IAQ &lt; 200: </strong>moderate pollution, more significant
+                    impact on your well-being passible.</li>
+                <li class="normalBullet"><strong>201 &lt; IAQ &lt; 250 : </strong>heavy pollution, possible effects
+                    include headaches etc.</li>
+                <li class="normalBullet"><strong>251 &lt; IAQ &lt; 350 : </strong>severe pollution, strong negative
+                    effects possible.</li>
+                <li class="normalBullet"><strong>351 &lt; IAQ: </strong>extrem pollution, strong negative effects
+                    possible, leave room immediately. </li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Furthermore, the sensor can determine the equivalent values in CO2
+                    and breathing air from the pollution of the ambient air. These are given in ppm, i.e. Parts Per
+                    Million. This describes one gas atom per one million normal air atoms. However, this data is only an
+                    estimate, as the sensor cannot measure it directly.</span></p>
+            <p>Finally, the sensor can output a calibration value. This shows how accurate the IAQ measurement is. Only
+                if this calibration value returns 3, the measurement is accurate. At the beginning of a measurement of
+                IAQ, the sensor must first be calibrated for about 25 minutes. This is done automatically, but
+                measurements are only accurate after these 25 minutes.</p>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <p>The gas sensor of the environmental sensor cannot be used at the same time as the BMP280 air
+                        pressure sensor.</p>
+                </div>
+            </div>
+            <p class="auto-cursor-target"><span style="letter-spacing: 0.0px;">Options:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, select the property you want to measure. You can
+                    choose between temperature, air pressure, humidity, air quality (IAQ), calibration value, CO2
+                    equivalent and VOC breathing air equivalent.</li>
+            </ul><span style="letter-spacing: 0.0px;">Return value:</span>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, temperature in °C.</li>
+                <li class="typcn typcn-arrow-right">Number, air pressure in hPa.</li>
+                <li class="typcn typcn-arrow-right">Number, humidity in %.</li>
+                <li class="typcn typcn-arrow-right">Number, indoor air quality (IAQ), number between 0 and 500.</li>
+                <li class="typcn typcn-arrow-right">Number, calibration value between 0 and 3.</li>
+                <li class="typcn typcn-arrow-right">Number, CO2 equivalent from air pollution, given in Parts Per
+                    Million (ppm). </li>
+                <li class="typcn typcn-arrow-right">Number, breathing air equivalent of air pollution, given in Parts
+                    Per Million (ppm).</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Getvaluemstimer...«">»Get value ms timer ... «</h3>
+            <p>With this block you can query the current value of a timer.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, number of the timer you want to query.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, time since the last reset of the timer in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»Resettimer...«">»Reset timer ... «</h3>
+            <p>With this block you can reset or restart one of the timers.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, number of the timer you want to reset.</li>
+            </ul>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="BlockdescriptionsenseBox-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»breakout/continuewithnextiterationofloop«[Expert-block]">»break
+                out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="BlockdescriptionsenseBox-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="BlockdescriptionsenseBox-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»mathematicalfunction«[Expert-block]">»mathematical function« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsenseBox-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»constrain«[Expert-block]">»constrain« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionsenseBox-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionsenseBox-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="BlockdescriptionsenseBox-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockdescriptionsenseBox-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="BlockdescriptionsenseBox-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsenseBox-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionsenseBox-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockdescriptionsenseBox-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to
+                Number« <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsenseBox-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsenseBox-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsenseBox-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsenseBox-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsenseBox-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsenseBox-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsenseBox-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="BlockdescriptionsenseBox-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockdescriptionsenseBox-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="BlockdescriptionsenseBox-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="BlockdescriptionsenseBox-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockdescriptionsenseBox-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red
+                ... green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="BlockdescriptionsenseBox-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green
+                ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="BlockdescriptionsenseBox-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ...
+                green ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="BlockdescriptionsenseBox-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function
+                blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function
+                blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»ifblocktobeusedwithinafunction«">»if block to be used within a function«
+            </h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="BlockdescriptionsenseBox-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function
+                with return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="BlockdescriptionsenseBox-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a
+                function with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="BlockdescriptionsenseBox-»functioncallwithoutreturnvalue«">»function call without return value «
+            </h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockdescriptionsenseBox-»functioncallwithreturnvalue«">»function call
+                with return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_wedo_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_wedo_de.html
@@ -1,310 +1,1218 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="ProgrammierBlöckeWeDo-»Programmstart«"><span style="color: rgb(0,0,0);">»Programmstart«</span><span style="color: rgb(0,0,0);"> </span></h3><p>Jedes Programm beginnt mit dem »Programmstart-Block«, welcher nicht gelöscht werden kann. Den ersten Block, den man verwenden möchte, verbindet man direkt mit der  »Sequenzverbindung« am Programmstart-Block. </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li><li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
-</ul><br><p>Wenn globale Variablen erzeugt wurden:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, Name der Variablen.</li><li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li><li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
-</ul></div><div id="robActions_motor_on_for" class="help beginner"><h3 id="ProgrammierBlöckeWeDo-»Motor...TempoZeit«">»Motor ... Tempo Zeit« </h3><p>Der Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Motor </span><span><span style="color: rgb(0,0,0);">... Tempo Zeit</span></span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« s</span></span>etzt das Tempo (Geschwindigkeit) und die Zeit des an den WeDo 2.0 angeschlossenen Motors auf einen neuen Wert.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 (positive Zahlen drehen im Uhrzeigersinn, negative Zahlen drehen gegen den Uhrzeigersinn)</li><li class="typcn typcn-arrow-left">Zahl, gewünschte Dauer in Millisekunden (ms)</li>
-</ul></div><div id="robActions_motor_on" class="help expert"><h3 id="ProgrammierBlöckeWeDo-»Motor...Tempo«[Experten-Block]">»Motor ... Tempo« <span class="typcn typcn-star"></span></h3><p>Der Block »<span style="color: rgb(0,0,255);"><span><span style="color: rgb(0,0,0);">Motor </span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">... Tempo</span></span></span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« </span></span>setzt das Tempo (Geschwindigkeit) des an den WeDo 2.0 angeschlossenen Motors auf einen neuen Wert.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 (positive Zahlen drehen im Uhrzeigersinn, negative Zahlen drehen gegen den Uhrzeigersinn)</li>
-</ul></div><div id="robActions_motor_stop" class="help expert"><h3 id="ProgrammierBlöckeWeDo-»StoppeMotor«[Experten-Block]">»Stoppe Motor« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Stoppe Motor</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« </span></span>schaltet man den an den WeDo 2.0 angeschlossenen Motor aus.  </p></div><div id="robActions_display_text" class="help beginner"><h3 id="ProgrammierBlöckeWeDo-»ZeigeText«"><span style="color: rgb(0,0,0);">»Zeige Text«</span></h3><p>Mit dem Block »Zeige Text« kannst du einen Text im Textausgabefenster der App darstellen. Wenn du diesen Block öfter verwendest, dann werden die Ausgaben untereinander geschrieben. Das Fenster kannst du mit einem Klick auf »OK« schließen.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zeichenkette, anzuzeigender Text.</li>
-</ul></div><div id="robActions_display_clear" class="help beginner"><h3 id="ProgrammierBlöckeWeDo-»LöscheBildschirm«"><span style="color: rgb(0,0,255);"> <span style="color: rgb(0,0,0);">»Lösche Bildschirm«</span><br></span></h3><p>Mit dem Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Lösche Bildschirm</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« kann </span></span>der Inhalt des Textausgabefensters in der App gelöscht werden. Das Fenster kannst du mit einem Klick auf »OK« schließen.</p></div><div id="mbedActions_play_note" class="help beginner"><h3 id="ProgrammierBlöckeWeDo-»Spiele...«">»Spiele ...«</h3><p>Mit dem Block »Spiele ...« bringst du deinen WeDo 2.0 dazu, eine ganze, halbe, viertel, achtel oder sechzehntel Note, abzuspielen.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Länge der Note.</li><li class="typcn typcn-arrow-sorted-down">Note, die gespielt werden soll.</li>
-</ul></div><div id="robActions_play_tone" class="help beginner"><h3 id="ProgrammierBlöckeWeDo-»SpieleFrequenz...Dauer«[Experten-Block]">»Spiele Frequenz ... Dauer« <span class="typcn typcn-star"></span></h3><p>Mit dem Block »Spiele Frequenz ... Dauer« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie lange der Ton gespielt wird) programmieren. Der Ton wird über den eingebauten Lautsprecher deines WeDo 2.0 abgespielt, bis die eingestellte Dauer erreicht ist.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Bitte beachte, dass das menschliche Gehör Frequenzen zwischen ca. 30 Hz bis ca. 15.000 Hz (15 kHz) wahrnehmen kann - je nach Mensch und Alter kann dies unterschiedlich sein.</p></div></div><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, gewünschte Frequenz in Hz (Hertz) eingeben.</li><li class="typcn typcn-arrow-left"> Zahl, gewünschte Dauer des Tons in Millisekunden (ms) eingeben.</li>
-</ul></div><div id="robActions_led_on" class="help beginner"><h3 id="ProgrammierBlöckeWeDo-»SchalteLEDanFarbe...«">»Schalte LED an Farbe...«</h3><p>Mit dem Block »Schalte LED an Farbe...« kann die LED auf deinem WeDo 2.0 in einer bestimmten Farbe, eingeschaltet werden.</p><p>Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Farbe, in der die LED leuchten soll. (Auswahl aus 10 Farben)</li>
-</ul></div><div id="robActions_led_off" class="help beginner"><h3 id="ProgrammierBlöckeWeDo-»SchalteLEDaus«">»Schalte LED aus«</h3><p>Mit dem Block »Schalte LED aus« kannst du die LED auf deinem WeDo 2.0 ausschalten.</p></div><div id="robSensors_key_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeWeDo-»Taste...gedrückt?«">»Taste ... gedrückt?«</h3><p>Mit dem Block »Taste ... gedrückt?« kannst du einem anderen Block »mitteilen«, ob die Taste auf dem WeDo 2.0 gedrückt wurde oder nicht</p><p>. Dieser Block gibt die logischen Werte <em>wahr = gedrückt</em> oder <em>falsch = nicht gedrückt</em> zurück.</p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn die Taste gedrückt ist, sonst »falsch«.</li>
-</ul> </div><div id="robSensors_gyro_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeWeDo-»Kreiselsensor...geneigt?«">»Kreiselsensor ... geneigt?«</h3><p> Mit dem Block »Kreiselsensor … geneigt?« kannst du einem anderen Block »mitteilen«, ob der am WeDo 2.0 angeschlossene Kreiselsensor in einer bestimmte Richtung geneigt ist.</p><p>Befindet sich der Kreiselsensor in der abgefragten Richtung liefert der »Kreiselsensor … geneigt?« Block  »wahr«, sonst »falsch«.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Richtung, die abgefragt werden soll (aufwärts, abwärts, hinten, vorne, nicht, irgendwie).</li>
-</ul>Rückgabewert:
-<ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn er in die Richtung geneigt ist, sonst »falsch«.</li>
-</ul> </div><div id="robSensors_infrared_getSample" class="help beginner"> <h3 id="ProgrammierBlöckeWeDo-»gibAbstandInfrarotsensor«">»gib Abstand Infrarotsensor«</h3><p> Mit dem Block »gib Abstand Infrarotsensor« kannst du einem anderen Block "mitteilen", welchen Abstand der angeschlossene Infrarotsensor misst.  </p><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, 0-10: sehr nah bis weiter weg</li>
-</ul> </div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="ProgrammierBlöckeWeDo-»gibWertZeitgeber«">»gib Wert Zeitgeber«</h3><p>Mit dem Block »Gib Wert Zeitgeber« kannst du einem anderen Block den aktuellen Stand des internen Zeitgebers in Millisekunden »mitteilen«. Der Zeitgeber wird automatisch mit dem Beginn eines Programms gestartet.</p><p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, aktueller Wert des Zeitgebers in Millisekunden, die seit dem Programmstart oder dem letzten Zurücksetzen des Zeitgebers vergangen sind.</li>
-</ul></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="ProgrammierBlöckeWeDo-»SetzeZeitgeberzurück«">»Setze Zeitgeber zurück«</h3><p> Mit dem Block »Setze Zeitgeber 1 zurück« kannst du den eingebauten Zeitgeber auf den Wert 0 zurücksetzen.</p></div><div id="robControls_if" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wennmache«">»Wenn mache«</h3><p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch), wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert.</p><p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wennmachesonst«">»Wenn mache sonst«</h3><p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als Eingabewert. Falls die Bedingung  erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke) ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind, wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p><p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Bedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »wahr« ist.</li><li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung »falsch« ist.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner notWedo"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«</h3><p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch »Endlosschleife« genannt.</p><p style="text-align: left;">Eingaben:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_repeat_ext" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wiederholenmal«">»Wiederhole n mal«</h3><p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Nur ganzzahlige Werte können eingegeben werden.</p></div></div><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole solange/bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden, werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb wird dieser Block auch »bedingte Schleife« genannt.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu bestimmen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_forEach" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»FürWertausderListe«[Experten-Block]">»Für Wert aus der Liste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den enthaltenen Blöcken verwendet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer Wert«, »Farbe«, »Verbindung«</li><li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente übergeben werden.</li><li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block, solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li><li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li><li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li><li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">»Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden. Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende der Schleife ignoriert.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der nächsten Iteration der Schleife fortfahren«.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammierBlöckeWeDo-»Wartebis...«">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="robControls_wait_time" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wartems...«">»Warte ms ... «</h3><p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen. Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wartebis...«.1">»Warte bis ... «</h3><p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte bis«-Blocks erfüllt ist.</p><p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li><li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li><li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Vergleiche«">»Vergleiche«</h3><p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe, logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische Wert »wahr« zurückgegeben, sonst »falsch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li><li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li><li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_operation" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»und/oder«">»und/oder«</h3><p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li><li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
-</ul><br></div><div id="logic_negate" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»nicht«[Experten-Block]">»nicht« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
-</ul><br></div><div id="logic_boolean" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»wahr/falsch«">»wahr/falsch«</h3><p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder »falsch« an einen anderen Block übermitteln.</p><p style="text-align: left;"> Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert.</li>
-</ul><br></div><div id="logic_null" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»null«[Experten-Block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist. Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist, wird der Anfangswert auf »null« gesetzt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»teste«[Experten-Block]">»teste« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis unterschiedliche Ergebnisse zurückgeben.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird "wahr" angenommen.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li><li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
-</ul><br></div><div id="math_number" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wert«">»Wert«</h3><p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p><p style="text-align: left;"> Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Rechnen«">»Rechnen«</h3><p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren, multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block nutzbar, der eine Zahl als Eingabewert benötigt.</p><p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Zahl</li><li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
-</ul><br></div><div id="math_single" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»MathematischeFunktionen«[Experten-Block]">»Mathematische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische Funktionen berechnet werden.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert, Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion) 10^ (Zehner-Exponent)</li><li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
-</ul><br></div><div id="math_trig" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»TrigonometrischeFunktionen«[Experten-Block]">»Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe Hinweis oben).</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li><li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
-</ul><br></div><div id="math_constant" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Konstanten«[Experten-Block]">»Konstanten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p><p style="text-align: left;">Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist »infinity«.</li>
-</ul><br></div><div id="math_number_property" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Zahleneigenschaft«[Experten-Block]">»Zahleneigenschaft« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«, »negativ«, »teilbar durch«.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li><li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li><li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar durch« erforderlich.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte Zahl die untersuchte Eigenschaft hat.</li>
-</ul><br></div><div id="robMath_change" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen Betrag erhöht.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Zahl.</li>
-</ul></div><div id="math_round" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»runden«[Experten-Block]">»runden« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li><li class="typcn typcn-arrow-left">Zahl</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
-</ul><br></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Listeauswerten«[Experten-Block]">»Liste auswerten« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste vorgenommen werden:</p><ul style="text-align: left;"><li>Summe - alle Werte der Liste werden zusammengezählt</li><li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li><li>Maximalwert - der größte Wert der Liste wird ausgegeben</li><li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li><li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li><li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li><li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li></ul><p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li><li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
-</ul><br></div><div id="math_modulo" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Restvon«[Experten-Block]">»Rest von« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der Division, der nicht mehr durch den Divisor geteilt werden konnte.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li><li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
-</ul><br></div><div id="math_constrain" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Begrenze«[Experten-Block]">»Begrenze« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden. Er erfordert drei Eingabewerte:</p><ol style="text-align: left;"><li>zu prüfender Wert</li><li>untere Grenze</li><li>obere Grenze</li></ol><p style="text-align: left;">Der Rückgabewert ist</p><ul style="text-align: left;"><li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li><li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li><li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li></ul><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li><li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
-</ul><br></div><div id="math_random_int" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»GanzzahligeZufallswerte«[Experten-Block]">»Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte innerhalb selbst gewählter Grenzen erzeugt werden.</p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, untere Grenze</li><li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten Grenzen liegt</li>
-</ul><br></div><div id="math_random_float" class="help expert"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Zufallszahl«[Experten-Block]">»Zufallszahl« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0 bestimmt.</p><p style="text-align: left;">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
-</ul></div><div id="text" class="help beginner notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Text«">»Text«</h3><p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
-</ul><br></div><div id="text_comment" class="help beginner"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Kommentar«">»Kommentar«</h3><p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu sehen sein.  </p><p style="text-align: left;">Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»ErstelleText«[Experten-Block]">»Erstelle Text« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden. Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p><p style="text-align: left;">Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li><li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).</li><li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
-</ul><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
-</ul><br></div><div id="robText_append" class="help expert notWedo notBob3"><h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Textanhängen«[Experten-Block]">»Text anhängen« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem an empfangene Nachrichten eine Signatur angehängt wird.</p><p style="text-align: left;">Eingabemöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li><li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
-</ul></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeWeDo-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw. entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li><li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte gesetzt werden.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
-</ul><br></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeWeDo-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste« <span class="typcn typcn-star"></span></h3><p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen.  </p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder »Verbindung«.</li><li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt. Dieser Wert wird in der Liste wiederholt.</li><li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von gleichen Elementen.</li>
-</ul><br></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeWeDo-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3><p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine leere Liste hat die Länge 0.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeWeDo-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span></h3><p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p><p>Eingabewert
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
-</ul><br></div><div id="robLists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeWeDo-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span class="typcn typcn-star"></span></h3><p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten« Treffer suchen.</li><li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Zahl, die Position, an der das Element in der Liste steht.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeWeDo-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span class="typcn typcn-star"></span></h3><p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.</p><p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p><p>Einstellmöglichkeiten und Eingabewerte
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste, »entferne« entfernt das Element aus der Liste.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left"><p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.</p><p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert. <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses Listenelement reduziert.</li>
-</ul><br></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammierBlöckeWeDo-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span class="typcn typcn-star"></span></h3><p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert ersetzt bzw. es wird ein Wert eingefügt.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das Element, »füge« fügt ein neues Element in die Liste ein.</li><li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von hinten«, »erste«, »letzte« oder »zufälliges« .</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt oder eingefügt wird.</li>
-</ul><br></div><div id="robLists_getSublist" class="help expert  notWedo notBob3"><h3 id="ProgrammierBlöckeWeDo-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span class="typcn typcn-star"></span></h3><p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p><p>Einstellmöglichkeiten und Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li><li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten« oder »vom Anfang«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li><li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder »zum Ende«.</li><li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene Liste.</li>
-</ul><br></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammierBlöckeWeDo-»Farbwahl«">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammierBlöckeWeDo-»Farbwahl«.1">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammierBlöckeWeDo-»Farbwahl«.2">»Farbwahl «</h3><p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p><p>Option:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
-</ul><p class="auto-cursor-target">Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die  ausgewählte Farbe.</li>
-</ul></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierBlöckeWeDo-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, die  Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 class="auto-cursor-target" id="ProgrammierBlöckeWeDo-»FarbemitRot...Grün...Blau...«[Experten-Block]">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 class="auto-cursor-target" id="ProgrammierBlöckeWeDo-»FarbemitRot...Grün...Blau...«[Experten-Block].1">»Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau mischst.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li><li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammierBlöckeWeDo-»SchreibeVariable«">»Schreibe Variable«</h3><p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert übergeben werden.</p><p>Einstellmöglichkeit und Eingabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li><li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
-</ul><br></div><div id="variables_get" class="help beginner"><h3 id="ProgrammierBlöckeWeDo-»LiesVariable«">»Lies Variable«</h3><p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert wurde.</p><p>Einstellmöglichkeit:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-</ul><br></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammierBlöckeWeDo-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale Variablen werden nicht initialisiert.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle diese Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammierBlöckeWeDo-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3><p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als Funktionswert zurückgegeben.</p><p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p><p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p><p>Einstellmöglichkeiten:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li><li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert zugewiesen wird.</li><li class="typcn typcn-minus">Lösche eine lokale Variable.</li><li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«, »Liste Verbindung«.</li><li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.</li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
-</ul> <div class="confluence-information-macro confluence-information-macro-note"><div class="confluence-information-macro-body"><ul><li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im Funktionsnamen sind nicht erlaubt.</li><li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle Werte beim Funktionsaufruf belegt werden.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammierBlöckeWeDo-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb einer Funktion <span class="typcn typcn-star"></span></h3><p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p><h4 id="ProgrammierBlöckeWeDo-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb einer Funktion mit Rückgabewert:</h4><ul><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das Funktionsende erreicht.</li></ul><h4 id="ProgrammierBlöckeWeDo-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert:</h4><ul><li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.</li><li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird beendet.</li><li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li></ul><p>Einstellgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li><li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</span></li>
-</ul><br><p>Rückgabewert:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
-</ul><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammierBlöckeWeDo-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne Rückgabewert « <span class="typcn typcn-star"></span></h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen Wert zurück.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammierBlöckeWeDo-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf mit Rückgabewert «</h3><p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p><p>Eingabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.</li>
-</ul><br><p>Rückgabewerte:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
-</ul><br></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»Programmstart«"><span style="color: rgb(0,0,0);">»Programmstart«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Programmstart-Block«, welcher nicht gelöscht werden kann. Den ersten
+                Block, den man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am
+                Programmstart-Block. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
+                <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
+            </ul><br>
+            <p>Wenn globale Variablen erzeugt wurden:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, Name der Variablen.</li>
+                <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
+                <li class="typcn typcn-arrow-left">Wert, Anfangswert der Variablen.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on_for" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»Motor...TempoZeit«">»Motor ... Tempo Zeit« </h3>
+            <p>Der Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Motor </span><span><span
+                            style="color: rgb(0,0,0);">... Tempo Zeit</span></span></span><span
+                    style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">« s</span></span>etzt das Tempo
+                (Geschwindigkeit) und die Zeit des an den WeDo 2.0 angeschlossenen Motors auf einen neuen Wert.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 (positive Zahlen drehen im
+                    Uhrzeigersinn, negative Zahlen drehen gegen den Uhrzeigersinn)</li>
+                <li class="typcn typcn-arrow-left">Zahl, gewünschte Dauer in Millisekunden (ms)</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on" class="help expert">
+            <h3 id="ProgrammierBlöckeWeDo-»Motor...Tempo«[Experten-Block]">»Motor ... Tempo« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »<span style="color: rgb(0,0,255);"><span><span style="color: rgb(0,0,0);">Motor </span><span
+                            style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">...
+                                Tempo</span></span></span></span><span style="color: rgb(0,0,255);"><span
+                        style="color: rgb(0,0,0);">« </span></span>setzt das Tempo (Geschwindigkeit) des an den WeDo 2.0
+                angeschlossenen Motors auf einen neuen Wert.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 (positive Zahlen drehen im
+                    Uhrzeigersinn, negative Zahlen drehen gegen den Uhrzeigersinn)</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_stop" class="help expert">
+            <h3 id="ProgrammierBlöckeWeDo-»StoppeMotor«[Experten-Block]">»Stoppe Motor« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Stoppe
+                        Motor</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">«
+                    </span></span>schaltet man den an den WeDo 2.0 angeschlossenen Motor aus. </p>
+        </div>
+        <div id="robActions_display_text" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»ZeigeText«"><span style="color: rgb(0,0,0);">»Zeige Text«</span></h3>
+            <p>Mit dem Block »Zeige Text« kannst du einen Text im Textausgabefenster der App darstellen. Wenn du diesen
+                Block öfter verwendest, dann werden die Ausgaben untereinander geschrieben. Das Fenster kannst du mit
+                einem Klick auf »OK« schließen.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, anzuzeigender Text.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»LöscheBildschirm«"><span style="color: rgb(0,0,255);"> <span
+                        style="color: rgb(0,0,0);">»Lösche Bildschirm«</span><br></span></h3>
+            <p>Mit dem Block »<span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">Lösche
+                        Bildschirm</span></span><span style="color: rgb(0,0,255);"><span style="color: rgb(0,0,0);">«
+                        kann </span></span>der Inhalt des Textausgabefensters in der App gelöscht werden. Das Fenster
+                kannst du mit einem Klick auf »OK« schließen.</p>
+        </div>
+        <div id="mbedActions_play_note" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»Spiele...«">»Spiele ...«</h3>
+            <p>Mit dem Block »Spiele ...« bringst du deinen WeDo 2.0 dazu, eine ganze, halbe, viertel, achtel oder
+                sechzehntel Note, abzuspielen.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Länge der Note.</li>
+                <li class="typcn typcn-arrow-sorted-down">Note, die gespielt werden soll.</li>
+            </ul>
+        </div>
+        <div id="robActions_play_tone" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»SpieleFrequenz...Dauer«[Experten-Block]">»Spiele Frequenz ... Dauer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit dem Block »Spiele Frequenz ... Dauer« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie
+                lange der Ton gespielt wird) programmieren. Der Ton wird über den eingebauten Lautsprecher deines WeDo
+                2.0 abgespielt, bis die eingestellte Dauer erreicht ist.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Bitte beachte, dass das menschliche Gehör Frequenzen zwischen ca. 30 Hz bis ca. 15.000 Hz (15
+                        kHz) wahrnehmen kann - je nach Mensch und Alter kann dies unterschiedlich sein.</p>
+                </div>
+            </div>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, gewünschte Frequenz in Hz (Hertz) eingeben.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, gewünschte Dauer des Tons in Millisekunden (ms) eingeben.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_on" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»SchalteLEDanFarbe...«">»Schalte LED an Farbe...«</h3>
+            <p>Mit dem Block »Schalte LED an Farbe...« kann die LED auf deinem WeDo 2.0 in einer bestimmten Farbe,
+                eingeschaltet werden.</p>
+            <p>Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Farbe, in der die LED leuchten soll. (Auswahl aus 10 Farben)</li>
+            </ul>
+        </div>
+        <div id="robActions_led_off" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»SchalteLEDaus«">»Schalte LED aus«</h3>
+            <p>Mit dem Block »Schalte LED aus« kannst du die LED auf deinem WeDo 2.0 ausschalten.</p>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»Taste...gedrückt?«">»Taste ... gedrückt?«</h3>
+            <p>Mit dem Block »Taste ... gedrückt?« kannst du einem anderen Block »mitteilen«, ob die Taste auf dem WeDo
+                2.0 gedrückt wurde oder nicht</p>
+            <p>. Dieser Block gibt die logischen Werte <em>wahr = gedrückt</em> oder <em>falsch = nicht gedrückt</em>
+                zurück.</p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn die Taste gedrückt ist, sonst »falsch«.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_gyro_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»Kreiselsensor...geneigt?«">»Kreiselsensor ... geneigt?«</h3>
+            <p> Mit dem Block »Kreiselsensor … geneigt?« kannst du einem anderen Block »mitteilen«, ob der am WeDo 2.0
+                angeschlossene Kreiselsensor in einer bestimmte Richtung geneigt ist.</p>
+            <p>Befindet sich der Kreiselsensor in der abgefragten Richtung liefert der »Kreiselsensor … geneigt?« Block
+                »wahr«, sonst »falsch«.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Richtung, die abgefragt werden soll (aufwärts, abwärts,
+                    hinten, vorne, nicht, irgendwie).</li>
+            </ul>Rückgabewert:
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert: »wahr«, wenn er in die Richtung geneigt ist, sonst
+                    »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»gibAbstandInfrarotsensor«">»gib Abstand Infrarotsensor«</h3>
+            <p> Mit dem Block »gib Abstand Infrarotsensor« kannst du einem anderen Block "mitteilen", welchen Abstand
+                der angeschlossene Infrarotsensor misst. </p>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, 0-10: sehr nah bis weiter weg</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»gibWertZeitgeber«">»gib Wert Zeitgeber«</h3>
+            <p>Mit dem Block »Gib Wert Zeitgeber« kannst du einem anderen Block den aktuellen Stand des internen
+                Zeitgebers in Millisekunden »mitteilen«. Der Zeitgeber wird automatisch mit dem Beginn eines Programms
+                gestartet.</p>
+            <p><span style="letter-spacing: 0.0px;">Rückgabewert:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, aktueller Wert des Zeitgebers in Millisekunden, die seit dem
+                    Programmstart oder dem letzten Zurücksetzen des Zeitgebers vergangen sind.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»SetzeZeitgeberzurück«">»Setze Zeitgeber zurück«</h3>
+            <p> Mit dem Block »Setze Zeitgeber 1 zurück« kannst du den eingebauten Zeitgeber auf den Wert 0
+                zurücksetzen.</p>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wennmache«">»Wenn mache«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache« kannst du gezielt Aktionen auslösen, die von einer
+                Bedingung abhängen. Der »Wenn mache«-Block benötigt einen logischen Wert als Eingabewert. Falls die
+                Bedingung in »Wenn« erfüllt (wahr) ist, wird der eingefügte Block (oder die Blöcke) ausgeführt. Bei
+                einem verschachtelten »Wenn mache« Block, also wenn eine weitere Unterscheidung eingefügt wurde, wird
+                zuerst die erste »Wenn« Bedingung abgefragt und, falls diese nicht erfüllt ist (Bedingung = falsch),
+                wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung benötigt wieder einen
+                logischen Wert als Eingabewert.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch Anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wennmachesonst«">»Wenn mache sonst«</h3>
+            <p style="text-align: left;">Mit dem Block »Wenn mache sonst« kannst du gezielt Aktionen auslösen, die von
+                einer Bedingung abhängen. Der »Wenn mache sonst«-Block benötigt hierfür einen logischen Wert als
+                Eingabewert. Falls die Bedingung erfüllt (wahr) ist, wird der dort eingefügte Block (oder die Blöcke)
+                ausgeführt, ansonsten (Bedingung nicht erfüllt = falsch) wird der Block (bzw. die Blöcke), der bei
+                »sonst« eingefügt wurde, ausgeführt. Bei einem verschachtelten »Wenn mache sonst« Block, also wenn eine
+                weitere Unterscheidung dazugefügt wurde, wird zuerst die erste »Wenn« Bedingung abgefragt und, falls
+                diese nicht erfüllt ist, wird die zweite »oder wenn« Bedingung geprüft. Auch diese zweite Bedingung
+                benötigt wieder einen logischen Wert als Eingabewert. Nur wenn beide Bedingungen nicht erfüllt sind,
+                wird der Block ausgeführt, der bei »sonst« eingefügt wurde.</p>
+            <p style="text-align: left;">Die Bedingungen können beliebig durch anklicken des »+« Plus-Symbols erweitert
+                und durch das »-« Minus-Symbol wieder bis auf eine einzige Bedingung reduziert werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Bedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Bedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »wahr« ist.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die nur dann ausgeführt werden, wenn die zugehörige Bedingung
+                    »falsch« ist.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner notWedo">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wiederholeunendlichoft«">»Wiederhole unendlich oft«
+            </h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole unendlich oft« kannst du Blöcke endlos von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im »Wiederhole unendlich oft«-Block befinden, werden
+                immer wieder ausgeführt. Die Blöcke werden dabei von oben nach unten ausgeführt. Sobald der letzte Block
+                ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block. Deshalb wird dieser Block auch
+                »Endlosschleife« genannt.</p>
+            <p style="text-align: left;">Eingaben:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wiederholenmal«">»Wiederhole n mal«</h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole n mal« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole n mal« befinden, werden so
+                oft ausgeführt, wie im Eingabefeld eingestellt ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                bis die eingestellte Wiederholungszahl erreicht ist. Deshalb wird dieser Block auch »Schleife« genannt.
+            </p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Nur ganzzahlige Werte können eingegeben werden.</p>
+                </div>
+            </div>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, wie oft die enthaltenen Blöcke wiederholt werden sollen.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wiederholesolange/bis«[Experten-Block]">»Wiederhole
+                solange/bis« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Wiederhole solange/bis« kannst du andere Blöcke beliebig oft von
+                deinem Roboter ausführen lassen. Alle Blöcke, die sich im Block »Wiederhole solange/bis« befinden,
+                werden immer wieder ausgeführt, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Die Blöcke
+                werden dabei von oben nach unten ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das
+                Programm wieder mit dem ersten Block, solange bzw. bis die Bedingung im Eingabefeld erfüllt ist. Deshalb
+                wird dieser Block auch »bedingte Schleife« genannt.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">»solange« oder »bis«, um den Typ der bedingten Wiederholung zu
+                    bestimmen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»FürWertausderListe«[Experten-Block]">»Für Wert aus
+                der Liste« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Für Wert aus der Liste« werden nacheinander alle Werte einer
+                Liste an eine Variable übergeben und können dann in der so genannten Schleife verarbeitet werden. Mit
+                jedem Schleifendurchlauf wird das nächste Element aus der Liste geholt, bis die Liste vollständig
+                abgearbeitet ist. Der Wert des Listenelements wird an die Variable Element gebunden und kann in den
+                enthaltenen Blöcken verwendet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ der Listenelemente, »Zahl«, »Zeichenkette«, »logischer
+                    Wert«, »Farbe«, »Verbindung«</li>
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name, an den nacheinander die Listenelemente
+                    übergeben werden.</li>
+                <li class="typcn typcn-arrow-left">Liste, die Elemente des festgelegten Typs enthält. Wenn die
+                    Listenelemente nicht den richtigen Typ haben, kann die Liste nicht als Eingabewert verwendet werden.
+                </li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Zählevonbis«[Experten-Block]">»Zähle von bis« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zähle von bis« kannst du andere Blöcke mehrfach von deinem
+                Roboter ausführen lassen. Alle Blöcke, die sich im Block »Zähle von bis« befinden, werden so oft
+                ausgeführt, bis die Zählung im Eingabefeld abgearbeitet ist. Die Blöcke werden dabei von oben nach unten
+                ausgeführt. Sobald der letzte Block ausgeführt wurde, beginnt das Programm wieder mit dem ersten Block,
+                solange die Zählbedingung im Eingabefeld erfüllt ist, d.h. der Endwert der Zählung noch nicht erreicht
+                ist. Die Werte der Zählung werden jeweils an die Zählvariable gebunden, deren Name frei eingestellt
+                werden kann. Der Wert der Zählvariablen kann in den Blöcken der Schleife verwendet werden. Der letzte
+                Eingabewert gibt an, in welcher Schrittweite gezählt wird.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, frei wählbarer Name für die Zählvariable.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Anfangswert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Endwert der Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Schrittweite für die Zählschleife.</li>
+                <li class="typcn typcn-arrow-left">Blöcke, die wiederholt ausgeführt werden.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 style="text-align: left;"
+                id="ProgrammierBlöckeWeDo-»DieSchleifeabbrechen/mitdernächstenIterationderSchleifefortfahren«[Experten-Block]">
+                »Die Schleife abbrechen/mit der nächsten Iteration der Schleife fortfahren« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Die Schleife abbrechen/mit der nächsten Iteration der Schleife
+                fortfahren« kann eine Schleife vorzeitig beendet bzw. wieder zum Anfang der Schleife gesprungen werden.
+                Sobald dieser Block in einer Reihe von Blöcken erscheint, werden alle nachfolgenden Blöcke bis zum Ende
+                der Schleife ignoriert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Abbruchverhalten, »Die Schleife abbrechen« oder »mit der
+                    nächsten Iteration der Schleife fortfahren«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeWeDo-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wartems...«">»Warte ms ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
+                du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
+                Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
+                dadurch einen Text in dem Display deines Roboters exakt für diese Zeit anzeigen lassen.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, Wartezeit in Millisekunden.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wartebis...«.1">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Vergleiche«">»Vergleiche«</h3>
+            <p style="text-align: left;">Mit dem Block »Vergleiche« kannst du verschiedene Eingabewerte (Zahl, Farbe,
+                logischer Wert, Text) gleichen Typs miteinander vergleichen. Stimmt der Vergleich, wird der logische
+                Wert »wahr« zurückgegeben, sonst »falsch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Linker Eingabewert für den Vergleich.</li>
+                <li class="typcn typcn-arrow-sorted-down">Vergleich, wähle aus, wie verglichen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Rechter Eingabewert für den Vergleich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»und/oder«">»und/oder«</h3>
+            <p style="text-align: left;">Mit dem Block »und/oder« kannst du logische Werte zueinander in Beziehung
+                setzen. Der »und/oder« Block liefert bei der Einstellung »und« nur dann den logischen Wert »wahr«, wenn
+                beide Eingabewerte des Blocks gleichzeitig »wahr« sind. Bei der Einstellung »oder« genügt es, wenn einer
+                der beiden Eingabewerte »wahr« ist, damit der »und/oder« Block als logischen Wert »wahr« liefert.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Verknüpfung.</li>
+                <li class="typcn typcn-arrow-sorted-down">Wähle die logische Verknüpfung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul><br>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»nicht«[Experten-Block]">»nicht« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »nicht« kannst du einen logischen Wert umkehren. Der logische
+                Wert ergibt sich aus der logischen Umkehrung des Eingabewertes, aus »wahr« wird »falsch« und umgekehrt.
+            </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für die Umkehrung.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, Ergebnis der Umkehrung.</li>
+            </ul><br>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»wahr/falsch«">»wahr/falsch«</h3>
+            <p style="text-align: left;">Mit dem Block »wahr/falsch« kannst du entweder den logischen Wert »wahr« oder
+                »falsch« an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Logischer Wert, wähle den Wert, der ausgegeben werden soll.
+                </li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert.</li>
+            </ul><br>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»null«[Experten-Block]">»null« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »null« ist ein Platzhalter für eine Eingabe, die noch unbestimmt ist.
+                Wenn z.B. eine neue Verbindungsvariable für die Kommunikation erzeugt wird und noch nicht belegt ist,
+                wird der Anfangswert auf »null« gesetzt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »null«.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»teste«[Experten-Block]">»teste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »teste« kannst du einen Test durchführen und je nach Ergebnis
+                unterschiedliche Ergebnisse zurückgeben.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert für den Test; wenn kein Block angegeben wird, wird
+                    "wahr" angenommen.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, der mit einem Block bestimmt werden kann.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert von beliebigem Typ.</li>
+            </ul><br>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Wert«">»Wert«</h3>
+            <p style="text-align: left;">Mit dem Block »Wert« kannst du Zahlen an einen anderen Block übermitteln.</p>
+            <p style="text-align: left;"> Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Rechnen«">»Rechnen«</h3>
+            <p style="text-align: left;">Mit dem Block »Rechnen« kannst du Zahlen addieren, subtrahieren,
+                multiplizieren, dividieren oder potenzieren. Dieser Block ist nur in Verbindung mit einem anderen Block
+                nutzbar, der eine Zahl als Eingabewert benötigt.</p>
+            <p style="text-align: left;"> Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Zahl</li>
+                <li class="typcn typcn-arrow-sorted-down"> Berechnung, wähle einen Operator aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»MathematischeFunktionen«[Experten-Block]">
+                »Mathematische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Mathematische Funktionen« können einige elementare mathematische
+                Funktionen berechnet werden.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Funktion, Quadratwurzel, Absolutwert,
+                    Invertieren, ln (natürlicher Logarithmus), log10 (dekadischer Logarithmus), e^ (Exponentialfunktion)
+                    10^ (Zehner-Exponent)</li>
+                <li class="typcn typcn-arrow-left">Zahl, auf die die mathematische Funktion angewandt wird.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»TrigonometrischeFunktionen«[Experten-Block]">
+                »Trigonometrische Funktionen« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Trigonometrische Funktionen« können Sinus, Cosinus, Tangens und
+                die zugehörigen Umkehrfunktionen berechnet werden. Die Eingabewerte werden im Bogenmaß erwartet (siehe
+                Hinweis oben).</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Trigonometrische Funktion, wähle eine Funktion aus.</li>
+                <li class="typcn typcn-arrow-left">Zahl, im Bogenmaß</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, das Ergebnis der trigonometrischen Berechnung.</li>
+            </ul><br>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Konstanten«[Experten-Block]">»Konstanten« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Konstanten« stellt einige mathematische Konstanten bereit. »π«
+                (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mathematische Konstanten, wähle eine Konstante aus.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Zahl, Wert der mathematischen Konstante. Der Wert von Unendlich ist
+                    »infinity«.</li>
+            </ul><br>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Zahleneigenschaft«[Experten-Block]">
+                »Zahleneigenschaft« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zahleneigenschaft« wird geprüft, ob eine eingegebene Zahl eine
+                bestimmte Eigenschaft aufweist. »gerade«, »ungerade«, »ist Primzahl«, »ganze Zahl«, »positiv«,
+                »negativ«, »teilbar durch«.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die mit einem Block geprüft wird.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahleneigenschaft, wähle, was geprüft werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl; ein zweiter Eingabewert ist nur bei der Wahl von »ist teilbar
+                    durch« erforderlich.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, »wahr« oder »falsch«, je nachdem, ob die geprüfte
+                    Zahl die untersuchte Eigenschaft hat.</li>
+            </ul><br>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Erhöheumx«[Experten-Block]">»Erhöhe um x« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Erhöhe um x« wird der Wert einer numerischen Variable um einen
+                Betrag erhöht.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»runden«[Experten-Block]">»runden« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »runden« können Werte gerundet werden. Beim Runden werden die
+                Nachkommastellen auf 0 gesetzt. Es wird je nach Größe der Nachkommastellen automatisch auf- oder
+                abgerundet. Man kann jedoch auch einstellen, dass stets auf- bzw. stets abgerundet werden soll.</p>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Rundung, wähle, wie gerundet werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, gerundete Ganzzahl</li>
+            </ul><br>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Listeauswerten«[Experten-Block]">»Liste auswerten«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Liste auswerten« können verschiedene Analysen einer Liste
+                vorgenommen werden:</p>
+            <ul style="text-align: left;">
+                <li>Summe - alle Werte der Liste werden zusammengezählt</li>
+                <li>Minimalwert - der kleinste Wert der Liste wird ausgegeben</li>
+                <li>Maximalwert - der größte Wert der Liste wird ausgegeben</li>
+                <li>Mittelwert - aus den Werten der Liste wird der Mittelwert bestimmt</li>
+                <li>Median - der Median (Zentralwert) einer Liste wird ausgegeben</li>
+                <li>Standardabweichung - die Standardabweichung (Varianz) der Listenwerte wird ausgegeben</li>
+                <li>Zufallswert - einer der Listenwerte wird per Zufall gewählt und ausgegeben</li>
+            </ul>
+            <p style="text-align: left;">Einstellmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Art der Listenauswertung</li>
+                <li class="typcn typcn-arrow-left">Liste mit Zahlen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Ergebnis der eingestellten Listenauswertung.</li>
+            </ul><br>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Restvon«[Experten-Block]">»Rest von« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Rest von« führt eine Division durch und liefert den Rest der
+                Division, der nicht mehr durch den Divisor geteilt werden konnte.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die geteilt wird (Dividend)</li>
+                <li class="typcn typcn-arrow-left">Zahl, durch die geteilt wird (Divisor bzw. Teiler)</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Rest der Division</li>
+            </ul><br>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Begrenze«[Experten-Block]">»Begrenze« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Der Block »Begrenze« sorgt dafür, dass Grenzwerte nicht überschritten werden.
+                Er erfordert drei Eingabewerte:</p>
+            <ol style="text-align: left;">
+                <li>zu prüfender Wert</li>
+                <li>untere Grenze</li>
+                <li>obere Grenze</li>
+            </ol>
+            <p style="text-align: left;">Der Rückgabewert ist</p>
+            <ul style="text-align: left;">
+                <li>der zu prüfende Wert, wenn gilt: untere Grenze ≤ zu prüfender Wert ≤ obere Grenze</li>
+                <li>untere Grenze, wenn zu prüfender Wert &lt; untere Grenze</li>
+                <li>obere Grenze, wenn zu prüfender Wert &gt; obere Grenze</li>
+            </ul>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die begrenzt wird.</li>
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze.</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die innerhalb der eingestellten Grenzen liegt.</li>
+            </ul><br>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»GanzzahligeZufallswerte«[Experten-Block]">
+                »Ganzzahlige Zufallswerte« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Ganzzahlige Zufallswerte« können ganzzahlige Zufallswerte
+                innerhalb selbst gewählter Grenzen erzeugt werden.</p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, untere Grenze</li>
+                <li class="typcn typcn-arrow-left">Zahl, obere Grenze</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine ganzzahlige Zufallszahl, die innerhalb der eingestellten
+                    Grenzen liegt</li>
+            </ul><br>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Zufallszahl«[Experten-Block]">»Zufallszahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
+                bestimmt.</p>
+            <p style="text-align: left;">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
+            </ul>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Text«">»Text«</h3>
+            <p style="text-align: left;">Mit dem einfachen »Text«-Block wird ein Stück Text bereitgestellt.</p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Text, bestehend aus beliebigen Zeichen</li>
+            </ul><br>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Kommentar«">»Kommentar«</h3>
+            <p style="text-align: left;">Dokumentiere dein Programm mit diesem Block, damit du und andere es später
+                leichter haben, dein Programm zu verstehen. Dieser Kommentar wird auch im generierten Source Code zu
+                sehen sein. </p>
+            <p style="text-align: left;">Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»ErstelleText«[Experten-Block]">»Erstelle Text«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
+                Eingabewerten zusammengesetzt. Mit dem +-Zeichen können weitere Eingabemöglichkeiten geschaffen werden.
+                Alle Eingaben werden zu einer kontinuierlichen Zeichenkette zusammengefügt. </p>
+            <p style="text-align: left;">Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Weitere Eingabemöglichkeiten bereitstellen.</li>
+                <li class="typcn typcn-minus">Letzte Eingabemöglichkeit entfernen (bei mehr als 2 Eingabemöglichkeiten).
+                </li>
+                <li class="typcn typcn-arrow-left">Beliebiger Wert, Zahl, Text, logischer Wert, Farbe.</li>
+            </ul>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, bestehend aus beliebigen Zeichen.</li>
+            </ul><br>
+        </div>
+        <div id="robText_append" class="help expert notWedo notBob3">
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Textanhängen«[Experten-Block]">»Text anhängen«
+                <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">Mit dem »Text anhängen«-Block können Zeichenketten erweitert werden, z.B. indem
+                an empfangene Nachrichten eine Signatur angehängt wird.</p>
+            <p style="text-align: left;">Eingabemöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
+                <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
+            </ul>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeWeDo-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Der Block »Erzeuge eine leere Liste« erzeugt eine Liste ohne Inhalt. Der Block »Liste« erzeugt eine Liste
+                mit einigen voreingestellten Werten. Mit + und - können weitere Listenelemente am Ende hinzugefügt bzw.
+                entfernt werden. Wenn das letzte Element einer Liste entfernt wurde, liegt eine leere Liste vor.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-plus">Erzeuge ein weiteres Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-minus"> Lösche das Listenelement am Ende der bestehenden Liste.</li>
+                <li class="typcn typcn-arrow-left">Werte, die dem Listentyp entsprechen. Hiermit können Anfangswerte
+                    gesetzt werden.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Leere Liste oder eine Liste mit Elementen gleichen Typs.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeWeDo-»WiederholeElementinListe«[Experten-Block]">»Wiederhole Element in Liste«
+                <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Wiederhole Element in Liste« erzeugt eine Liste mit gleichen Elementen. </p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Typ, »Zahl«, »logischer Wert«, »Zeichenkette«, »Farbe« oder
+                    »Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das mit dem eingestellten Listentyp übereinstimmt.
+                    Dieser Wert wird in der Liste wiederholt.</li>
+                <li class="typcn typcn-arrow-left"> Zahl, die angibt, wie oft der eingestellte Wert wiederholt werden
+                    soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Eine Liste des spezifizierten Typs mit der eingestellten Anzahl von
+                    gleichen Elementen.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeWeDo-»Länge«[Experten-Block]">»Länge« <span class="typcn typcn-star"></span></h3>
+            <p>Der Block »Länge« gibt als Wert die Länge einer Liste zurück, die als Eingabewert angegeben wird. Eine
+                leere Liste hat die Länge 0.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, Anzahl der Listenelemente</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeWeDo-»istleer?«[Experten-Block]">»ist leer?« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>Eine als Eingabewert gegebene Liste wird geprüft, ob sie leer ist.</p>
+            <p>Eingabewert
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logischer Wert, entweder »wahr« oder »falsch«</li>
+            </ul><br>
+        </div>
+        <div id="robLists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeWeDo-»SucheinderListe«[Experten-Block]">»Suche in der Liste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Eine Liste wird durchsucht, ob ein Element darin enthalten ist. Wenn das Element enthalten ist, wird die
+                Listenposition zurückgegeben. Wenn das Element nicht enthalten ist, ist das Ergebnis -1.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die untersucht werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position für den Treffer, entweder »ersten« oder »letzten«
+                    Treffer suchen.</li>
+                <li class="typcn typcn-arrow-left">Wert, der mit den Listentyp übereinstimmt.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Zahl, die Position, an der das Element in der Liste steht.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeWeDo-»NimmListenelement«[Experten-Block]">»Nimm Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block wird auf ein Element einer Liste zugegriffen. Das Element wird gegebenenfalls verändert.
+            </p>
+            <p>Es wird eine Liste als Eingabe übergeben. Danach wird per Drop-Down-Liste spezifiziert, was mit dem
+                Listenelement geschehen soll. Anschließend wird angegeben, in welcher Richtung die Liste durchsucht
+                werden soll, ob von vorn (links), von hinten (rechts) oder zufällig.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »nimm« liest das Element und
+                    lässt es unverändert, »nimm und entferne« liest das Element und entfernt es aus der Liste,
+                    »entferne« entfernt das Element aus der Liste.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »erste«, »letzte« oder »zufälliges«
+                        als Position bestimmt wurde.</p>
+                    <p>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</p>
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Das spezifizierte Listenelement, das an der angegebenen
+                    Listenposition gefunden wurde. »undefined« (undefiniert), wenn die Listenposition nicht existiert.
+                    <br>Bei »entferne« wird kein Wert zurückgegeben; die bearbeitete Liste ist dann um dieses
+                    Listenelement reduziert.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammierBlöckeWeDo-»SetzeListenelement«[Experten-Block]">»Setze Listenelement« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>In einer als Eingabewert übergebenen Liste wird ein näher spezifiziertes Element durch einen neuen Wert
+                ersetzt bzw. es wird ein Wert eingefügt.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Aktion für das gefundene Element: »setze« verändert das
+                    Element, »füge« fügt ein neues Element in die Liste ein.</li>
+                <li class="typcn typcn-arrow-sorted-down">Positionsbestimmung für das gefundene Element: »#te«, »#te von
+                    hinten«, »erste«, »letzte« oder »zufälliges« .</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor
+                    »erste«, »letzte« oder »zufälliges« als Position bestimmt wurde.<br>Beachte: Die Zählung der
+                    Listenpositionen beginnt bei 0.</li>
+                <li class="typcn typcn-arrow-left">Listenelement, das an der zuvor bestimmten Listenposition gesetzt
+                    oder eingefügt wird.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_getSublist" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammierBlöckeWeDo-»ErhalteUnterliste«[Experten-Block]">»Erhalte Unterliste« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>Aus einer als Eingabewert übergebenen Liste wird eine Unterliste erzeugt. In der Unterliste sind alle
+                Elemente enthalten, die den weiteren Spezifikationen dieses Blocks entsprechen.</p>
+            <p>Einstellmöglichkeiten und Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Liste, die bearbeitet werden soll.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Anfang der Unterliste: »von #«, »von # von hinten«
+                    oder »vom Anfang«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »vom
+                    Anfang« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">Position, Ende der Unterliste: »zu #«, »zu # von hinten« oder
+                    »zum Ende«.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Listenposition. Dieser Eingabewert entfällt, wenn zuvor »zum
+                    Ende« als Position bestimmt wurde.<br>Beachte: Die Zählung der Listenpositionen beginnt bei 0.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Liste, Unterliste gleichen Typs wie die als Eingabewert übergebene
+                    Liste.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammierBlöckeWeDo-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammierBlöckeWeDo-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammierBlöckeWeDo-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeWeDo-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün
+                ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeWeDo-»FarbemitRot...Grün...Blau...«[Experten-Block]">
+                »Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeWeDo-»FarbemitRot...Grün...Blau...«[Experten-Block].1">
+                »Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammierBlöckeWeDo-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeWeDo-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Die Eingabewerte werden durch die lokalen Variablen im Funktionsblock festgelegt. Mit
+                dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock erzeugt werden. Lokale
+                Variablen werden nicht initialisiert.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage (siehe unten) eingebaut wird, kann es zu einem
+                vorzeitigen Abbruch der Funktion kommen.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            diese Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeWeDo-Funktionsblockohne/mitEingabe-undmitRückgabewerten[Experten-Block]">
+                Funktionsblock ohne/mit Eingabe- und mit Rückgabewerten <span class="typcn typcn-star"></span></h3>
+            <p>In einem Funktionsblock ohne/mit Eingabe- und mit Rückgabewert wird eine Folge von Anweisungen
+                zusammengefasst. Mit dem »+«-Zeichen können lokale Variablen als Eingabewerte für den Funktionsblock
+                erzeugt werden. Nachdem alle Anweisungen durchlaufen wurden, wird abschließend ein Wert als
+                Funktionswert zurückgegeben.</p>
+            <p>Falls in einen Funktionsblock eine Wenn-Abfrage eingebaut wird, kann es zu einem vorzeitigen Abbruch der
+                Funktion kommen, und es kann ein alternativer Funktionswert zurückgegeben werden.</p>
+            <p>Der Funktionsblock steht nach seiner Definition als zusätzlicher Block in der Kategorie »Funktion« zur
+                Verfügung. Auf diese Weise kann die Lesbarkeit komplexer Programme wesentlich vereinfacht werden.</p>
+            <p>Einstellmöglichkeiten:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Funktionsname, ohne Leer- und Sonderzeichen</li>
+                <li class="typcn typcn-plus">Erzeuge eine lokale Variable, der über den Funktionsaufruf ein Wert
+                    zugewiesen wird.</li>
+                <li class="typcn typcn-minus">Lösche eine lokale Variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Datentyp für den Rückgabewert. »Zahl«, »logischer Wert«,
+                    »Zeichenkette«, »Farbe«, »Verbindung«, »Liste Zahl«, »Liste logischer Wert«, »Liste Zeichenkette«,
+                    »Liste Verbindung«.</li>
+                <li class="typcn typcn-arrow-left">Wert, der dem eingestellten Datentyp des Rückgabewertes entspricht.
+                </li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der im Rückgabeblock berechnet wurde.</li>
+            </ul>
+            <div class="confluence-information-macro confluence-information-macro-note">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>Der Name eines Funktionsblocks muss mit einem Kleinbuchstaben beginnen. Sonderzeichen im
+                            Funktionsnamen sind nicht erlaubt.</li>
+                        <li>Wenn in einem Funktionsblock Eingabewerte (lokale Variablen) definiert werden, müssen alle
+                            Werte beim Funktionsaufruf belegt werden.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeWeDo-Wenn-AbfrageinnerhalbeinerFunktion[Experten-Block]">Wenn-Abfrage innerhalb
+                einer Funktion <span class="typcn typcn-star"></span></h3>
+            <p>Die Wenn-Abfrage innerhalb einer Funktion ist von besonderer Bedeutung. Sobald der Funktionsablauf auf
+                eine Wenn-Abfrage trifft, wird die Gültigkeit der Bedingung geprüft.</p>
+            <h4 id="ProgrammierBlöckeWeDo-Wenn-AbfrageinnerhalbeinerFunktionmitRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion mit Rückgabewert:</h4>
+            <ul>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet. Der zweite übergebene Wert wird als Funktionswert zurückgegeben. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird nicht weiter berücksichtig. Der Rückgabewert-Typ wird durch
+                    den Typ des Rückgabewerts der umgebenden Funktion festgelegt.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt. Ein eventuell mit der
+                    Funktion definierter Rückgabewert wird als Funktionswert zurückgegeben, wenn der Funktionsablauf das
+                    Funktionsende erreicht.</li>
+            </ul>
+            <h4 id="ProgrammierBlöckeWeDo-Wenn-AbfrageinnerhalbeinerFunktionohneRückgabewert:">Wenn-Abfrage innerhalb
+                einer Funktion ohne Rückgabewert:</h4>
+            <ul>
+                <li>Eine Wenn-Abfrage innerhalb einer Funktion ohne Rückgabewert hat nur die Bedingung als Eingabewert.
+                </li>
+                <li>Wenn die Bedingung erfüllt ist, wird der weitere Funktionsablauf ignoriert und die Funktion wird
+                    beendet.</li>
+                <li>Wenn die Bedingung nicht erfüllt ist, wird der Funktionsablauf fortgesetzt.</li>
+            </ul>
+            <p>Einstellgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Logischer Wert, der aus einer Bedingung bestimmt wird.</li>
+                <li class="typcn typcn-arrow-left"><span>Wert, dessen Typ am Ende des Funktionsblock eingestellt
+                        ist.</span></li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
+            </ul><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammierBlöckeWeDo-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne
+                Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeWeDo-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf
+                mit Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>

--- a/OpenRobertaServer/staticResources/help/progHelp_wedo_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_wedo_en.html
@@ -1,327 +1,1209 @@
-<head><title></title><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div id="helpContent"><div id="robControls_start" class="help beginner"><h3 id="ProgrammingblocksWeDo-»Start«">»Start«</h3><p>Each program starts with the »Program start block«, which cannot be deleted. The first block to be used is connected directly to the »Sequence connection« on the program start block.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Create a new global variable.</li><li class="typcn typcn-minus">Remove the global variable.</li>
-</ul><p class="auto-cursor-target">If global variables were created:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Text, name of the variable.</li><li class="typcn typcn-arrow-sorted-down">Type of the variable.</li><li class="typcn typcn-arrow-left">Value, initial value of the variable.</li>
-</ul></div><div id="robActions_motor_on_for" class="help beginner"><h3 id="ProgrammingblocksWeDo-»Motor...Speed...time...«">»Motor ... Speed ... time ... «</h3><p>This blocks sets the speed of the connected motor to the given speed for the designated time.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, between -100 and 100 to control the speed and direction of the motor</li><li class="typcn typcn-arrow-left">Number, time in milliseconds. 1000 milliseconds equal 1 second</li>
-</ul></div><div id="robActions_motor_on" class="help expert"><h3 id="ProgrammingblocksWeDo-»Motor...Speed...«[Expert-Block]">» Motor ... Speed ... « <span class="typcn typcn-star"></span></h3><p>This blocks controlls the speed of the conneted motor.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, between -100 and 100, controlls the speed and direction of the motor.</li>
-</ul></div><div id="robActions_motor_stop" class="help expert"><h3 id="ProgrammingblocksWeDo-»StopMotor...«[Expert-Block]">»Stop Motor ...  « <span class="typcn typcn-star"></span></h3><p>This block stops the conneted motor instantaneously.</p></div><div id="robActions_display_text" class="help beginner"><h3 id="ProgrammingblocksWeDo-»Showtext...«">»Show text ...  «</h3><p>With this block you can show any text in the WeDo-App. Each use of this block will print the text into a new line, so you don't have to worry about spacing.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, text that you want to show in the app.</li>
-</ul></div><div id="robActions_display_clear" class="help beginner"><h3 id="ProgrammingblocksWeDo-»ClearScreen«">»Clear Screen «</h3><p>This block clears the text-window of your WeDo-App. Once it is empty you can close it by clicking "Ok".</p></div><div id="mbedActions_play_note" class="help beginner"><h3 id="ProgrammingblocksWeDo-»Play...note...«">»Play ... note ... «</h3><p>With this block you can make your WeDo play a certain note for a period of a time.</p><p>Option:</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Length of the note, from whole to a sixteenth.</li><li class="typcn typcn-arrow-sorted-down">Note, that you want your WeDo to play.</li>
-</ul></div><div id="robActions_play_tone" class="help expert"><h3 id="ProgrammingblocksWeDo-»Playfrequency...time...«[Expert-Block]">»Play frequency ... time ... « <span class="typcn typcn-star"></span></h3><p>This block makes your WeDo play a certain frequency for a time.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>The human ear can only register frequencies between 30 and 15000 Hz (Hertz). This may vary from person to person and from age to age.</p></div></div><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, Frequency of the note that you want your WeDo to play. Between 20 and 15000</li><li class="typcn typcn-arrow-left">Number, Time you want the note to be played for.</li>
-</ul></div><div id="robActions_led_on" class="help beginner"><h3 id="ProgrammingblocksWeDo-»TurnLEDon«">»Turn LED on «</h3><p>With this block you can control the LED of your WeDo and change it's colour.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Colour, that you want the LED to be in (Choice of 10).</li>
-</ul></div><div id="robActions_led_off" class="help beginner"><h3 id="ProgrammingblocksWeDo-»TurnLEDoff«">»Turn LED off «</h3><p>This block turns the LED of your WeDo off.</p></div><div id="robSensors_key_getSample" class="help beginner"><h3 id="ProgrammingblocksWeDo-»Buttonpressed?«">»Button pressed ?«</h3><p>This block checks whether the WeDo's button is currently beeing pressed. It then returns a logical value to he next block.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logical value, "true" if the button is pressed, "false" otherwise.</li>
-</ul></div><div id="robSensors_gyro_getSample" class="help beginner"><h3 id="ProgrammingblocksWeDo-»Gyroscopetilted«">»Gyroscope tilted «</h3><p>This block uses the build-in gyroscope of the WeDo to check the robots orientation. It then return "true" of "false", depending on whether the robot is tilted into the specified direction.</p><p>Options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Direction, specify the direction you want the robot to check for, so e.g. left or right.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Logical value, "true" if the robot is tilted in that direction, "false" otherwise.</li>
-</ul></div><div id="robSensors_infrared_getSample" class="help beginner"><h3 id="ProgrammingblocksWeDo-»GetdistanceInfrared«">»Get distance Infrared «</h3><p>This sensor uses infrared-light to check the distance to the nearest objekt. Be aware that the robot can only measure the distance of the direction the sensor is facing.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, between 0 and 10, 0 for very close, 10 for far away</li>
-</ul></div><div id="robSensors_timer_getSample" class="help beginner"><h3 id="ProgrammingblocksWeDo-»getvaluetimer«">»get value timer «</h3><p>With this block you can get the value of the timer, which gets started automatically at program start.</p><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, current value of the chosen timer in milli-seconds since start of the program or the last reset.</li>
-</ul></div><div id="robSensors_timer_reset" class="help beginner"><h3 id="ProgrammingblocksWeDo-»Resettimer1«">»Reset timer 1 «</h3><p>With this block you can reset the value of the build-in timer to 0.</p></div><div id="robControls_if" class="help beginner"><h3 id="ProgrammingblocksWeDo-»ifdo«">»if do«<strong><br></strong></h3><p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do« block therefore requires a logical value as an input parameter, the condition. Only if the condition of the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false), the second »else if« condition will be checked. Also this second condition requires a logical value as an input parameter.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional condition.</li><li class="typcn typcn-minus">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be executed</li>
-</ul></div><div id="robControls_ifElse" class="help beginner"><h3 id="ProgrammingblocksWeDo-»ifdoelse«">»if do else«</h3><p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if do then« block therefore requires a logical value as an input parameter. If the condition in »if« is true the  inserted block will be executed, otherwise (condition is not fulfilled = false) the block connected to the »else« statement will be executed. In a nested »if do else« block with further distinctions added, the first  »if« condition is queried. If it is not true, the second condition »else if«  is checked. Also the second condition requires a logical value as an input parameter. Only when both conditions are not true, the block which is inserted at the »else« statement will be executed.</p><p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces the block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Insert an additional if-do-else condition.</li><li class="typcn typcn-minus">Delete the last if-do-else condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates to »true«.</li><li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition evaluates to »false«.</li>
-</ul></div><div id="robControls_loopForever" class="help beginner  notWedo"><h3 id="ProgrammingblocksWeDo-»repeatindefinitely«">»repeat indefinitely«</h3><p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><p>Input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
-</ul><br></div><div id="controls_repeat_ext" class="help beginner"><h3 id="ProgrammingblocksWeDo-»repeatntimes«">»repeat n times«</h3><p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat« block will be executed as often as defined in the entry field. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again. Therefore, this block is also called »loop«.</p><div class="confluence-information-macro confluence-information-macro-information"><div class="confluence-information-macro-body"><p>Only integer values can be entered.</p></div></div><p>Settings and input:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be repeated.</li><li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
-</ul><br></div><div id="robControls_wait_time" class="help beginner"><h3 id="ProgrammingblocksWeDo-»wait«">»wait«</h3><p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your program will then remain for the specified duration at this point. After the specified time the next block will be executed. For example you can display text in the screen of your robot for exactly the time you specified in the »wait« block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
-</ul></div><div id="robControls_wait" class="help beginner"><h3 id="ProgrammingblocksWeDo-»waituntil...«">»wait until ...«</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="robControls_wait_for" class="help beginner"><h3 id="ProgrammingblocksWeDo-»waituntil...«.1">»wait until ... «</h3><p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block. Your program then waits until the condition is true. The »wait until« block you can extended by click on "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-plus">Add a new condition.</li><li class="typcn typcn-pen">Delete the last condition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
-</ul></div><div id="controls_flow_statements" class="help expert"><h3 id="ProgrammingblocksWeDo-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue with next iteration of loop« <span class="typcn typcn-star"></span></h3><p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end of the loop will be ignored.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next iteration«.</li>
-</ul></div><div id="robControls_for" class="help expert"><h3 id="ProgrammingblocksWeDo-»countwithfromto«[Expert-block]">»count with from to« <span class="typcn typcn-star"></span></h3><p>With the block »count with from to« you can run other block as many times as you like. All blocks in the »count with from to« block will be executed as long as the counting is in progress. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the counting is in progress. The last parameter declares the step width for counting.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one after the other to the variable. </li><li class="typcn typcn-arrow-left">Number, initial value of the counter.</li><li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value the loop ends.</li><li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by this amount after every loop cycle.</li><li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
-</ul></div><div id="robControls_forEach" class="help expert  notWedo notBob3"><h3 id="ProgrammingblocksWeDo-»foreachiteminlist«[Expert-block]">»for each item in list« <span class="typcn typcn-star"></span></h3><p>With the block »for each item in list« all list items will successively be bound to a variable. The variable can be used within the loop. With each loop cycle the next item of the list will be bound until all list elements have been processed.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«, »Colour«, »Connection«</li><li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the other to the variable.</li><li class="typcn typcn-arrow-left">List  that contains elements of the desired type. If the list elements are not of the correct type then the list will not fit to the input slot.</li><li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the list.</li>
-</ul></div><div id="controls_whileUntil" class="help expert"><h3 id="ProgrammingblocksWeDo-»repeatwhile/until«[Expert-block]">»repeat while/until« <span class="typcn typcn-star"></span></h3><p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the »repeat while/until« block will be executed as long as the condition in the entry field is true. The blocks are applied sequentially from top to bottom. Once the last block has been executed, the program repeats with the first block again if the condition is still true. Therefore, this block is also called »conditional loop«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the conditional repetition.</li><li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li><li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to »true«. </li>
-</ul></div><div id="logic_compare" class="help beginner"><h3 id="ProgrammingblocksWeDo-»comparison«">»comparison«</h3><p>With the block »comparison« you can compare different parameters of the same type (number, color, logical value, text). This block can only be used in conjunction with another block which requires a logical value as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Value for the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li><li class="typcn typcn-arrow-left">Value for the right hand side.</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_operation" class="help beginner"><h3 id="ProgrammingblocksWeDo-»and/or«">»and/or«</h3><p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return true.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li><li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li><li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
-</ul></div><div id="logic_boolean" class="help beginner"><h3 id="ProgrammingblocksWeDo-»true/false«">»true/false«</h3><p>With the block »true/false« you can return either the logical value »true« or »false« to another block.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
-</ul></div><div id="logic_negate" class="help expert"><h3 id="ProgrammingblocksWeDo-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3><p>Using the »not« lets you invert a logical value and pass this value to another block.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
-</ul></div><div id="logic_ternary" class="help expert notWedo"><h3 id="ProgrammingblocksWeDo-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3><p>Using the »test« block will perform a test and returns a value which depends on the test result.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be assumed.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li><li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
-</ul></div><div id="logic_null" class="help expert"><h3 id="ProgrammingblocksWeDo-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3><p style="text-align: left;">The block »null« is a place holder for an input value that is not yet specified. If for instance a new connection variable has been created and is not yet bound, the initial value of this connection will be set to »null«.</p><p style="text-align: left;">Return value::
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
-</ul></div><div id="math_number" class="help beginner"><h3 id="ProgrammingblocksWeDo-»parameter«">»parameter«</h3><p>With the block »parameter« you can send numbers to another block.</p><p>  Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number</li>
-</ul><p style="text-align: left;">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number</li>
-</ul><br></div><div id="math_arithmetic" class="help beginner"><h3 id="ProgrammingblocksWeDo-»calculating«">»calculating«</h3><p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only be used in conjunction with another block which requires a number as an input parameter.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li><li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.</li><li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
-</ul></div><div id="math_single" class="help expert"><h3 id="ProgrammingblocksWeDo-»mathematicalfunction«[Expert-block]">»mathematical function« <span class="typcn typcn-star"></span></h3><p>With the block »mathematical function« some elementary mathematical functions may be calculated. Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm), »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li><li class="typcn typcn-arrow-left">Number to apply the function to.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
-</ul></div><div id="math_trig" class="help expert"><h3 id="ProgrammingblocksWeDo-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span class="typcn typcn-star"></span></h3><p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can be calculated. Input values are expected in radian measure(see hint above).</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li><li class="typcn typcn-arrow-left">Number, in radian measure.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
-</ul></div><div id="math_constant" class="help expert"><h3 id="ProgrammingblocksWeDo-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span></h3><p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e« (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will return »infinity«.</li>
-</ul></div><div id="math_number_property" class="help expert"><h3 id="ProgrammingblocksWeDo-»numberproperty«[Expert-block]">»number property« <span class="typcn typcn-star"></span></h3><p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«, »prime«, »whole«, »positive«, »negative«, »divisible by«.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li><li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li><li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only required for the property »divisible by«.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected property.</li>
-</ul></div><div id="robMath_change" class="help expert"><h3 id="ProgrammingblocksWeDo-»changeby...«[Expert-block]">»change by ... « <span class="typcn typcn-star"></span></h3><p>The block »change by ... « increments a numerical variable by a defined value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to be changed.</li><li class="typcn typcn-arrow-left">Number, given by a block.</li>
-</ul></div><div id="math_round" class="help expert"><h3 id="ProgrammingblocksWeDo-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3><p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on the value of the decimal places whether the block rounds up or down. You may also decide by settings to always round up or down.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li><li class="typcn typcn-arrow-left">Number you want to round.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
-</ul></div><div id="math_on_list" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksWeDo-»listevaluation«[Expert-block]">»list evaluation« <span class="typcn typcn-star"></span></h3><p>With the block »list evaluation« you may analyse a list.</p><p>Modes for list evaluation:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li><li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li><li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li><li class="typcn typcn-arrow-sorted-down">average - average of all list values</li><li class="typcn typcn-arrow-sorted-down">median - median of all list values</li><li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values</li><li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
-</ul><br><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li><li class="typcn typcn-arrow-left">List of numbers</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.</li>
-</ul></div><div id="math_modulo" class="help expert"><h3 id="ProgrammingblocksWeDo-»remainderof«[Expert-block]">»remainder of« <span class="typcn typcn-star"></span></h3><p>The block »remainder of« calculates a divison and returns the remainder of the division.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number to be divided (dividend).</li><li class="typcn typcn-arrow-left">Number, divisor.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, rest of the division.</li>
-</ul></div><div id="math_constrain" class="help expert"><h3 id="ProgrammingblocksWeDo-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span></h3><p>The block »constrain« ensures that given boundaries will not be exceeded.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, that will be constrained.</li><li class="typcn typcn-arrow-left">Number, lower bound.</li><li class="typcn typcn-arrow-left">Number, upper bound.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
-</ul></div><div id="math_random_int" class="help expert"><h3 id="ProgrammingblocksWeDo-»randominteger«[Expert-block]">»random integer« <span class="typcn typcn-star"></span></h3><p>With the block »random integer« you may generate random integer numbers within defined limits</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, lower bound</li><li class="typcn typcn-arrow-left">Number, upper bound</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower bounds.</li>
-</ul></div><div id="math_random_float" class="help expert"><h3 id="ProgrammingblocksWeDo-»randomfraction«[Expert-block]">»random fraction« <span class="typcn typcn-star"></span></h3><p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
-</ul></div><div id="math_cast_toString" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingblocksWeDo-»cast...toString«[Expert-block]">»cast ... to String« <span class="typcn typcn-star"></span></h3><p>This block converts a number into a string containing that number. So for example the number 123 would be converted into the string »123«.</p><p><br>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing this number.</li>
-</ul><br><p><span>Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
-</ul><br></div><div id="math_cast_toChar" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingblocksWeDo-»cast...toChar«[Expert-block]">»cast ... to Char« <span class="typcn typcn-star"></span></h3><p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII character for this number, an empty string is passed on. So for example the number 97 gets converted into the lower-case letter »a«.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII number.</li>
-</ul><br></div><div id="text" class="help beginner notBob3"><h3 id="ProgrammingblocksWeDo-»Text«">»Text«</h3><p>The simple »Text« block creates a little text.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
-</ul></div><div id="text_comment" class="help beginner"><h3 class="auto-cursor-target" id="ProgrammingblocksWeDo-»comment«">»comment«</h3><p>Document your program with this block, so that you and others will find it easier to understand your program later. This comment will also be visible in the generated source code.  </p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
-</ul></div><div id="robText_join" class="help expert notBob3 notFestobionic"><h3 id="ProgrammingblocksWeDo-»createText«[Expert-block]">»create Text« <span class="typcn typcn-star"></span></h3><p>The »create text« block compiles a text from different input parameters. Using the + sign will insert further input slots. All input parameters will be connected one after the other. Essentially the »create text« block converts an arbitrary input value into a text string.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from all input values.</li>
-</ul></div><div id="robtext_append" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksWeDo-»appendText«[Expert-block]">»append Text« <span class="typcn typcn-star"></span></h3><p>The »append text« block will append some string to a given string, for instance to extend a message with a signature.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li><li class="typcn typcn-arrow-left">String, that shall be appended.</li>
-</ul></div><div id="text_cast_string_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingblocksWeDo-»cast...toNumber«[Expert-block]">»cast ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a string into a number if this is possible. So if a string contains only numbers, this block can convert the string into a number. If the block does not contain numbers, this block will pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but then contains other characters that are not numbers, this block will pass only the numbers and stop as soon as the first character is in the string. So, as an example, this block makes the number 52 out of the string »52abcd«.</span></p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
-</ul><br><p><span>Return values:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the converted number.</li>
-</ul><br></div><div id="text_cast_char_toNumber" class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino"><h3 id="ProgrammingblocksWeDo-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number« <span class="typcn typcn-star"></span></h3><p>This block converts a letter or a character from a character string into the corresponding ASCII number. Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted into the number 97.</p><p>Options and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">String, from which a single character is selected.</li><li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the numbering starts at 0.</li>
-</ul><br><p>Return values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0 and 255.</li>
-</ul><br></div><div id="robLists_create_with" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksWeDo-»createlist«">»create list«</h3><p>The block »empty list« creates a list with no content.The block »list« generates a list with some predefined values.</p><p>This block may only be used in the context of a »set variable« block.</p><p>Using »+« or »−« enables you to extend or reduce the list at its end.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«, »Connection«.</li><li class="typcn typcn-plus">Create further list element, append to the end of the list.</li><li class="typcn typcn-minus">Delete list element at the end of the list.</li><li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values is possible.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.</li>
-</ul></div><div id="robLists_repeat" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksWeDo-»repeatelementinlist«">»repeat element in list«</h3><p>The »repeat element in list« block generates a list of equal elements.  </p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or »Connection«.</li><li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value will be repeated in the list.</li><li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of equal elements.</li>
-</ul></div><div id="robLists_length" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksWeDo-»lengthof«">»length of«</h3><p>The »length of« block returns a value which is the length of the list given as parameter. An empty list has a length of 0.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Number, number of list elements.</li>
-</ul><br></div><div id="robLists_isEmpty" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksWeDo-»isempty?«">»is empty?«</h3><p>A list given as parameter will be checked whether it is empty.</p><p>Input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
-</ul></div><div id="roblists_indexOf" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksWeDo-»findinlist«">»find in list«</h3><p>A list is searched for an item. If the item is in the list, the list position will be returned. If the item is not in the list the result is -1.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be examined.</li><li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li><li class="typcn typcn-arrow-left">Value, list item to be found.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>Number, indicating the position where the element was found in the list.</p><p>Note: Counting list positions will start with 0.</p></li>
-</ul></div><div id="robLists_getIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksWeDo-»getlistelement«">»get list element«</h3><p>This block accesses an item of a list. Depending on the settings this item may be altered.</p><p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under consideration.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that is under consideration.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove« just removes the element from the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected as position.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right"><p>List element that has been found at the specified list position; »undefined«, if the list position does not exist.</p><p>With selection of »remove« there is no return value; instead the list will be shortened by this list element.</p></li>
-</ul></div><div id="robLists_setIndex" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksWeDo-»setlistelement«">»set list element«</h3><p>In a list given as input parameter one specified element will be replaced by a new value.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List, that will be changed.</li><li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the element, »insert at« inserts a new element into the list.</li><li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from end«, »first«, »last« or »random« .</li><li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins with 0.</li><li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list position.</li>
-</ul></div><div id="robLists_getSublist" class="help expert notWedo notBob3"><h3 id="ProgrammingblocksWeDo-»getsublist«">»get sublist«</h3><p>From a list given as parameter a sublist will be created. The sublist contains all those elements that match the further specifications of the block.</p><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">List to be examined.</li><li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »first« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li><li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li><li class="typcn typcn-arrow-left"><p>Number, indicating the list position. This input value is not required if »last« has been selected.</p><p>Note: Counting of list positions starts with 0.</p></li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
-</ul></div><div id="mbedColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingblocksWeDo-»Colourpicker«">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope"><h3 id="ProgrammingblocksWeDo-»Colourpicker«.1">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p><span style="letter-spacing: 0.0px;">Return value:</span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="naoColour_picker" class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope"><h3 id="ProgrammingblocksWeDo-»Colourpicker«.2">»Colour picker «</h3><p>With this block you can choose from a pool of predefined colours for your robot.</p><p>options:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">colour, your selected colour.</li>
-</ul><br></div><div id="mbedColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison"><h3 id="ProgrammingblocksWeDo-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ... green ... blue  ... white ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
-</ul><br></div><div id="robColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison"><h3 id="ProgrammingblocksWeDo-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="naoColour_rgb" class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope"><h3 id="ProgrammingblocksWeDo-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green ... blue  ... « <span class="typcn typcn-star"></span></h3><p>With this block you can create your own colour by mixing red, green and blue.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li><li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
-</ul><br></div><div id="variables_set" class="help beginner"><h3 id="ProgrammingblocksWeDo-»setvariable«">»set variable«</h3><p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the value may be assigned by an input connector.</p><p>Settings and input value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li><li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.</li>
-</ul></div><div id="variables_get" class="help beginner"><h3 id="ProgrammingblocksWeDo-»getvariable«">»get variable«</h3><p>Using the block »get variable« returns the value of a variable to another block.The type of the output parameter is equal to the type that has been assigned to the variable in the »start« block.</p><p><span>Settings:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by reading.</li>
-</ul><br><p><span>Return value:<br></span>
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
-</ul><span class="auto-cursor-target"><br></span></div><div id="robProcedures_defnoreturn" class="help expert"><h3 id="ProgrammingblocksWeDo-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function blocks with/without input parameters and no return statement«</h3><p>In a function block with/without input parameter and without return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li><p>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</p></li><li><p>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</p></li></ul></div></div></div><div id="robProcedures_defreturn" class="help expert"><h3 id="ProgrammingblocksWeDo-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function blocks with/without input parameters with return statements«</h3><p>In a function block with/without input parameter and with return parameter a sequence of program statements will be condensed. The input parameters will be determined by the local variables of the function block. Local variables may be generated by using the »+« sign of the function block. Local variables will not be initialized. After running through all the blocks of the function a value will be returned.</p><p>If a function block contains an if-block the function may be terminated before reaching it's end. An alternative value may be returned by the if-block.</p><p>The function block is available in the »Functions« category immediately after its definition. Using function blocks improves the readability of complex programs.</p><p>Settings:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li><li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.</li><li class="typcn typcn-minus">Delete the associated local variable.</li><li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li><li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.</li>
-</ul><br><div class="confluence-information-macro confluence-information-macro-warning"><div class="confluence-information-macro-body"><ul><li>The name of a function block has to start with a lower case letter. Special characters are not allowed in a function block name.</li><li>If the function block defines input parameters (local variables), all the parameter slots have to be occupied when calling the function.</li></ul></div></div></div><div id="robProcedures_ifreturn" class="help expert"><h3 id="ProgrammingblocksWeDo-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3><p>The if statement within a function is of special importance. As the function sequence meets an if statement the validity of the condition will be checked.</p><h4 id="ProgrammingblocksWeDo-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function with return value:</h4><ul><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates. The second input value of the if statement will be returned. A possibly defined return value of the function will be ignored. The return value data type is determined by the return data type of the function definition.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The return value of the function will be returned after reaching the end of the function.</li></ul><h4 id="ProgrammingblocksWeDo-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function with no return value:</h4><ul><li>An if statement within a function without return value has just the if statement as input parameter.</li><li>If the condition evaluates to »true« the rest of the function will be ignored and the function terminates.</li><li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li></ul><p>Settings and input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li><li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><p>Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">Value of the specified data type.</li>
-</ul><br><br></div><div id="robProcedures_callnoreturn" class="help expert"><h3 id="ProgrammingblocksWeDo-»functioncallwithoutreturnvalue«">»function call without return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
-</ul></div><div id="robProcedures_callreturn" class="help expert"><h3 class="auto-cursor-target" id="ProgrammingblocksWeDo-»functioncallwithreturnvalue«">»function call with return value «</h3><p>With this block you can call a previous defined function in your program.</p><p>Input values:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
-</ul><p class="auto-cursor-target">Return value:
-</p><ul style="margin-top: 0; margin-bottom: 10px">
-<li class="typcn typcn-arrow-right">element,  depending on the  return value of the function.</li>
-</ul></div></div></body>
+<head>
+    <title></title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+    <div id="helpContent">
+        <div id="robControls_start" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»Start«">»Start«</h3>
+            <p>Each program starts with the »Program start block«, which cannot be deleted. The first block to be used
+                is connected directly to the »Sequence connection« on the program start block.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Create a new global variable.</li>
+                <li class="typcn typcn-minus">Remove the global variable.</li>
+            </ul>
+            <p class="auto-cursor-target">If global variables were created:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Text, name of the variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Type of the variable.</li>
+                <li class="typcn typcn-arrow-left">Value, initial value of the variable.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on_for" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»Motor...Speed...time...«">»Motor ... Speed ... time ... «</h3>
+            <p>This blocks sets the speed of the connected motor to the given speed for the designated time.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, between -100 and 100 to control the speed and direction of
+                    the motor</li>
+                <li class="typcn typcn-arrow-left">Number, time in milliseconds. 1000 milliseconds equal 1 second</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_on" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»Motor...Speed...«[Expert-Block]">» Motor ... Speed ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This blocks controlls the speed of the conneted motor.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, between -100 and 100, controlls the speed and direction of
+                    the motor.</li>
+            </ul>
+        </div>
+        <div id="robActions_motor_stop" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»StopMotor...«[Expert-Block]">»Stop Motor ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block stops the conneted motor instantaneously.</p>
+        </div>
+        <div id="robActions_display_text" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»Showtext...«">»Show text ... «</h3>
+            <p>With this block you can show any text in the WeDo-App. Each use of this block will print the text into a
+                new line, so you don't have to worry about spacing.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, text that you want to show in the app.</li>
+            </ul>
+        </div>
+        <div id="robActions_display_clear" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»ClearScreen«">»Clear Screen «</h3>
+            <p>This block clears the text-window of your WeDo-App. Once it is empty you can close it by clicking "Ok".
+            </p>
+        </div>
+        <div id="mbedActions_play_note" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»Play...note...«">»Play ... note ... «</h3>
+            <p>With this block you can make your WeDo play a certain note for a period of a time.</p>
+            <p>Option:</p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Length of the note, from whole to a sixteenth.</li>
+                <li class="typcn typcn-arrow-sorted-down">Note, that you want your WeDo to play.</li>
+            </ul>
+        </div>
+        <div id="robActions_play_tone" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»Playfrequency...time...«[Expert-Block]">»Play frequency ... time ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block makes your WeDo play a certain frequency for a time.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>The human ear can only register frequencies between 30 and 15000 Hz (Hertz). This may vary from
+                        person to person and from age to age.</p>
+                </div>
+            </div>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, Frequency of the note that you want your WeDo to play.
+                    Between 20 and 15000</li>
+                <li class="typcn typcn-arrow-left">Number, Time you want the note to be played for.</li>
+            </ul>
+        </div>
+        <div id="robActions_led_on" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»TurnLEDon«">»Turn LED on «</h3>
+            <p>With this block you can control the LED of your WeDo and change it's colour.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Colour, that you want the LED to be in (Choice of 10).</li>
+            </ul>
+        </div>
+        <div id="robActions_led_off" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»TurnLEDoff«">»Turn LED off «</h3>
+            <p>This block turns the LED of your WeDo off.</p>
+        </div>
+        <div id="robSensors_key_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»Buttonpressed?«">»Button pressed ?«</h3>
+            <p>This block checks whether the WeDo's button is currently beeing pressed. It then returns a logical value
+                to he next block.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logical value, "true" if the button is pressed, "false" otherwise.
+                </li>
+            </ul>
+        </div>
+        <div id="robSensors_gyro_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»Gyroscopetilted«">»Gyroscope tilted «</h3>
+            <p>This block uses the build-in gyroscope of the WeDo to check the robots orientation. It then return "true"
+                of "false", depending on whether the robot is tilted into the specified direction.</p>
+            <p>Options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Direction, specify the direction you want the robot to check
+                    for, so e.g. left or right.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Logical value, "true" if the robot is tilted in that direction,
+                    "false" otherwise.</li>
+            </ul>
+        </div>
+        <div id="robSensors_infrared_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»GetdistanceInfrared«">»Get distance Infrared «</h3>
+            <p>This sensor uses infrared-light to check the distance to the nearest objekt. Be aware that the robot can
+                only measure the distance of the direction the sensor is facing.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, between 0 and 10, 0 for very close, 10 for far away</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_getSample" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»getvaluetimer«">»get value timer «</h3>
+            <p>With this block you can get the value of the timer, which gets started automatically at program start.
+            </p>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, current value of the chosen timer in milli-seconds since
+                    start of the program or the last reset.</li>
+            </ul>
+        </div>
+        <div id="robSensors_timer_reset" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»Resettimer1«">»Reset timer 1 «</h3>
+            <p>With this block you can reset the value of the build-in timer to 0.</p>
+        </div>
+        <div id="robControls_if" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»ifdo«">»if do«<strong><br></strong></h3>
+            <p>With the block »if do« you can selectively trigger actions to be executed by your robot. The »if do«
+                block therefore requires a logical value as an input parameter, the condition. Only if the condition of
+                the »if« statement is true, the inserted block will be executed. In a nested »if do« block, if a further
+                distinction was added, the first »if« condition is queried. If it is not fulfilled (condition = false),
+                the second »else if« condition will be checked. Also this second condition requires a logical value as
+                an input parameter.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional condition.</li>
+                <li class="typcn typcn-minus">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed</li>
+            </ul>
+        </div>
+        <div id="robControls_ifElse" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»ifdoelse«">»if do else«</h3>
+            <p>With the block »if do else« you can selectively trigger actions which are executed by your robot. The »if
+                do then« block therefore requires a logical value as an input parameter. If the condition in »if« is
+                true the inserted block will be executed, otherwise (condition is not fulfilled = false) the block
+                connected to the »else« statement will be executed. In a nested »if do else« block with further
+                distinctions added, the first »if« condition is queried. If it is not true, the second condition »else
+                if« is checked. Also the second condition requires a logical value as an input parameter. Only when both
+                conditions are not true, the block which is inserted at the »else« statement will be executed.</p>
+            <p>The conditions may arbitrarily be expanded by clicking the "+" plus symbol. The "-" minus symbol reduces
+                the block.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Insert an additional if-do-else condition.</li>
+                <li class="typcn typcn-minus">Delete the last if-do-else condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Do blocks that will be executed if the according condition evaluates
+                    to »true«.</li>
+                <li class="typcn typcn-arrow-left">Else blocks that will be executed if the according condition
+                    evaluates to »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_loopForever" class="help beginner  notWedo">
+            <h3 id="ProgrammingblocksWeDo-»repeatindefinitely«">»repeat indefinitely«</h3>
+            <p>With the block »repeat indefinitely« you can endlessly run the blocks on your robot. All blocks which are
+                within the »repeat indefinitely« block will be executed endlessly. The blocks are applied sequentially
+                from top to bottom. Once the last block has been executed, the program repeats with the first block
+                again. Therefore, this block is also called »loop«.</p>
+            <p>Input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Blocks to be repeated indefinitely.</li>
+            </ul><br>
+        </div>
+        <div id="controls_repeat_ext" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»repeatntimes«">»repeat n times«</h3>
+            <p>With the block »repeat« you can run other block as many times as you like. All blocks in the »repeat«
+                block will be executed as often as defined in the entry field. The blocks are applied sequentially from
+                top to bottom. Once the last block has been executed, the program repeats with the first block again.
+                Therefore, this block is also called »loop«.</p>
+            <div class="confluence-information-macro confluence-information-macro-information">
+                <div class="confluence-information-macro-body">
+                    <p>Only integer values can be entered.</p>
+                </div>
+            </div>
+            <p>Settings and input:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number that indicates how often the contained blocks will be
+                    repeated.</li>
+                <li class="typcn typcn-arrow-left">Blocks to be repeated as often as defined.</li>
+            </ul><br>
+        </div>
+        <div id="robControls_wait_time" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»wait«">»wait«</h3>
+            <p>With the block »wait« you can "pause" your program at the point where you inserted the »wait« block. Your
+                program will then remain for the specified duration at this point. After the specified time the next
+                block will be executed. For example you can display text in the screen of your robot for exactly the
+                time you specified in the »wait« block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, waiting time in milliseconds.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»waituntil...«">»wait until ...«</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="robControls_wait_for" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»waituntil...«.1">»wait until ... «</h3>
+            <p>With the block »wait until« you can "stop" your program at the point you insert the »wait until« block.
+                Your program then waits until the condition is true. The »wait until« block you can extended by click on
+                "+" symbol. Your program then waits until (at least) one of the condition of your »wait until« block is
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Add a new condition.</li>
+                <li class="typcn typcn-pen">Delete the last condition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="controls_flow_statements" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»breakout/continuewithnextiterationofloop«[Expert-block]">»break out/continue
+                with next iteration of loop« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »break out/continue with next iteration of loop« a loop can be terminated ahead of
+                schedule. As soon as the block is entered within a sequence of blocks, all further blocks up to the end
+                of the loop will be ignored.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of breaking behavior, »break out« or »continue with next
+                    iteration«.</li>
+            </ul>
+        </div>
+        <div id="robControls_for" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»countwithfromto«[Expert-block]">»count with from to« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »count with from to« you can run other block as many times as you like. All blocks in the
+                »count with from to« block will be executed as long as the counting is in progress. The blocks are
+                applied sequentially from top to bottom. Once the last block has been executed, the program repeats with
+                the first block again if the counting is in progress. The last parameter declares the step width for
+                counting.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Variable, name of free choice; numbers of the counter will be delivered one
+                    after the other to the variable. </li>
+                <li class="typcn typcn-arrow-left">Number, initial value of the counter.</li>
+                <li class="typcn typcn-arrow-left">Number, final value of the counter. As the counter exceeds this value
+                    the loop ends.</li>
+                <li class="typcn typcn-arrow-left">Number, defining the increment. The variable value will increase by
+                    this amount after every loop cycle.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be executed in every loop cycle.</li>
+            </ul>
+        </div>
+        <div id="robControls_forEach" class="help expert  notWedo notBob3">
+            <h3 id="ProgrammingblocksWeDo-»foreachiteminlist«[Expert-block]">»for each item in list« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »for each item in list« all list items will successively be bound to a variable. The
+                variable can be used within the loop. With each loop cycle the next item of the list will be bound until
+                all list elements have been processed.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of list elements, »Number«, »String«, »Boolean«,
+                    »Colour«, »Connection«</li>
+                <li class="typcn typcn-pen">Variable, name of free choice; list elements will be delivered one after the
+                    other to the variable.</li>
+                <li class="typcn typcn-arrow-left">List that contains elements of the desired type. If the list elements
+                    are not of the correct type then the list will not fit to the input slot.</li>
+                <li class="typcn typcn-arrow-left">Blocks which will be executed as often as there are elements in the
+                    list.</li>
+            </ul>
+        </div>
+        <div id="controls_whileUntil" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»repeatwhile/until«[Expert-block]">»repeat while/until« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »repeat while/until« you can run other block as many times as you like. All blocks in the
+                »repeat while/until« block will be executed as long as the condition in the entry field is true. The
+                blocks are applied sequentially from top to bottom. Once the last block has been executed, the program
+                repeats with the first block again if the condition is still true. Therefore, this block is also called
+                »conditional loop«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, »while« or »until«, defining the type of the
+                    conditional repetition.</li>
+                <li class="typcn typcn-arrow-left">Boolean value, »true« or »false«.</li>
+                <li class="typcn typcn-arrow-left">Blocks that will be repeated while/until the condition evaluates to
+                    »true«. </li>
+            </ul>
+        </div>
+        <div id="logic_compare" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»comparison«">»comparison«</h3>
+            <p>With the block »comparison« you can compare different parameters of the same type (number, color, logical
+                value, text). This block can only be used in conjunction with another block which requires a logical
+                value as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Value for the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Comparison, select one of =, ≠, &lt;, ≤, &gt;, ≥</li>
+                <li class="typcn typcn-arrow-left">Value for the right hand side.</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_operation" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»and/or«">»and/or«</h3>
+            <p>With the block »and/or« you can interrelate logical values with each other. The »and/or« block with the
+                setting "and" will be true only if both logical parameters are "'true"'. If the block has the setting
+                »or« it is sufficient if one of the two parameters is "true", so that the »and/or« block will return
+                true.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value on the left hand side.</li>
+                <li class="typcn typcn-arrow-sorted-down">Boolean function, »and« or »or«.</li>
+                <li class="typcn typcn-arrow-left">Boolean value on the right hand side.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value »true« or»false«.</li>
+            </ul>
+        </div>
+        <div id="logic_boolean" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»true/false«">»true/false«</h3>
+            <p>With the block »true/false« you can return either the logical value »true« or »false« to another block.
+            </p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, make your choice.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="logic_negate" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»not«[Expert-block]">»not« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »not« lets you invert a logical value and pass this value to another block.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, to be inverted.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«; result of inverting.</li>
+            </ul>
+        </div>
+        <div id="logic_ternary" class="help expert notWedo">
+            <h3 id="ProgrammingblocksWeDo-»test«[Expert-block]">»test« <span class="typcn typcn-star"></span></h3>
+            <p>Using the »test« block will perform a test and returns a value which depends on the test result.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value for the test; if no input value is given "true" will be
+                    assumed.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+                <li class="typcn typcn-arrow-left">Arbitrary value, evaluated by a block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of arbitrary type.</li>
+            </ul>
+        </div>
+        <div id="logic_null" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»null«[Expert-block]">»null« <span class="typcn typcn-star"></span></h3>
+            <p style="text-align: left;">The block »null« is a place holder for an input value that is not yet
+                specified. If for instance a new connection variable has been created and is not yet bound, the initial
+                value of this connection will be set to »null«.</p>
+            <p style="text-align: left;">Return value::
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Boolean value, »null«.</li>
+            </ul>
+        </div>
+        <div id="math_number" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»parameter«">»parameter«</h3>
+            <p>With the block »parameter« you can send numbers to another block.</p>
+            <p> Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number</li>
+            </ul>
+            <p style="text-align: left;">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number</li>
+            </ul><br>
+        </div>
+        <div id="math_arithmetic" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»calculating«">»calculating«</h3>
+            <p>With the block »calculating« you can sum up, subtract, multiply, and divide numbers. This block can only
+                be used in conjunction with another block which requires a number as an input parameter.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left"> Number, first number on the left you want to calculate with.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical operator, choose one of +, −, ×, ÷, ^.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, second number on the right you want to calculate with.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Number, result of the calculation.</li>
+            </ul>
+        </div>
+        <div id="math_single" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»mathematicalfunction«[Expert-block]">»mathematical function« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »mathematical function« some elementary mathematical functions may be calculated.
+                Available functions are »square root«, »absolute«, »invert« (multiply by -1), »ln« (natural logarithm),
+                »log10« (decadic logarithm), »e^« (exponential function), »10^« (base 10 exponent)</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical function, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number to apply the function to.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, result of the function application.</li>
+            </ul>
+        </div>
+        <div id="math_trig" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»trigonometricfunctions«[Expert-block]">»trigonometric functions« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »trigonometric function« sine, cosine, tangent and their respective revers functions can
+                be calculated. Input values are expected in radian measure(see hint above).</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, trigonometric function to choose from.</li>
+                <li class="typcn typcn-arrow-left">Number, in radian measure.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, result of the trigonometric calculation.</li>
+            </ul>
+        </div>
+        <div id="math_constant" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»constant«[Expert-block]">»constant« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>With the »constant« block some mathematical constant values are available: »π« (3,1415...), »e«
+                (2,718...), »φ« (1,618...), »sqrt(2)« (1,414...), »sqrt(½)« (0,7071...), »∞«</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, mathematical constants, choose one.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right"> Number, value of the selected mathematical constant. Infinity will
+                    return »infinity«.</li>
+            </ul>
+        </div>
+        <div id="math_number_property" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»numberproperty«[Expert-block]">»number property« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »number property« you check whether a given number has a specific property: »even«, »odd«,
+                »prime«, »whole«, »positive«, »negative«, »divisible by«.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the property of this input value will be checked.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, number property, choose one.</li>
+                <li class="typcn typcn-arrow-left">Number, evaluated from a block. The second input value is only
+                    required for the property »divisible by«.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean value, »true« or »false«, depending on the selected
+                    property.</li>
+            </ul>
+        </div>
+        <div id="robMath_change" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»changeby...«[Expert-block]">»change by ... « <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »change by ... « increments a numerical variable by a defined value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Variable name, which value is to be changed. Choose the variable to
+                    be changed.</li>
+                <li class="typcn typcn-arrow-left">Number, given by a block.</li>
+            </ul>
+        </div>
+        <div id="math_round" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»round«[Expert-block]">»round« <span class="typcn typcn-star"></span></h3>
+            <p>With the block »round« values may be rounded. Rounding will set the decimal places to 0. It depends on
+                the value of the decimal places whether the block rounds up or down. You may also decide by settings to
+                always round up or down.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Type of rounding, choose a round mode.</li>
+                <li class="typcn typcn-arrow-left">Number you want to round.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rounded whole number, according to the round mode.</li>
+            </ul>
+        </div>
+        <div id="math_on_list" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksWeDo-»listevaluation«[Expert-block]">»list evaluation« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »list evaluation« you may analyse a list.</p>
+            <p>Modes for list evaluation:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">sum - addition of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">min - smallest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">max - largest value in the list</li>
+                <li class="typcn typcn-arrow-sorted-down">average - average of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">median - median of all list values</li>
+                <li class="typcn typcn-arrow-sorted-down">standard deviation - standard deviation of all list values
+                </li>
+                <li class="typcn typcn-arrow-sorted-down">random item - one list value randomly selected</li>
+            </ul><br>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Mode of list evaluation, choose one mode.</li>
+                <li class="typcn typcn-arrow-left">List of numbers</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, calculated according to the selected list evaluation mode.
+                </li>
+            </ul>
+        </div>
+        <div id="math_modulo" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»remainderof«[Expert-block]">»remainder of« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The block »remainder of« calculates a divison and returns the remainder of the division.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number to be divided (dividend).</li>
+                <li class="typcn typcn-arrow-left">Number, divisor.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, rest of the division.</li>
+            </ul>
+        </div>
+        <div id="math_constrain" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»constrain«[Expert-block]">»constrain« <span class="typcn typcn-star"></span>
+            </h3>
+            <p>The block »constrain« ensures that given boundaries will not be exceeded.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, that will be constrained.</li>
+                <li class="typcn typcn-arrow-left">Number, lower bound.</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, constrained by the lower and the upper bound.</li>
+            </ul>
+        </div>
+        <div id="math_random_int" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»randominteger«[Expert-block]">»random integer« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random integer« you may generate random integer numbers within defined limits</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, lower bound</li>
+                <li class="typcn typcn-arrow-left">Number, upper bound</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, a whole random number from within the upper and lower
+                    bounds.</li>
+            </ul>
+        </div>
+        <div id="math_random_float" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»randomfraction«[Expert-block]">»random fraction« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>With the block »random fraction« a random value between 0.0 and 1.0 is calculated.</p>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, positive random value between 0.0 and 1.0.</li>
+            </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingblocksWeDo-»cast...toString«[Expert-block]">»cast ... to String« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a number into a string containing that number. So for example the number 123 would be
+                converted into the string »123«.</p>
+            <p><br>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the number that you want to convert into a String containing
+                    this number.</li>
+            </ul><br>
+            <p><span>Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, the string containing the selected number.</li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingblocksWeDo-»cast...toChar«[Expert-block]">»cast ... to Char« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a single number to the corresponding ASCII letter. If there is no associated ASCII
+                character for this number, an empty string is passed on. So for example the number 97 gets converted
+                into the lower-case letter »a«.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Number, the ASCII code that you want to convert into a character.
+                </li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, a single character that corresponds to the selected ASCII
+                    number.</li>
+            </ul><br>
+        </div>
+        <div id="text" class="help beginner notBob3">
+            <h3 id="ProgrammingblocksWeDo-»Text«">»Text«</h3>
+            <p>The simple »Text« block creates a little text.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="text_comment" class="help beginner">
+            <h3 class="auto-cursor-target" id="ProgrammingblocksWeDo-»comment«">»comment«</h3>
+            <p>Document your program with this block, so that you and others will find it easier to understand your
+                program later. This comment will also be visible in the generated source code. </p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, containing arbitrary characters.</li>
+            </ul>
+        </div>
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
+            <h3 id="ProgrammingblocksWeDo-»createText«[Expert-block]">»create Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »create text« block compiles a text from different input parameters. Using the + sign will insert
+                further input slots. All input parameters will be connected one after the other. Essentially the »create
+                text« block converts an arbitrary input value into a text string.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Arbitrary values [numbers, text, logical values, colours)</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">String, containing arbitrary characters, compiled sequentially from
+                    all input values.</li>
+            </ul>
+        </div>
+        <div id="robtext_append" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksWeDo-»appendText«[Expert-block]">»append Text« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>The »append text« block will append some string to a given string, for instance to extend a message with
+                a signature.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, to which some other text will be appended.</li>
+                <li class="typcn typcn-arrow-left">String, that shall be appended.</li>
+            </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingblocksWeDo-»cast...toNumber«[Expert-block]">»cast ... to Number« <span
+                    class="typcn typcn-star"></span></h3>
+            <p>This block converts a string into a number if this is possible. So if a string contains only numbers,
+                this block can convert the string into a number. If the block does not contain numbers, this block will
+                pass »NaN« when used in th Open Roberta Lab simulation and may have a different <span
+                    style="letter-spacing: 0.0px;">behavior depending on the programming language of the robot you are
+                    currently using. I</span><span style="letter-spacing: 0.0px;">f the string starts with numbers but
+                    then contains other characters that are not numbers, this block will pass only the numbers and stop
+                    as soon as the first character is in the string. So, as an example, this block makes the number 52
+                    out of the string »52abcd«.</span></p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the string you want to convert into a number.</li>
+            </ul><br>
+            <p><span>Return values:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the converted number.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammingblocksWeDo-»cast...atindex...toNumber«[Experten-Block]">»cast ... at index ... to Number«
+                <span class="typcn typcn-star"></span></h3>
+            <p>This block converts a letter or a character from a character string into the corresponding ASCII number.
+                Each character has an associated number in the ASCII table. For example, a lower-case »a« is converted
+                into the number 97.</p>
+            <p>Options and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, from which a single character is selected.</li>
+                <li class="typcn typcn-arrow-left">Number, the digit of the character to be converted. Note that the
+                    numbering starts at 0.</li>
+            </ul><br>
+            <p>Return values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, the ASCII number of to selected character. Number between 0
+                    and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_create_with" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksWeDo-»createlist«">»create list«</h3>
+            <p>The block »empty list« creates a list with no content.The block »list« generates a list with some
+                predefined values.</p>
+            <p>This block may only be used in the context of a »set variable« block.</p>
+            <p>Using »+« or »−« enables you to extend or reduce the list at its end.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »String«, »Boolean«, »Colour«,
+                    »Connection«.</li>
+                <li class="typcn typcn-plus">Create further list element, append to the end of the list.</li>
+                <li class="typcn typcn-minus">Delete list element at the end of the list.</li>
+                <li class="typcn typcn-arrow-left">Values, according to the list type. Here the input of initial values
+                    is possible.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Empty list or list, containing elements of the specified list type.
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_repeat" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksWeDo-»repeatelementinlist«">»repeat element in list«</h3>
+            <p>The »repeat element in list« block generates a list of equal elements. </p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">List type, »Number«, »Boolean«, »String«, »Colour« or
+                    »Connection«.</li>
+                <li class="typcn typcn-arrow-sorted-down">List element, according to the selected list type. This value
+                    will be repeated in the list.</li>
+                <li class="typcn typcn-arrow-left">Number, defining how often the list element will be repeated.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List of the specified list type, containing the specified number of
+                    equal elements.</li>
+            </ul>
+        </div>
+        <div id="robLists_length" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksWeDo-»lengthof«">»length of«</h3>
+            <p>The »length of« block returns a value which is the length of the list given as parameter. An empty list
+                has a length of 0.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Number, number of list elements.</li>
+            </ul><br>
+        </div>
+        <div id="robLists_isEmpty" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksWeDo-»isempty?«">»is empty?«</h3>
+            <p>A list given as parameter will be checked whether it is empty.</p>
+            <p>Input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, evaluated by an appropriate block.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Boolean, either »true« or »false«.</li>
+            </ul>
+        </div>
+        <div id="roblists_indexOf" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksWeDo-»findinlist«">»find in list«</h3>
+            <p>A list is searched for an item. If the item is in the list, the list position will be returned. If the
+                item is not in the list the result is -1.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position of the occurrence, either »first« or »last«.</li>
+                <li class="typcn typcn-arrow-left">Value, list item to be found.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>Number, indicating the position where the element was found in the list.</p>
+                    <p>Note: Counting list positions will start with 0.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_getIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksWeDo-»getlistelement«">»get list element«</h3>
+            <p>This block accesses an item of a list. Depending on the settings this item may be altered.</p>
+            <p>A list is given as parameter. Then a drop-down-list specifies what will happen to the list item under
+                consideration.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that is under consideration.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found: »get« reads the element
+                    and leaves it unchanged, »get and remove« reads the element and removes it from the list, »remove«
+                    just removes the element from the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position of the element found: »#«, »# from end«,
+                    »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first«, »last« or
+                        »random« was selected as position.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">
+                    <p>List element that has been found at the specified list position; »undefined«, if the list
+                        position does not exist.</p>
+                    <p>With selection of »remove« there is no return value; instead the list will be shortened by this
+                        list element.</p>
+                </li>
+            </ul>
+        </div>
+        <div id="robLists_setIndex" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksWeDo-»setlistelement«">»set list element«</h3>
+            <p>In a list given as input parameter one specified element will be replaced by a new value.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List, that will be changed.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, action for the element found; »set« changes the
+                    element, »insert at« inserts a new element into the list.</li>
+                <li class="typcn typcn-arrow-sorted-down">Option, position for the element to be changed: »#«, »# from
+                    end«, »first«, »last« or »random« .</li>
+                <li class="typcn typcn-arrow-left">Number, indicating the list position. This input value is not
+                    required if »first«, »last« or »random« was selected.<br>Note: Counting of list positions begins
+                    with 0.</li>
+                <li class="typcn typcn-arrow-left">List element, that will be set or inserted at the selected list
+                    position.</li>
+            </ul>
+        </div>
+        <div id="robLists_getSublist" class="help expert notWedo notBob3">
+            <h3 id="ProgrammingblocksWeDo-»getsublist«">»get sublist«</h3>
+            <p>From a list given as parameter a sublist will be created. The sublist contains all those elements that
+                match the further specifications of the block.</p>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">List to be examined.</li>
+                <li class="typcn typcn-arrow-sorted-down">Position, start of the sublist: »#«, »# from end« or »first«.
+                </li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »first« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+                <li class="typcn typcn-arrow-left">Position, end of the sublist: »#«, »# from end« or »last«.</li>
+                <li class="typcn typcn-arrow-left">
+                    <p>Number, indicating the list position. This input value is not required if »last« has been
+                        selected.</p>
+                    <p>Note: Counting of list positions starts with 0.</p>
+                </li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">List, a sublist of the same type as the given list.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingblocksWeDo-»Colourpicker«">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingblocksWeDo-»Colourpicker«.1">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p><span style="letter-spacing: 0.0px;">Return value:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="ProgrammingblocksWeDo-»Colourpicker«.2">»Colour picker «</h3>
+            <p>With this block you can choose from a pool of predefined colours for your robot.</p>
+            <p>options:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">option, choose the colour you want to use.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">colour, your selected colour.</li>
+            </ul><br>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="ProgrammingblocksWeDo-»Colourwithred...green...blue...white...«[ExpertBlock]">»Colour with red ...
+                green ... blue ... white ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the brightness of your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 id="ProgrammingblocksWeDo-»Colourwithred...green...blue...«[ExpertBlock]">»Colour with red ... green ...
+                blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 id="ProgrammingblocksWeDo-»Colourwithred...green...blue...«[ExpertBlock].1">»Colour with red ... green
+                ... blue ... « <span class="typcn typcn-star"></span></h3>
+            <p>With this block you can create your own colour by mixing red, green and blue.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">number, the red part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the green part in your color. Value between 0 and 255.</li>
+                <li class="typcn typcn-arrow-left">number, the blue part in your color. Value between 0 and 255.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»setvariable«">»set variable«</h3>
+            <p>Using the block »set variable« will assign a value to a variable. Depending on the variable type the
+                value may be assigned by an input connector.</p>
+            <p>Settings and input value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, which value is to be changed.</li>
+                <li class="typcn typcn-arrow-left">Value, new value for the variable, evaluated from a suitable block.
+                </li>
+            </ul>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="ProgrammingblocksWeDo-»getvariable«">»get variable«</h3>
+            <p>Using the block »get variable« returns the value of a variable to another block.The type of the output
+                parameter is equal to the type that has been assigned to the variable in the »start« block.</p>
+            <p><span>Settings:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, that will be read. The value will not be changed by
+                    reading.</li>
+            </ul><br>
+            <p><span>Return value:<br></span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value, stored in the variable.</li>
+            </ul><span class="auto-cursor-target"><br></span>
+        </div>
+        <div id="robProcedures_defnoreturn" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»Functionblockswith/withoutinputparametersandnoreturnstatement«">»Function
+                blocks with/without input parameters and no return statement«</h3>
+            <p>In a function block with/without input parameter and without return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>
+                            <p>The name of a function block has to start with a lower case letter. Special characters
+                                are not allowed in a function block name.</p>
+                        </li>
+                        <li>
+                            <p>If the function block defines input parameters (local variables), all the parameter slots
+                                have to be occupied when calling the function.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_defreturn" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»Functionblockswith/withoutinputparameterswithreturnstatements«">»Function
+                blocks with/without input parameters with return statements«</h3>
+            <p>In a function block with/without input parameter and with return parameter a sequence of program
+                statements will be condensed. The input parameters will be determined by the local variables of the
+                function block. Local variables may be generated by using the »+« sign of the function block. Local
+                variables will not be initialized. After running through all the blocks of the function a value will be
+                returned.</p>
+            <p>If a function block contains an if-block the function may be terminated before reaching it's end. An
+                alternative value may be returned by the if-block.</p>
+            <p>The function block is available in the »Functions« category immediately after its definition. Using
+                function blocks improves the readability of complex programs.</p>
+            <p>Settings:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-pen">Function name, no special characters and white spaces allowed.</li>
+                <li class="typcn typcn-plus">Generate new local variables, that will be assigned with the function call.
+                </li>
+                <li class="typcn typcn-minus">Delete the associated local variable.</li>
+                <li class="typcn typcn-arrow-sorted-down">Data type for the return value; choose one data type.</li>
+                <li class="typcn typcn-arrow-sorted-down">Block, that returns a value of the defined data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the defined data type, evaluated in an appropriate block.
+                </li>
+            </ul><br>
+            <div class="confluence-information-macro confluence-information-macro-warning">
+                <div class="confluence-information-macro-body">
+                    <ul>
+                        <li>The name of a function block has to start with a lower case letter. Special characters are
+                            not allowed in a function block name.</li>
+                        <li>If the function block defines input parameters (local variables), all the parameter slots
+                            have to be occupied when calling the function.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div id="robProcedures_ifreturn" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»ifblocktobeusedwithinafunction«">»if block to be used within a function«</h3>
+            <p>The if statement within a function is of special importance. As the function sequence meets an if
+                statement the validity of the condition will be checked.</p>
+            <h4 id="ProgrammingblocksWeDo-Ifstatementwithinafunctionwithreturnvalue:">If statement within a function
+                with return value:</h4>
+            <ul>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates. The second input value of the if statement will be returned. A possibly defined return
+                    value of the function will be ignored. The return value data type is determined by the return data
+                    type of the function definition.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued. The
+                    return value of the function will be returned after reaching the end of the function.</li>
+            </ul>
+            <h4 id="ProgrammingblocksWeDo-Ifstatementwithinafunctionwithnoreturnvalue:">If statement within a function
+                with no return value:</h4>
+            <ul>
+                <li>An if statement within a function without return value has just the if statement as input parameter.
+                </li>
+                <li>If the condition evaluates to »true« the rest of the function will be ignored and the function
+                    terminates.</li>
+                <li>If the condition evaluates to »false« the sequence of the function blocks will be continued.</li>
+            </ul>
+            <p>Settings and input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Boolean value, possibly evaluated by a condition.</li>
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br>
+            <p>Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Value of the specified data type.</li>
+            </ul><br><br>
+        </div>
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="ProgrammingblocksWeDo-»functioncallwithoutreturnvalue«">»function call without return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending of the required input value of the function.</li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingblocksWeDo-»functioncallwithreturnvalue«">»function call with
+                return value «</h3>
+            <p>With this block you can call a previous defined function in your program.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">element, depending on the required input value of the function.</li>
+            </ul>
+            <p class="auto-cursor-target">Return value:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">element, depending on the return value of the function.</li>
+            </ul><br>
+        </div>
+    </div>
+</body>


### PR DESCRIPTION

# Description

This pull request closes Issue #1068 by making all block help windows a uniform size. Additionally all helpfiles were formatted using the default VSCode formatter to ensure better readability.

Fixes #1068 

# How Has This Been Tested?

The changes have been tested locally by looking at all block help windows in English and German.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes