### PR TITLE
Issue #556: invisible simulations are canceled  

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
@@ -212,7 +212,7 @@ define(["require", "exports", "simulation.scene", "simulation.constants", "util"
         }
     }
     exports.initMicrophone = initMicrophone;
-    var time;
+    var time = new Date().getTime();
     var renderTime = 5; // approx. time in ms only for the first rendering
     var dt = 0;
     function getDt() {
@@ -598,11 +598,9 @@ define(["require", "exports", "simulation.scene", "simulation.constants", "util"
         for (var i = 0; i < numRobots; i++) {
             actionValues.push({});
         }
-        globalID = requestAnimationFrame(render);
         var now = new Date().getTime();
-        var dtSim = now - (time || now);
-        var dtRobot = Math.min(15, (dtSim - renderTime) / numRobots);
-        var dtRobot = Math.abs(dtRobot);
+        var dtSim = now - time;
+        var dtRobot = Math.min(15, Math.abs(dtSim - renderTime) / numRobots);
         dt = dtSim / 1000;
         time = now;
         stepCounter += 1;
@@ -663,6 +661,7 @@ define(["require", "exports", "simulation.scene", "simulation.constants", "util"
         scene.updateSensorValues(!pause);
         scene.drawRobots();
         renderTime = new Date().getTime() - renderTimeStart;
+        globalID = requestAnimationFrame(render);
     }
     function allInterpretersTerminated() {
         for (var i = 0; i < interpreters.length; i++) {
@@ -1588,6 +1587,7 @@ define(["require", "exports", "simulation.scene", "simulation.constants", "util"
         $('#blocklyDiv').off('click touchstart', setFocusBlocklyDiv);
     }
     function initScene() {
+        cancelAnimationFrame(globalID);
         scene = new simulation_scene_1.default(imgObjectList[currentBackground], robots, imgPattern, ruler);
         scene.drawRobots();
         resetSelection();

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.js
@@ -236,7 +236,7 @@ function initMicrophone(robot) {
     }
 }
 
-var time;
+var time = new Date().getTime();
 var renderTime = 5; // approx. time in ms only for the first rendering
 
 var dt = 0;
@@ -632,11 +632,9 @@ function render() {
     for (var i = 0; i < numRobots; i++) {
         actionValues.push({});
     }
-    globalID = requestAnimationFrame(render);
     var now = new Date().getTime();
-    var dtSim = now - (time || now);
-    var dtRobot = Math.min(15, (dtSim - renderTime) / numRobots);
-    var dtRobot = Math.abs(dtRobot);
+    var dtSim = now - time;
+    var dtRobot = Math.min(15, Math.abs(dtSim - renderTime) / numRobots);
     dt = dtSim / 1000;
     time = now;
     stepCounter += 1;
@@ -702,6 +700,7 @@ function render() {
     scene.updateSensorValues(!pause);
     scene.drawRobots();
     renderTime = new Date().getTime() - renderTimeStart;
+    globalID = requestAnimationFrame(render);
 }
 
 function allInterpretersTerminated() {
@@ -1636,6 +1635,7 @@ function removeMouseEvents() {
 }
 
 function initScene() {
+    cancelAnimationFrame(globalID);
     scene = new Scene(imgObjectList[currentBackground], robots, imgPattern, ruler);
     scene.drawRobots();
     resetSelection();


### PR DESCRIPTION
A running rendering of a simulation is now always canceled before starting a new one.
New frames are only requested after the pending frame is fully rendered.

Fixes #556 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- maven integration Tests
- visual tests in the lab
