### PR TITLE
Issue #1188: Robot and Variable Simualtion Window are no longer modals

### DIFF
--- a/OpenRobertaServer/staticResources/css/roberta.css
+++ b/OpenRobertaServer/staticResources/css/roberta.css
@@ -1151,24 +1151,40 @@ button#simCustomObstacle.typcn:before {
     clear: both;
 }
 
-.modal.simRobotModal {
+.simWindow {
+    position: absolute;
     left: 50px;
     top: 100px;
-    right: inherit;
-    bottom: inherit;
+    z-index: 99;
+    display: none;
 }
 
-.modal#simRobotModal button.close {
-    margin-right: -10px;
-    margin-top: -14px;
+.simWindow#simValuesWindow button.close {
+    top: 4px;
+    right: 14px;
+    color: #bbb;
+    position: absolute;
+}
+
+.simWindow#simValuesWindow button.close:hover {
+    top: 4px;
+    right: 14px;
+    color: #333;
+}
+
+.simWindow#simRobotWindow button.close {
+    top: 4px;
+    right: 24px;
     color: #f1f1f1;
+    position: absolute;
 }
 
-.modal#simValuesModal button.close {
-    margin-right: -10px;
-    margin-top: -14px;
+.simWindow#simRobotWindow button.close:hover {
+    top: 4px;
+    right: 24px;
     color: #bbb;
 }
+
 
 #VariablesContent {
     height: 300px;
@@ -1189,6 +1205,8 @@ button#simCustomObstacle.typcn:before {
     white-space: nowrap;
     overflow: hidden;
     min-width: 250px;
+    max-height: 70vh;
+    overflow-y: auto;
 }
 
 #simValuesContent span {
@@ -1198,36 +1216,18 @@ button#simCustomObstacle.typcn:before {
     width: 60px;
 }
 
-
-.modal#simRobotModal button.close:hover {
-    margin-right: -10px;
-    margin-top: -14px;
-    color: #ffffff;
-}
-
-.modal#simValuesModal button.close:hover {
-    margin-right: -10px;
-    margin-top: -14px;
-    color: #333;
-}
-
 .bigNumber {
     color: #8fa402;
     font-size: large;
     font-weight: bold;
 }
 
-.simRobotModal .modal-header {
-    position: fixed;
-    right: 16;
-}
-
-.simRobotModal .modal-dialog {
+.simWindow .modal-dialog {
     width: inherit;
     margin: 0;
 }
 
-.simRobotModal text {
+.simWindow text {
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     -khtml-user-select: none;
@@ -2489,7 +2489,7 @@ input[type=range]:focus::-ms-fill-upper {
         margin-bottom: 0;
     }
 
-    .modal.simRobotModal {
+    .simWindow {
         left: 6px;
         top: 60px;
     }

--- a/OpenRobertaServer/staticResources/index.html
+++ b/OpenRobertaServer/staticResources/index.html
@@ -1421,25 +1421,19 @@ limitations under the License.
         </div>
     </div>
     <!-- Popup for simulated robot -> EV3 -->
-    <div id="simRobotModal" class="modal fade simRobotModal" data-backdrop="false">
+    <div id="simRobotWindow" class="simWindow" data-backdrop="false">
         <div class="modal-dialog">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-            </div>
+            <button type="button" class="close">&times;</button>
             <div id="simRobotContent"></div>
         </div>
     </div>
     <!-- Popup for simulation sensor data -->
-    <div id="simValuesModal" class="modal fade simRobotModal" data-backdrop="false">
-        <div class="modal-dialog">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-            </div>
-            <div id="simValuesContent">
-                <div id="valuesContent">
-                    <div id="constantValue"></div>
-                    <div id="notConstantValue"></div>
-                </div>
+    <div id="simValuesWindow" class="simWindow slide-in" data-backdrop="false">
+        <button type="button" class="close">&times;</button>
+        <div id="simValuesContent">
+            <div id="valuesContent">
+                <div id="constantValue"></div>
+                <div id="notConstantValue"></div>
             </div>
         </div>
     </div>

--- a/OpenRobertaServer/staticResources/js/app/roberta/controller/guiState.controller.js
+++ b/OpenRobertaServer/staticResources/js/app/roberta/controller/guiState.controller.js
@@ -278,6 +278,7 @@ define(["require", "exports", "util", "message", "guiState.model", "progHelp.con
         $('#head-navi-icon-robot').removeClass('typcn-open');
         $('#head-navi-icon-robot').removeClass('typcn-' + GUISTATE.gui.robotGroup);
         $('#head-navi-icon-robot').addClass('typcn-' + robotGroup);
+        $('.simWindow').removeClass('simWindow-openedButHidden');
         checkSim();
         setProgramOwnerName(null);
         setProgramAuthorName(null);

--- a/OpenRobertaServer/staticResources/js/app/roberta/controller/progSim.controller.js
+++ b/OpenRobertaServer/staticResources/js/app/roberta/controller/progSim.controller.js
@@ -30,7 +30,6 @@ define(["require", "exports", "message", "util", "webots.simulation", "simulatio
             toggleSim();
             return false;
         });
-        $('#simRobotModal').removeClass('modal-backdrop');
         $('#simStop').onWrap('click', function (event) {
             $('#simStop').addClass('disabled');
             $('#simControl').addClass('typcn-media-play-outline').removeClass('typcn-media-play');
@@ -110,43 +109,46 @@ define(["require", "exports", "message", "util", "webots.simulation", "simulatio
         $('#simImport').onWrap('click', function (event) {
             SIM.importImage();
         }, 'simImport clicked');
-        $('#simRobotModal').removeClass('modal-backdrop');
         $('.simInfo').onWrap('click', function (event) {
             SIM.setInfo();
         }, 'sim info clicked');
         $('#simRobot').onWrap('click', function (event) {
-            $('#simRobotModal').modal('toggle');
             var robot = GUISTATE_C.getRobot();
             var position = $('#simDiv').position();
-            position.top += 12;
             if (robot == 'calliope2016' || robot == 'calliope2017' || robot == 'calliope2017NoBlue' || robot == 'microbit') {
                 position.left = $('#blocklyDiv').width() + 12;
-                $('#simRobotModal').css({
-                    top: position.top,
-                    left: position.left,
-                });
             }
             else {
                 position.left += 48;
-                $('#simRobotModal').css({
-                    top: position.top,
-                    left: position.left,
-                });
             }
-            $('#simRobotModal').draggable();
+            toggleRobotWindow('#simRobotWindow', position);
         }, 'sim show robot clicked');
         $('#simValues').onWrap('click', function (event) {
-            $('#simValuesModal').modal('toggle');
             var position = $('#simDiv').position();
-            position.top += 12;
-            $('#simValuesModal').css({
-                top: position.top,
-                right: 12,
-                left: 'initial',
-                bottom: 'inherit',
-            });
-            $('#simValuesModal').draggable();
+            position.left = $(window).width() - ($('#simValuesWindow').width() + 12);
+            toggleRobotWindow('#simValuesWindow', position);
         }, 'sim show values clicked');
+        function toggleRobotWindow(id, position) {
+            if ($(id).is(':hidden')) {
+                $(id).css({
+                    top: position.top + 12,
+                    left: position.left
+                });
+            }
+            $(id).animate({
+                'opacity': 'toggle',
+                'top': 'toggle'
+            }, 300);
+            $(id).draggable({
+                constraint: 'window'
+            });
+        }
+        $('.simWindow .close').onWrap('click', function (event) {
+            $($(this).parents('.simWindow:first')).animate({
+                'opacity': 'hide',
+                'top': 'hide'
+            }, 300);
+        }, 'sim close robotWindow clicked');
         $('#simResetPose').onWrap('click', function (event) {
             if (GUISTATE_C.hasWebotsSim()) {
                 NAOSIM.resetPose();
@@ -248,6 +250,7 @@ define(["require", "exports", "message", "util", "webots.simulation", "simulatio
                 $('.' + GUISTATE_C.getRobot()).addClass('disabled');
             });
             $('#simStop, #simControlStepOver,#simControlStepInto').hide();
+            UTIL.closeSimRobotWindow(simulation_constants_1.default.ANIMATION_DURATION);
             SIM.endDebugging();
         }
         else {
@@ -271,6 +274,7 @@ define(["require", "exports", "message", "util", "webots.simulation", "simulatio
                 }
                 PROG_C.reloadProgram(result);
             });
+            UTIL.openSimRobotWindow(simulation_constants_1.default.ANIMATION_DURATION);
         }
     }
     function toggleSimEvent(event) {

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/constants.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/constants.js
@@ -275,6 +275,7 @@ define(["require", "exports"], function (require, exports) {
         DEBUG_STEP_OVER: 'DebugStepOver',
         MIN_SIZE_OBJECT: 10,
         CORNER_RADIUS: 5,
+        ANIMATION_DURATION: 750
     };
     exports.default = CONST;
 });

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
@@ -1891,7 +1891,6 @@ define(["require", "exports", "simulation.scene", "simulation.constants", "util"
     }
     function createRobots(reqRobot, numRobots) {
         $('#simRobotContent').empty();
-        $('#simRobotModal').modal('hide');
         robots = [];
         if (numRobots >= 1) {
             var tempRobot = createRobot(reqRobot, configurations[0], 0, 0, interpreters[0].getRobotBehaviour());

--- a/OpenRobertaWeb/src/app/roberta/controller/guiState.controller.js
+++ b/OpenRobertaWeb/src/app/roberta/controller/guiState.controller.js
@@ -1,4 +1,3 @@
-import * as exports from 'exports';
 import * as UTIL from 'util';
 import * as MSG from 'message';
 import * as GUISTATE from 'guiState.model';
@@ -285,6 +284,7 @@ function setRobot(robot, result, opt_init) {
     $('#head-navi-icon-robot').removeClass('typcn-open');
     $('#head-navi-icon-robot').removeClass('typcn-' + GUISTATE.gui.robotGroup);
     $('#head-navi-icon-robot').addClass('typcn-' + robotGroup);
+    $('.simWindow').removeClass('simWindow-openedButHidden');
 
     checkSim();
     setProgramOwnerName(null);

--- a/OpenRobertaWeb/src/app/roberta/controller/progSim.controller.js
+++ b/OpenRobertaWeb/src/app/roberta/controller/progSim.controller.js
@@ -45,8 +45,6 @@ function initEvents() {
         return false;
     });
 
-    $('#simRobotModal').removeClass('modal-backdrop');
-
     $('#simStop').onWrap(
         'click',
         function (event) {
@@ -135,8 +133,6 @@ function initEvents() {
         'simImport clicked'
     );
 
-    $('#simRobotModal').removeClass('modal-backdrop');
-
     $('.simInfo').onWrap(
         'click',
         function (event) {
@@ -145,51 +141,52 @@ function initEvents() {
         'sim info clicked'
     );
 
-    $('#simRobot').onWrap(
-        'click',
-        function (event) {
-            $('#simRobotModal').modal('toggle');
-            var robot = GUISTATE_C.getRobot();
-            var position = $('#simDiv').position();
-            position.top += 12;
-            if (robot == 'calliope2016' || robot == 'calliope2017' || robot == 'calliope2017NoBlue' || robot == 'microbit') {
-                position.left = $('#blocklyDiv').width() + 12;
-                $('#simRobotModal').css({
-                    top: position.top,
-                    left: position.left,
-                });
-            } else {
-                position.left += 48;
-                $('#simRobotModal').css({
-                    top: position.top,
-                    left: position.left,
-                });
-            }
-            $('#simRobotModal').draggable();
-        },
-        'sim show robot clicked'
-    );
+    $('#simRobot').onWrap('click', function (event) {
+        var robot = GUISTATE_C.getRobot();
+        var position = $('#simDiv').position();
 
-    $('#simValues').onWrap(
-        'click',
-        function (event) {
-            $('#simValuesModal').modal('toggle');
-            var position = $('#simDiv').position();
-            position.top += 12;
-            $('#simValuesModal').css({
-                top: position.top,
-                right: 12,
-                left: 'initial',
-                bottom: 'inherit',
+        if (robot == 'calliope2016' || robot == 'calliope2017' || robot == 'calliope2017NoBlue' || robot == 'microbit') {
+            position.left = $('#blocklyDiv').width() + 12;
+        } else {
+            position.left += 48;
+        }
+        toggleRobotWindow('#simRobotWindow', position);
+    }, 'sim show robot clicked');
+
+    $('#simValues').onWrap('click', function(event) {
+        var position = $('#simDiv').position();
+        position.left = $(window).width() - ($('#simValuesWindow').width() + 12);
+        toggleRobotWindow('#simValuesWindow', position);
+    }, 'sim show values clicked');
+
+    function toggleRobotWindow(id, position) {
+        if ($(id).is(':hidden')) {
+            $(id).css({
+                top: position.top + 12,
+                left: position.left
             });
-            $('#simValuesModal').draggable();
-        },
-        'sim show values clicked'
-    );
+        }
+        $(id).animate({
+            'opacity': 'toggle',
+            'top': 'toggle'
+        }, 300);
+        $(id).draggable(
+            {
+                constraint: 'window'
+            }
+        );
+    }
+
+    $('.simWindow .close').onWrap('click', function(event) {
+        $($(this).parents('.simWindow:first')).animate({
+            'opacity': 'hide',
+            'top': 'hide'
+        }, 300);
+    }, 'sim close robotWindow clicked');
 
     $('#simResetPose').onWrap(
         'click',
-        function (event) {
+        function(event) {
             if (GUISTATE_C.hasWebotsSim()) {
                 NAOSIM.resetPose();
                 return;
@@ -351,16 +348,19 @@ function toggleSim() {
     if ($('.fromRight.rightActive').hasClass('shifting')) {
         return;
     }
+
     if (($('#simButton').hasClass('rightActive') && !debug) || ($('#simDebugButton').hasClass('rightActive') && debug)) {
         if (!GUISTATE_C.hasWebotsSim()) {
             SIM.cancel();
         }
         $('#simControl').addClass('typcn-media-play-outline').removeClass('typcn-media-play').removeClass('typcn-media-stop');
-        $('#blockly').closeRightView(function () {
+        $('#blockly').closeRightView(function() {
             $('.nav > li > ul > .robotType').removeClass('disabled');
             $('.' + GUISTATE_C.getRobot()).addClass('disabled');
         });
         $('#simStop, #simControlStepOver,#simControlStepInto').hide();
+        UTIL.closeSimRobotWindow(CONST.ANIMATION_DURATION);
+
         SIM.endDebugging();
     } else {
         var xmlProgram = Blockly.Xml.workspaceToDom(blocklyWorkspace);
@@ -382,6 +382,7 @@ function toggleSim() {
             }
             PROG_C.reloadProgram(result);
         });
+        UTIL.openSimRobotWindow(CONST.ANIMATION_DURATION);
     }
 }
 

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/constants.js
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/constants.js
@@ -537,6 +537,8 @@ var CONST = {
     MIN_SIZE_OBJECT: 10,
 
     CORNER_RADIUS: 5,
+
+    ANIMATION_DURATION: 750
 };
 
 export default CONST;

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.js
@@ -1949,7 +1949,6 @@ function arrToRgb(values) {
 
 function createRobots(reqRobot, numRobots) {
     $('#simRobotContent').empty();
-    $('#simRobotModal').modal('hide');
     robots = [];
     if (numRobots >= 1) {
         var tempRobot = createRobot(reqRobot, configurations[0], 0, 0, interpreters[0].getRobotBehaviour());


### PR DESCRIPTION
Previously The robot and variable simulation windows were modals which caused an issue where the simulation would scroll out of the window/ disappear when one of those windows was partially out of frame while opening another.
This is now fixed by having them not be modals anymore.

This PR also changes a bunch of other things to the behavior of those two windows for convinience and to stop them from moving out of the window.

Effects:
- RobotWindows no longer make the simulation disappear when out of the window,
- simRobotModal now has a max height,
- RobotWindows now have a different animation when the simulation is closed compared to using the toggle button,
- RobotWindows no longer show up in front of error messages and warning modals,
- Is no longer in the class .modal, but it's now directly connected to the simulation, so it still closes whenever the simulation closes,
- RobotWindows are now closed when switching to different views like codeView, helpView and so on,
- RobotWindows now can't be dragged out of the window,
- RobotWindows now won't be moved out of the window by resizing it
- RobotWindows are now reopened if the simulation window was closed while RobotWindows were used.
This is not the case if the robot is changed.


Fixes Issue #1188

## Type of change
Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
linux chrome
linux firefox
Browserstack:
  win7 internet explorer 11
  ios Safari
  ios chrom 
