### PR TITLE
Issue #1208: shorten crosscompiler errors derived from source code editor

### DIFF
--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/components/Project.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/components/Project.java
@@ -56,6 +56,7 @@ public final class Project {
     private RobotCommunicator robotCommunicator;
     private IRobotFactory robotFactory;
     private boolean withWrapping = true;
+    private boolean isNativeEditorCode = false;
     private ProgramAst<Void> program = null;
     private ConfigurationAst configuration = null;
     private StringBuilder sourceCodeBuilder = new StringBuilder();
@@ -166,6 +167,10 @@ public final class Project {
         return this.withWrapping;
     }
 
+    public boolean isNativeEditorCode() {
+        return this.isNativeEditorCode;
+    }
+
     /**
      * @return the programTransformer
      */
@@ -251,6 +256,10 @@ public final class Project {
     public boolean hasSucceeded() {
         Assert.notNull(this.result);
         return this.result.isSuccess();
+    }
+
+    public void setNativeEditorCode(boolean isNativeEditorCode) {
+        this.isNativeEditorCode = isNativeEditorCode;
     }
 
     public Map<String, String> getResultParams() {
@@ -414,6 +423,7 @@ public final class Project {
             } else if ( this.programNativeSource != null ) { // Used to run native code directly
                 Assert.isNull(this.programXml, "Program XML should not be set when using native compile");
                 this.project.setSourceCode(this.programNativeSource);
+                this.project.setNativeEditorCode(true);
             } else { // STANDARD CASE - Used to follow the default generation, compilation, run from blockly
                 if ( this.project.configuration == null ) {
                     transformConfiguration();

--- a/RobotArdu/src/main/java/de/fhg/iais/roberta/worker/compile/ArduinoCompilerWorker.java
+++ b/RobotArdu/src/main/java/de/fhg/iais/roberta/worker/compile/ArduinoCompilerWorker.java
@@ -160,13 +160,17 @@ public class ArduinoCompilerWorker implements IWorker {
                 resultKey = Key.COMPILERWORKFLOW_ERROR_PROGRAM_COMPILE_FAILED;
             }
         }
+        String workflowMessage = result.getSecond();
         project.setResult(resultKey);
-        project.addResultParam("MESSAGE", result.getSecond());
+        project.addResultParam("MESSAGE", workflowMessage);
         String robot = project.getRobot();
         if ( resultKey == Key.COMPILERWORKFLOW_SUCCESS ) {
             LOG.info("compile {} program {} successful", robot, programName);
         } else {
-            LOG.error("compile {} program {} failed with {}", robot, programName, result.getSecond());
+            if ( project.isNativeEditorCode() ) {
+                workflowMessage = "user error (source code editor compilation error)";
+            }
+            LOG.error("compile {} program {} failed with {}", robot, programName, workflowMessage);
         }
     }
 }

--- a/RobotEV3/src/main/java/de/fhg/iais/roberta/worker/compile/Ev3C4ev3CompilerWorker.java
+++ b/RobotEV3/src/main/java/de/fhg/iais/roberta/worker/compile/Ev3C4ev3CompilerWorker.java
@@ -28,12 +28,16 @@ public class Ev3C4ev3CompilerWorker implements IWorker {
         C4Ev3SourceCompiler compiler = new C4Ev3SourceCompiler(compilerResourcesDir);
         Uf2Builder uf2Builder = new Uf2Builder(compilerResourcesDir);
         Pair<Key, String> workflowResult = this.runBuild(project, compiler, uf2Builder);
+        String workflowMessage = workflowResult.getSecond();
         project.setResult(workflowResult.getFirst());
-        project.addResultParam("MESSAGE", workflowResult.getSecond());
+        project.addResultParam("MESSAGE", workflowMessage);
         if ( workflowResult.getFirst() == Key.COMPILERWORKFLOW_SUCCESS ) {
             LOG.info("compile {} program {} successful", robot, programName);
         } else {
-            LOG.error("compile {} program {} failed with {}", robot, programName, workflowResult);
+            if ( project.isNativeEditorCode() ) {
+                workflowMessage = "user error (source code editor compilation error)";
+            }
+            LOG.error("compile {} program {} failed with {}", robot, programName, workflowMessage);
         }
     }
 

--- a/RobotEdison/src/main/java/de/fhg/iais/roberta/worker/EdisonCompilerWorker.java
+++ b/RobotEdison/src/main/java/de/fhg/iais/roberta/worker/EdisonCompilerWorker.java
@@ -27,12 +27,16 @@ public class EdisonCompilerWorker implements IWorker {
         String programName = project.getProgramName();
         String robot = project.getRobot();
         Pair<Key, String> workflowResult = this.runBuild(project);
+        String workflowMessage = workflowResult.getSecond();
         project.setResult(workflowResult.getFirst());
-        project.addResultParam("MESSAGE", workflowResult.getSecond());
+        project.addResultParam("MESSAGE", workflowMessage);
         if ( workflowResult.getFirst() == Key.COMPILERWORKFLOW_SUCCESS ) {
             LOG.info("compile {} program {} successful", robot, programName);
         } else {
-            LOG.error("compile {} program {} failed with {}", robot, programName, workflowResult);
+            if ( project.isNativeEditorCode() ) {
+                workflowMessage = "user error (source code editor compilation error)";
+            }
+            LOG.error("compile {} program {} failed with {}", robot, programName, workflowMessage);
         }
     }
 

--- a/RobotMbed/src/main/java/de/fhg/iais/roberta/worker/CalliopeCompilerWorker.java
+++ b/RobotMbed/src/main/java/de/fhg/iais/roberta/worker/CalliopeCompilerWorker.java
@@ -27,12 +27,16 @@ public class CalliopeCompilerWorker implements IWorker {
 
         // TODO: check how to do this sensibly, without having the UsedHardwareWorker beforehand
         Pair<Key, String> workflowResult = this.runBuild(project);
+        String workflowMessage = workflowResult.getSecond();
         project.setResult(workflowResult.getFirst());
-        project.addResultParam("MESSAGE", workflowResult.getSecond());
+        project.addResultParam("MESSAGE", workflowMessage);
         if ( workflowResult.getFirst() == Key.COMPILERWORKFLOW_SUCCESS ) {
             LOG.info("compile {} program {} successful", robot, programName);
         } else {
-            LOG.error("compile {} program {} failed with {}", robot, programName, workflowResult);
+            if ( project.isNativeEditorCode() ) {
+                workflowMessage = "user error (source code editor compilation error)";
+            }
+            LOG.error("compile {} program {} failed with {}", robot, programName, workflowMessage);
         }
     }
 

--- a/RobotNXT/src/main/java/de/fhg/iais/roberta/worker/NxtCompilerWorker.java
+++ b/RobotNXT/src/main/java/de/fhg/iais/roberta/worker/NxtCompilerWorker.java
@@ -22,12 +22,17 @@ public class NxtCompilerWorker implements IWorker {
         String programName = project.getProgramName();
         String robot = project.getRobot();
         Pair<Key, String> workflowResult = this.runBuild(project);
+        String workflowMessage = workflowResult.getSecond();
         project.setResult(workflowResult.getFirst());
-        project.addResultParam("MESSAGE", workflowResult.getSecond());
+        project.addResultParam("MESSAGE", workflowMessage);
+        if ( project.isNativeEditorCode() )
         if ( workflowResult.getFirst() == Key.COMPILERWORKFLOW_SUCCESS ) {
             LOG.info("compile {} program {} successful", robot, programName);
         } else {
-            LOG.error("compile {} program {} failed with {}", robot, programName, workflowResult);
+            if ( project.isNativeEditorCode() ) {
+                workflowMessage = "user error (source code editor compilation error)";
+            }
+            LOG.error("compile {} program {} failed with {}", robot, programName, workflowMessage);
         }
     }
 


### PR DESCRIPTION
# Description

Fixes #1208: Cross compiler errors that occur due to user errors in the source code editor get shortened so they don't flood the logging output.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Built it using toolchain. Manual tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules