### PR TITLE
Issue #1210: add help text for display OLED SSD 1306 for all adruino …

### DIFF
--- a/OpenRobertaServer/staticResources/help/progHelp_arduino_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_arduino_de.html
@@ -149,6 +149,27 @@
                     Roboterkonfiguration angelegt hast.</li>
             </ul>
         </div>
+        <div id="robActions_display_text_oledssd1306i2c" class="help expert">
+            <h3 class="auto-cursor-target"
+                id="ProgrammierBlöckeArduino-»OLEDSSD1306I²CzeigeText...inSpalte...inZeile...«">»OLED SSD 1306 I²C zeige
+                Text ... in Spalte ... in Zeile ... «</h3>
+            <p>Mit diesem Block kannst du einen Text auf dem Bildschirm OLED SSD 1306, den du per I²C an deinen Arduino
+                anschließen kannst, anzeigen lassen. Der Bildschirm wird in 100 Spalten und 50 Zeilen aufgeteilt.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, der Text den du anzeigen möchtest.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Spalte in der der Text angezeigt werden soll. Zahl zwischen
+                    0 und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Zeile in der der Text angezeigt werden soll. Zahl zwischen
+                    0 und 50.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_display_clear_oledssd1306i2c" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammierBlöckeArduino-»LöscheOLEDSSD1306I²C«">»Lösche OLED SSD 1306
+                I²C«</h3>
+            <p>Mit diesem Block kannst du einen Bildschirm OLED SSD 1306 löschen.</p>
+        </div>
         <div id="robActions_play_tone" class="help beginner">
             <h3 id="ProgrammierBlöckeArduino-»Spiele...FrequenzHz...Dauerms«">»Spiele ... Frequenz Hz ... Dauer ms«</h3>
             <p>Mit dem Block »Spiele Frequenz Hz... Dauer ms« kannst du die Frequenz (Höhe eines Tons) und die Zeit (wie

--- a/OpenRobertaServer/staticResources/help/progHelp_arduino_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_arduino_en.html
@@ -148,6 +148,27 @@
                         pins you connected</span> the display to.</li>
             </ul>
         </div>
+        <div id="robActions_display_text_oledssd1306i2c" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksArduino-»OLEDSSD1306I²Cshowtext...incolumn...inrow...«">
+                »OLED SSD 1306 I²C show text ... in column ... in row ... «</h3>
+            <p>With this block you can display a text on the OLED SSD 1306 display, which can be connected via I²C to
+                your Arduino. This display has 100 columns and 50 rows.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the text that you want display.</li>
+                <li class="typcn typcn-arrow-left">Number, the column in which the text will be displayed. Number
+                    between 0 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, the row in which the text will be displayed. Number between 0
+                    and 50.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_display_clear_oledssd1306i2c" class="help expert">
+            <h3 class="auto-cursor-target" id="ProgrammingBlocksArduino-»clearOLEDSSD1306I²C«">»clear OLED SSD 1306 I²C«
+            </h3>
+            <p>With this block you can clear a connected OLED SSD 1306 display, which is connected via I²C to your
+                Arduino.</p>
+        </div>
         <div id="robActions_play_tone" class="help beginner">
             <h3 id="ProgrammingBlocksArduino-»play...frequencyHz..durationms«">»play ... frequency Hz .. duration ms«
             </h3>

--- a/OpenRobertaServer/staticResources/help/progHelp_nano33ble_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nano33ble_de.html
@@ -151,6 +151,27 @@
                     Roboterkonfiguration angelegt hast.</li>
             </ul>
         </div>
+        <div id="robActions_display_text_oledssd1306i2c" class="help expert">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungArduinoNano33BLE-»OLEDSSD1306I²CzeigeText...inSpalte...inZeile...«">»OLED SSD 1306
+                I²C zeige Text ... in Spalte ... in Zeile ... «</h3>
+            <p>Mit diesem Block kannst du einen Text auf dem Bildschirm OLED SSD 1306, den du per I²C an deinen Arduino
+                anschließen kannst, anzeigen lassen. Der Bildschirm wird in 100 Spalten und 50 Zeilen aufgeteilt.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, der Text den du anzeigen möchtest.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Spalte in der der Text angezeigt werden soll. Zahl zwischen
+                    0 und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Zeile in der der Text angezeigt werden soll. Zahl zwischen
+                    0 und 50.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_display_clear_oledssd1306i2c" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungArduinoNano33BLE-»LöscheOLEDSSD1306I²C«">»Lösche OLED
+                SSD 1306 I²C«</h3>
+            <p>Mit diesem Block kannst du einen Bildschirm OLED SSD 1306 löschen.</p>
+        </div>
         <div id="robActions_play_tone" class="help beginner">
             <h3 id="BlockbeschreibungArduinoNano33BLE-»Spiele...FrequenzHz...Dauerms«">»Spiele ... Frequenz Hz ... Dauer
                 ms«</h3>

--- a/OpenRobertaServer/staticResources/help/progHelp_nano33ble_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nano33ble_en.html
@@ -149,6 +149,28 @@
                         pins you connected</span> the display to.</li>
             </ul>
         </div>
+        <div id="robActions_display_text_oledssd1306i2c" class="help expert">
+            <h3 class="auto-cursor-target"
+                id="programmingblocksArduinoNano33BLE-»OLEDSSD1306I²Cshowtext...incolumn...inrow...«">»OLED SSD 1306 I²C
+                show text ... in column ... in row ... «</h3>
+            <p>With this block you can display a text on the OLED SSD 1306 display, which can be connected via I²C to
+                your Arduino. This display has 100 columns and 50 rows.</p>
+            <p>Input values:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">String, the text that you want display.</li>
+                <li class="typcn typcn-arrow-left">Number, the column in which the text will be displayed. Number
+                    between 0 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, the row in which the text will be displayed. Number between 0
+                    and 50.</li>
+            </ul><br>
+        </div>
+        <div id="robActions_display_clear_oledssd1306i2c" class="help expert">
+            <h3 class="auto-cursor-target" id="programmingblocksArduinoNano33BLE-»clearOLEDSSD1306I²C«">»clear OLED SSD
+                1306 I²C«</h3>
+            <p>With this block you can clear a connected OLED SSD 1306 display, which is connected via I²C to your
+                Arduino.</p>
+        </div>
         <div id="robActions_play_tone" class="help beginner">
             <h3 id="programmingblocksArduinoNano33BLE-»play...frequencyHz..durationms«">»play ... frequency Hz ..
                 duration ms«</h3>


### PR DESCRIPTION
# Description

added help texts for display OLED SSD 1306 for all arduino systems.
Fixes #1210 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested by looking at the help texts for all arduino systems in English and German.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes