### PR TITLE
Issue #1187: tone-block and sayText-block won't stop further code execution

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/nepostackmachine/interpreter.robotSimBehaviour.js
+++ b/OpenRobertaServer/staticResources/js/app/nepostackmachine/interpreter.robotSimBehaviour.js
@@ -159,7 +159,7 @@ define(["require", "exports", "./interpreter.aRobotBehaviour", "./interpreter.co
             this.hardwareState.actions.tone = {};
             this.hardwareState.actions.tone.frequency = frequency;
             this.hardwareState.actions.tone.duration = duration;
-            this.setBlocking(true);
+            this.setBlocking(duration > 0);
             return 0;
         };
         RobotMbedBehaviour.prototype.playFileAction = function (file) {
@@ -349,7 +349,7 @@ define(["require", "exports", "./interpreter.aRobotBehaviour", "./interpreter.co
             U.debug('***** show "' + showText + '" *****');
             this.hardwareState.actions.display = {};
             this.hardwareState.actions.display[mode.toLowerCase()] = showText;
-            this.setBlocking(true);
+            this.setBlocking(text.length > 0);
             return 0;
         };
         RobotMbedBehaviour.prototype.showTextActionPosition = function (text, x, y) {

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.ev3.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.ev3.js
@@ -662,8 +662,11 @@ define(["require", "exports", "simulation.simulation", "interpreter.constants", 
                 oscillator.start(cT);
                 oscillator.stop(cT + tone.duration / 1000.0);
             }
-            if (tone.file !== undefined) {
+            else if (tone.file !== undefined) {
                 this.tone.file[tone.file](this.webAudio);
+            }
+            else {
+                oscillatorFinish();
             }
         }
         // update sayText

--- a/OpenRobertaWeb/src/app/nepostackmachine/interpreter.robotSimBehaviour.ts
+++ b/OpenRobertaWeb/src/app/nepostackmachine/interpreter.robotSimBehaviour.ts
@@ -150,7 +150,7 @@ export class RobotMbedBehaviour extends ARobotBehaviour {
         this.hardwareState.actions.tone = {};
         this.hardwareState.actions.tone.frequency = frequency;
         this.hardwareState.actions.tone.duration = duration;
-        this.setBlocking(true);
+        this.setBlocking(duration > 0);
         return 0;
     }
 
@@ -354,7 +354,7 @@ export class RobotMbedBehaviour extends ARobotBehaviour {
         U.debug('***** show "' + showText + '" *****');
         this.hardwareState.actions.display = {};
         this.hardwareState.actions.display[mode.toLowerCase()] = showText;
-        this.setBlocking(true);
+        this.setBlocking(text.length > 0);
         return 0;
     }
 

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/robot.ev3.js
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/robot.ev3.js
@@ -668,9 +668,10 @@ Ev3.prototype.update = function () {
             oscillator.frequency.value = tone.frequency;
             oscillator.start(cT);
             oscillator.stop(cT + tone.duration / 1000.0);
-        }
-        if (tone.file !== undefined) {
+        } else if (tone.file !== undefined) {
             this.tone.file[tone.file](this.webAudio);
+        } else {
+            oscillatorFinish();
         }
     }
     // update sayText


### PR DESCRIPTION
This PR fixes the following issues:
- A zero for the tone-block duration parameter would end in an infinite loop in the simulation
- An empty string for the sayText-block parameter would end in an infinite loop in the simulation

The problem was, when executing these blocks the next operation gets blocked from execution so the tone-/sayText-block could finish, but a zero or an empty string as a parameter wasn't handled correctly. 
Now the further code execution only gets blocked when the tone-Block Parameter is > 0 and the sayText-block parameter isn't an empty string.
