### PR TITLE
Issue #1186: buttons in simulations appear like they should

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
@@ -508,7 +508,7 @@ define(["require", "exports", "simulation.scene", "simulation.constants", "util"
                 $('.dropdown.sim, .simScene, #simImport, #simResetPose, #simEditButtons').show();
             }
         }
-        $('#simButtons, #canvasDiv').show();
+        $('#simButtons, #canvasDiv, #simRobot, #simValues').show();
         $('#webotsButtons, #webotsDiv').hide();
         interpreters = programs.map(function (x) {
             var src = JSON.parse(x.javaScriptProgram);

--- a/OpenRobertaServer/staticResources/js/app/webotsSimulation/webots.simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/webotsSimulation/webots.simulation.js
@@ -336,7 +336,7 @@ define(["require", "exports", "jquery", "guiState.controller"], function (requir
                     switch (_a.label) {
                         case 0:
                             $('#simEditButtons, #canvasDiv, #simRobot, #simValues').hide();
-                            $('#webotsDiv, #simButtons').show();
+                            $('#webotsDiv, #simButtons, #simResetPose').show();
                             if (!!this.webotsSimulation) return [3 /*break*/, 6];
                             this.prepareWebots();
                             return [4 /*yield*/, new Promise(function (resolve_1, reject_1) { require(['webots'], resolve_1, reject_1); })];

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.js
@@ -541,7 +541,7 @@ function init(programs, refresh, robotType) {
             $('.dropdown.sim, .simScene, #simImport, #simResetPose, #simEditButtons').show();
         }
     }
-    $('#simButtons, #canvasDiv').show();
+    $('#simButtons, #canvasDiv, #simRobot, #simValues').show();
     $('#webotsButtons, #webotsDiv').hide();
     interpreters = programs.map(function (x) {
         var src = JSON.parse(x.javaScriptProgram);

--- a/OpenRobertaWeb/src/app/webotsSimulation/webots.simulation.ts
+++ b/OpenRobertaWeb/src/app/webotsSimulation/webots.simulation.ts
@@ -317,7 +317,7 @@ class WebotsSimulationController {
 
     async init(sourceCode) {
         $('#simEditButtons, #canvasDiv, #simRobot, #simValues').hide();
-        $('#webotsDiv, #simButtons').show();
+        $('#webotsDiv, #simButtons, #simResetPose').show();
 
         if (!this.webotsSimulation) {
             this.prepareWebots();


### PR DESCRIPTION
**This PR fixes following problems:**
- simRobot and simValue buttons appear again when switching from Nao-sim to another robot-sim
- simResetPose button appears again when switching from calliope/microbit-sim to Nao-sim