### PR TITLE
Issue #1193: integrate lab with tutorial editor

### DIFF
--- a/OpenRobertaServer/src/main/java/de/fhg/iais/roberta/javaServer/restServices/all/ServerData.java
+++ b/OpenRobertaServer/src/main/java/de/fhg/iais/roberta/javaServer/restServices/all/ServerData.java
@@ -1,6 +1,11 @@
 package de.fhg.iais.roberta.javaServer.restServices.all;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -9,6 +14,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +25,8 @@ import de.fhg.iais.roberta.persistence.util.DbSession;
 import de.fhg.iais.roberta.persistence.util.HttpSessionState;
 import de.fhg.iais.roberta.robotCommunication.RobotCommunicator;
 import de.fhg.iais.roberta.util.AliveData;
+import de.fhg.iais.roberta.util.ServerProperties;
+import de.fhg.iais.roberta.util.Util;
 
 @Path("/data")
 public class ServerData {
@@ -27,10 +35,12 @@ public class ServerData {
     private static final AtomicLong aliveRequestCounterForLogging = new AtomicLong(0);
 
     private final RobotCommunicator robotCommunicator;
+    private final ServerProperties serverProperties;
 
     @Inject
-    public ServerData(RobotCommunicator robotCommunicator) {
+    public ServerData(RobotCommunicator robotCommunicator, ServerProperties robotProperties) {
         this.robotCommunicator = robotCommunicator;
+        this.serverProperties = robotProperties;
     }
 
     @Path("/server/alive")
@@ -88,5 +98,53 @@ public class ServerData {
     public Response tellUsageOfDatabaseSessions() throws Exception {
         String dbSessionData = DbSession.getInfoAboutOpenDbDessions();
         return Response.ok(dbSessionData).build();
+    }
+
+    @Path("/robot/whitelist")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response returnRobotWhitelist() throws Exception {
+        List<String> robotWhitelist = this.serverProperties.getRobotWhitelist();
+        JSONArray jsonArray = new JSONArray();
+        for ( String robotName : robotWhitelist ) {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put("name", robotName);
+            if ( !Objects.equals(robotName, "sim") ) {
+                Properties robotProperties = Util.loadProperties("classpath:/" + robotName + ".properties");
+                jsonObject.put("realName", robotProperties.getProperty("robot.real.name"));
+                jsonObject.put("group", robotProperties.getProperty("robot.plugin.group", robotName));
+            }
+            jsonArray.put(jsonObject);
+        }
+        return Response.ok(jsonArray.toString()).build();
+    }
+
+    @Path("/robot/xml")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response returnRobotXMLData(@QueryParam("robotName") String robotName) throws Exception {
+        JSONObject robotObject = new JSONObject();
+        JSONObject xmlObject = new JSONObject();
+        JSONObject toolboxObject = new JSONObject();
+        JSONObject configurationObject = new JSONObject();
+
+        Properties robotProperties = Util.loadProperties("classpath:/" + robotName + ".properties");
+        List<String> robotXml =
+            Stream
+                .of("robot.program.toolbox.beginner", "robot.program.toolbox.expert", "robot.configuration.toolbox", "robot.configuration.default", "robot.program.default")
+                .map(robotProperties::getProperty)
+                .map(Util::readResourceContent)
+                .collect(Collectors.toList());
+
+        toolboxObject.put("beginner", robotXml.get(0));
+        toolboxObject.put("expert", robotXml.get(1));
+        configurationObject.put("toolbox", robotXml.get(2));
+        configurationObject.put("default", robotXml.get(3));
+        xmlObject.put("configuration", configurationObject);
+        xmlObject.put("toolbox", toolboxObject);
+        xmlObject.put("prog", robotXml.get(4));
+        robotObject.put(robotName, xmlObject);
+
+        return Response.ok(robotObject.toString()).build();
     }
 }

--- a/admin.bat
+++ b/admin.bat
@@ -1,14 +1,32 @@
 @ECHO OFF
 
-SET ADMIN_LOG_FILE="admin/logs/admin.log"
-SET SERVER_LOG_FILE="admin/logs/server.log"
+SET ADMIN_DIR=".\admin"
+
+:ARG_PARSER
+IF NOT "%1"=="" (
+    IF "%1"=="-admin-dir" (
+        SET ADMIN_DIR=%2
+        SHIFT
+    )
+    SHIFT
+    GOTO :ARG_PARSER
+)
+
+IF NOT EXIST %ADMIN_DIR% (
+  MKDIR %ADMIN_DIR%\logs\
+  MKDIR %ADMIN_DIR%\dbBackup\
+  MKDIR %ADMIN_DIR%\tutorial\
+)
+
+SET ADMIN_LOG_FILE="%ADMIN_DIR%\logs\admin.log"
+SET SERVER_LOG_FILE="%ADMIN_DIR%\logs\server.log"
 
 SET DB_NAME="openroberta-db"
 SET DB_PARENTDIR="db-embedded"
-SET DB_URI_FILE="jdbc:hsqldb:file:%DB_PARENTDIR%/%DB_NAME%"
+SET DB_URI_FILE="jdbc:hsqldb:file:%DB_PARENTDIR%\\%DB_NAME%"
 
 if not exist %DB_PARENTDIR% (
-  java -cp "./lib/\*" de.fhg.iais.roberta.main.Administration "create-empty-db" %DB_URI_FILE% >>%ADMIN_LOG_FILE%
+  java -cp ".\lib\\*" de.fhg.iais.roberta.main.Administration "create-empty-db" %DB_URI_FILE% >>%ADMIN_LOG_FILE%
 )
 
-java -cp "./lib/\*" de.fhg.iais.roberta.main.ServerStarter "-d" "database.parentdir=%DB_PARENTDIR%" "-d" "database.name=%DB_NAME%" "-d" "server.staticresources.dir=./staticResources" "-d" "database.mode=embedded" "-d" "server.admin.dir=./admin" >>%SERVER_LOG_FILE%
+java -cp ".\lib\\*" de.fhg.iais.roberta.main.ServerStarter "-d" "database.parentdir=%DB_PARENTDIR%" "-d" "database.name=%DB_NAME%" "-d" "server.staticresources.dir=.\staticResources" "-d" "database.mode=embedded" "-d" "server.admin.dir=%ADMIN_DIR%" >>%SERVER_LOG_FILE%


### PR DESCRIPTION
# Description

This PR implements the following changes:
Add support for tutorial-editor to access server through REST endpoints.
- add REST endpoints:
  - /robot/whitelist: get robots used by the server.
  - /robot/xml?robotName=<robot>: get XML data for a robot.
- fixed paths in admin.bat for use on Windows systems.

Fixes #1193 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Generate a local release `openrobertalab_binaries` and follow the usage guidelines [mentioned here](https://github.com/OpenRoberta/robertalab-tutorial-editor/blob/develop/README.md).

The corresponding changes to the tutorial editor can be [found here](https://github.com/OpenRoberta/robertalab-tutorial-editor/tree/develop).

Tested on:
- Windows (Chrome)
- Ubuntu (Chrome, Firefox)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules