### PR TITLE
Issue #1189: unitBackgroundLayer resets when clicking simResetPose button so that all drawings really get cleared

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
@@ -265,7 +265,7 @@ define(["require", "exports", "simulation.scene", "simulation.constants", "util"
             }
         }
         resetSelection();
-        scene.resetAllCanvas();
+        scene.resetAllCanvas(scene.backgroundImg);
         scene.drawColorAreas(highLightCorners);
         scene.drawObstacles(highLightCorners);
         scene.drawRuler();

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.js
@@ -292,7 +292,7 @@ function resetPose() {
         }
     }
     resetSelection();
-    scene.resetAllCanvas();
+    scene.resetAllCanvas(scene.backgroundImg);
     scene.drawColorAreas(highLightCorners);
     scene.drawObstacles(highLightCorners);
     scene.drawRuler();


### PR DESCRIPTION
This PR fixes the issue that the robot detects the colour of the line it draws after resetting and clearing it.
The problem was that even though the visual line was cleared, the unitBackgroundLayer still contained the data of the line so that the colorSensor detected the colour of the line