### PR TITLE
Issue #145: add indicator to block help for clipping

### DIFF
--- a/OpenRobertaServer/staticResources/help/progHelp_arduino_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_arduino_de.html
@@ -104,8 +104,12 @@
                 <li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 aus, das du in der
                     Roboterkonfiguration angelegt hast.</li>
                 <li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Spaltennummer, in der der Text beginnen soll. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 0 und 15
+                        begrenzt.</span></li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 0 und 1
+                        begrenzt.</span></li>
             </ul>
         </div>
         <div id="robActions_display_clear" class="help expert">
@@ -134,8 +138,12 @@
                 <li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 I²C aus, das du in der
                     Roboterkonfiguration angelegt hast.</li>
                 <li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Spaltennummer, in der der Text beginnen soll. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 0 und 15
+                        begrenzt.</span></li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 0 und 1
+                        begrenzt.</span></li>
             </ul>
         </div>
         <div id="robActions_display_clear_i2c" class="help beginner">
@@ -238,7 +246,9 @@
                 <li class="typcn typcn-arrow-sorted-down">analog/digital, wähle aus ob du einen digitalen oder analogen
                     Wert schreiben willst.</li>
                 <li class="typcn typcn-arrow-sorted-down">Pin, wähle den Pin aus auf den du schreiben möchtest.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Wert der geschrieben werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert der geschrieben werden soll. Entweder 0 oder 1 bei einem
+                    digitalen Signal oder zwischen 0 und 1023 bei einem analogen Signal. Dieser Wert wird intern auf den
+                    Bereich zwischen 0 und 1023 begrenzt.</li>
             </ul><br>
         </div>
         <div id="robSensors_out_getSample" class="help beginner">

--- a/OpenRobertaServer/staticResources/help/progHelp_arduino_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_arduino_en.html
@@ -102,8 +102,12 @@
                 <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
                             the pins you connected</span> the display to.</span></li>
                 <li class="typcn typcn-arrow-left">Text, to be shown on the display.</li>
-                <li class="typcn typcn-arrow-left">number, column-id the text is going to be shown.</li>
-                <li class="typcn typcn-arrow-left">number, row-id, the text should start at.</li>
+                <li class="typcn typcn-arrow-left">number, column-id the text is going to be shown. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 0 and
+                        15.</span></li>
+                <li class="typcn typcn-arrow-left">number, row-id, the text should start at. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 0 and
+                        1.</span></li>
             </ul>
         </div>
         <div id="robActions_display_clear" class="help expert">
@@ -132,8 +136,12 @@
                 <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
                         pins you connected</span> the display to.</li>
                 <li class="typcn typcn-arrow-left">Text, to be shown on the display.</li>
-                <li class="typcn typcn-arrow-left">number, column-id the text is going to be shown.</li>
-                <li class="typcn typcn-arrow-left">number, row-id, the text should start at.</li>
+                <li class="typcn typcn-arrow-left">number, column-id the text is going to be shown. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 0 and
+                        15.</span></li>
+                <li class="typcn typcn-arrow-left">number, row-id, the text should start at. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 0 and
+                        1.</span></li>
             </ul>
         </div>
         <div id="robActions_display_clear_i2c" class="help beginner">
@@ -239,7 +247,9 @@
                     an analog value to an actuator. (By changing this option the pickable actuators change)</li>
                 <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
                             the pins you connected</span> the actuator to.</span></li>
-                <li class="typcn typcn-arrow-left">Number, value to be written.</li>
+                <li class="typcn typcn-arrow-left">Number, value to be written. Either 0 or 1 when using digital or
+                    between 0 and 1023 when using analog signals. This value will be internally clipped between 0 and
+                    1023.</li>
             </ul><br>
         </div>
         <div id="robSensors_out_getSample" class="help beginner">

--- a/OpenRobertaServer/staticResources/help/progHelp_bob3_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_bob3_de.html
@@ -5,19 +5,24 @@
 
 <body>
     <div id="helpContent">
-        <div id="robControls_start" class="help beginner">
-            <h3 id="BlockbeschreibungBOB3-»Programmstart«"><span style="color: rgb(0,0,0);">»Programmstart«</span><span
+        <div id="robControls_start_ardu" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span
                     style="color: rgb(0,0,0);"> </span></h3>
-            <p>Jedes Programm beginnt mit dem »Programmstart-Block«, welcher nicht gelöscht werden kann. Den ersten
-                Block, den man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am
-                Programmstart-Block. </p>
+            <p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den
+                man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am »Wiederhole unendlich
+                oft«-Block.</p>
+            <p>Für Systeme, die auf einem Arduino oder einem ähnlichen Mikrocontroller basieren, ist hier immer eine
+                »Wiederhole unendlich oft«-Schleife mit dem Start-Block verbunden, die ebenfalls nicht entfernt werden
+                kann. Dies liegt daran, dass solche Mikrocontroller meistens für genau eine Aufgabe programmiert werden,
+                die dann immer wieder ausgeführt werden soll. Wenn du nur einen Durchlauf des Programm möchtest, kannst
+                du den Roboter am Ende der Schleife einfach für eine sehr lange Zeit warten lassen.</p>
             <p>Einstellmöglichkeiten:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
                 <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
-            </ul><br>
-            <p>Wenn globale Variablen erzeugt wurden:
+            </ul>
+            <p class="auto-cursor-target">Wenn globale Variablen erzeugt wurden:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-pen">Text, Name der Variablen.</li>
@@ -82,7 +87,7 @@
                 </li>
             </ul><br>
         </div>
-        <div id="bob3Sensors_ambientlight" class="help beginner">
+        <div id="robSensors_infrared_getSample" class="help beginner">
             <h3 id="BlockbeschreibungBOB3-»Gib...%Infrarotsensor«">»Gib ... % Infrarotsensor«</h3>
             <p>Mit diesem Block kannst du den Infrarotsensor deines Roboters abfragen und entweder das Umgebungslicht
                 oder das von deinem Roboter reflektierte Licht messen.</p>
@@ -117,7 +122,7 @@
                     gedrückt wird oder nicht.</li>
             </ul>
         </div>
-        <div id="bob3Sensors_temperature_getSample" class="help beginner">
+        <div id="robSensors_temperature_getSample" class="help beginner">
             <h3 id="BlockbeschreibungBOB3-»GibWert°Temperatursensor«">»Gib Wert ° Temperatursensor«</h3>
             <p>Mit diesem Block kannst du den eingebauten Temperatursensor deines Roboters abfragen und die
                 Umgebungstemperatur messen.</p>
@@ -127,7 +132,7 @@
                 <li class="typcn typcn-arrow-right">Zahl, Umgebungstemperatur in ° Celsius.</li>
             </ul>
         </div>
-        <div id="bob3Sensors_getCode" class="help beginner">
+        <div id="robSensors_code_getSample" class="help beginner">
             <h3 id="BlockbeschreibungBOB3-»GibWertBinär-Code«">»Gib Wert Binär-Code«</h3>
             <p>Mit diesem Block kannst du den Binär-Code auf der Rückseite deines Roboters abfragen.</p>
             <p>Rückgabewerte:
@@ -307,8 +312,23 @@
                     nächsten Iteration der Schleife fortfahren«.</li>
             </ul>
         </div>
+        <div id="robControls_wait" class="help beginner">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungBOB3-»Wartebis...«">»Warte bis ... «</h3>
+            <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
+                der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
+                erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
+                erweitern. Dein Programm wartet dann solange, bis (mindestens) eine der Bedingungen deines »Warte
+                bis«-Blocks erfüllt ist.</p>
+            <p style="text-align: left;">Einstelmöglichkeiten und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-plus">Eine weitere Wartebedingung am Ende anfügen.</li>
+                <li class="typcn typcn-minus">Die letzte Wartebedingung löschen.</li>
+                <li class="typcn typcn-arrow-left">Logischer Wert, »wahr« oder »falsch«.</li>
+            </ul>
+        </div>
         <div id="robControls_wait_time" class="help beginner">
-            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Warte«">»Warte«</h3>
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wartems...«">»Warte ms ... «</h3>
             <p style="text-align: left;">Mit dem Block »Warte« kannst du dein Programm an der Stelle "anhalten", an der
                 du den Block eingefügt hast. Dein Programm bleibt dann für die angegebene Dauer an dieser Stelle stehen.
                 Nach Ablauf der angegebenen Zeit wird dann der nachfolgende Block ausgeführt. Beispielsweise kannst du
@@ -320,7 +340,7 @@
             </ul>
         </div>
         <div id="robControls_wait_for" class="help beginner">
-            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wartebis«">»Warte bis«</h3>
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Wartebis...«.1">»Warte bis ... «</h3>
             <p style="text-align: left;">Mit dem Block »Warte bis« kannst du dein Programm an der Stelle »anhalten«, an
                 der du den »Warte bis«-Block eingefügt hast. Dein Programm wartet dann so lange, bis die Bedingung
                 erfüllt (wahr) ist. Den »Warte bis«-Block kannst du mit dem »+«-Zeichen um zusätzliche Bedingungen
@@ -662,8 +682,7 @@
             </ul><br>
         </div>
         <div id="math_random_float" class="help expert">
-            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Zufallszahl«[Experten-Block]">»Zufallszahl« <span
-                    class="typcn typcn-star"></span></h3>
+            <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Zufallszahl«">»Zufallszahl« </h3>
             <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
                 bestimmt.</p>
             <p style="text-align: left;">Rückgabewert:
@@ -671,6 +690,45 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
             </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungBOB3-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette«
+                <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungBOB3-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
         </div>
         <div id="text" class="help beginner notBob3">
             <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»Text«">»Text«</h3>
@@ -697,7 +755,7 @@
                 <li class="typcn typcn-pen">Zeichenkette, bestehend aus beliebigen Zeichen</li>
             </ul>
         </div>
-        <div id="robText_join" class="help expert notBob3">
+        <div id="robText_join" class="help expert notBob3 notFestobionic">
             <h3 style="text-align: left;" id="BlockbeschreibungBOB3-»ErstelleText«[Experten-Block]">»Erstelle Text«
                 <span class="typcn typcn-star"></span></h3>
             <p style="text-align: left;">Mit dem »Erstelle Text«-Block wird ein Stück Text aus verschiedenen
@@ -729,33 +787,50 @@
                 <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
             </ul>
         </div>
-        <div id="variables_set" class="help beginner">
-            <h3 id="BlockbeschreibungBOB3-»SchreibeVariable«">»Schreibe Variable«</h3>
-            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
-                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
-                übergeben werden.</p>
-            <p>Einstellmöglichkeit und Eingabewert:
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungBOB3-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
-                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
-                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
             </ul><br>
         </div>
-        <div id="variables_get" class="help beginner">
-            <h3 id="BlockbeschreibungBOB3-»LiesVariable«">»Lies Variable«</h3>
-            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
-                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
-                wurde.</p>
-            <p>Einstellmöglichkeit:
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungBOB3-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an
+                Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
-                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
             </ul><br>
-            <p>Rückgabewert:
+            <p>Rückgabewerte:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
-                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
-            </ul>
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
         </div>
         <div id="robLists_create_with" class="help expert notWedo notBob3">
             <h3 id="BlockbeschreibungBOB3-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span
@@ -930,6 +1005,137 @@
                     Liste.</li>
             </ul><br>
         </div>
+        <div id="mbedColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 id="BlockbeschreibungBOB3-»Farbwahl«">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="robColour_picker" class="help beginner notMicrobit notNao notFestobionic notEdison notCalliope">
+            <h3 id="BlockbeschreibungBOB3-»Farbwahl«.1">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="naoColour_picker"
+            class="help beginner notWedo notEv3 notNxt notMicrobit notBotnroll notBob3 notArduino notSensebox notMbot notFestobionic notMicrobit notCalliope">
+            <h3 id="BlockbeschreibungBOB3-»Farbwahl«.2">»Farbwahl «</h3>
+            <p>Mit diesem Block kannst du eine Farbe aus einer Auswahl von vordefinierten Farben auswählen.</p>
+            <p>Option:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Option, wähle die Farbeaus, die du verwenden möchtest.</li>
+            </ul>
+            <p class="auto-cursor-target">Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die ausgewählte Farbe.</li>
+            </ul>
+        </div>
+        <div id="mbedColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notMbot notFestobionic notEdison">
+            <h3 class="auto-cursor-target"
+                id="BlockbeschreibungBOB3-»FarbemitRot...Grün...Blau...Weiß...«[Experten-Block]">»Farbe mit Rot ... Grün
+                ... Blau ... Weiß ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Helligkeit deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="robColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBotnroll notNao notBob3 notArduino notSensebox notCalliope notFestobionic notEdison">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungBOB3-»FarbemitRot...Grün...Blau...«[Experten-Block]">
+                »Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="naoColour_rgb"
+            class="help expert notWedo notEv3 notNxt notMicrobit notBob3 notBotnroll notMbot notFestobionic notEdison notCalliope">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungBOB3-»FarbemitRot...Grün...Blau...«[Experten-Block].1">
+                »Farbe mit Rot ... Grün ... Blau ... « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du dir eine eigene Farbe erstellen, indem du deine Farbe aus Rot, Grün und Blau
+                mischst.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der Rot-Anteil in deine Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Grün-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+                <li class="typcn typcn-arrow-left">Zahl, der Blau-Anteil deiner Farbe. Wert zwischen 0 und 255.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Farbe, die von dir erstellte Farbe.</li>
+            </ul><br>
+        </div>
+        <div id="variables_set" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»SchreibeVariable«">»Schreibe Variable«</h3>
+            <p>Mit dem Block »Schreibe Variable« kannst du den Wert einer Variablen verändern. Je nach Typ der Variablen
+                (Zahl, Zeichenkette, logischer Wert, Liste, Farbe, Verbindung) kann der Variablen ein passender Wert
+                übergeben werden.</p>
+            <p>Einstellmöglichkeit und Eingabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert verändert werden soll.</li>
+                <li class="typcn typcn-arrow-left">Wert, auf den die Variable gesetzt werden soll.</li>
+            </ul><br>
+        </div>
+        <div id="variables_get" class="help beginner">
+            <h3 id="BlockbeschreibungBOB3-»LiesVariable«">»Lies Variable«</h3>
+            <p>Mit dem Block »lies Variable« kannst du den Wert einer Variablen an einen anderen Block übergeben. Der
+                Typ des Ausgabewertes entspricht immer dem Typ, mit dem die Variablen im Block »Start« initialisiert
+                wurde.</p>
+            <p>Einstellmöglichkeit:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-sorted-down">Variable, deren Wert gelesen werden soll.</li>
+            </ul><br>
+            <p>Rückgabewert:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, der in der Variablen gespeichert ist.</li>
+            </ul><br>
+        </div>
         <div id="robProcedures_defnoreturn" class="help expert">
             <h3 id="BlockbeschreibungBOB3-Funktionsblockohne/mitEingabe-undohneRückgabewert[Experten-Block]">
                 Funktionsblock ohne/mit Eingabe- und ohne Rückgabewert <span class="typcn typcn-star"></span></h3>
@@ -1038,7 +1244,35 @@
                 <li class="typcn typcn-arrow-right">Wert, dessen Typ am Ende des Funktionsblock eingestellt ist.</li>
             </ul><br>
         </div>
-        <div id="bob3Communication_sendBlock" class="help expert"><h3 id="BlockbeschreibungBOB3-»SendeNachricht...«">
+        <div id="robProcedures_callnoreturn" class="help expert">
+            <h3 id="BlockbeschreibungBOB3-»FunktionsaufrufohneRückgabewert«[Experten-Block]">»Funktionsaufruf ohne
+                Rückgabewert « <span class="typcn typcn-star"></span></h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen. Diese Funktion gibt dabei keinen
+                Wert zurück.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerte der vorher definierten Funktion.
+                </li>
+            </ul>
+        </div>
+        <div id="robProcedures_callreturn" class="help expert">
+            <h3 class="auto-cursor-target" id="BlockbeschreibungBOB3-»FunktionsaufrufmitRückgabewert«">»Funktionsaufruf
+                mit Rückgabewert «</h3>
+            <p>Mit diesem Block kannst du eine vorher definierte Funktion aufrufen und den Rückgabewerte abrufen.</p>
+            <p>Eingabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Wert, abhängig von den Eingabewerten der vorher definierten Funktion.
+                </li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Wert, abhängig von dem Rückgabewert der definierten Funktion.</li>
+            </ul><br>
+        </div>
+        <div id="bob3Communication_sendBlock" class="help expert">9<h3 id="BlockbeschreibungBOB3-»SendeNachricht...«">
                 »Sende Nachricht ... «</h3>
             <p>Mit diesem Block kannst du eine Nachricht an alle anderen Robotern in deiner Umgebung senden. Du kannst
                 allerdings nur Zahlen als Nachricht an andere Roboter versenden.</p>

--- a/OpenRobertaServer/staticResources/help/progHelp_calliope_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_calliope_de.html
@@ -66,7 +66,8 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 9 für die Helligkeit der LEDs. Dabei
-                    bedeutet 0, dass die LEDs aus sind und 9, dass die LEDs am hellsten leuchten.</li>
+                    bedeutet 0, dass die LEDs aus sind und 9, dass die LEDs am hellsten leuchten. Dieser Wert wird
+                    intern auf den Bereich zwischen 0 und 9 begrenzt.</li>
             </ul>
         </div>
         <div id="mbedActions_display_getBrightness" class="help expert">
@@ -95,7 +96,8 @@
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 4 für die y-Position der LED. Dabei steht 0
                     für die erste LED in der Spalte und 4 für die fünfte und die letzte LED in der Spalte.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 9 für die Helligkeit der LED. Dabei
-                    bedeutet 0, dass die LED aus ist und 9, dass die LED am hellsten leuchtet.</li>
+                    bedeutet 0, dass die LED aus ist und 9, dass die LED am hellsten leuchtet. Dieser Wert wird intern
+                    auf den Bereich zwischen 0 und 9 begrenzt.</li>
             </ul>
         </div>
         <div id="mbedActions_display_getPixel" class="help expert">
@@ -189,9 +191,11 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Zahl, Wert von 0 bis 9. Die Zahl zeigt die LED, die gesteuert werden
-                    soll. Die Nummerierung der LEDs beginnt unten am Schriftzug »LED Bar v2.0«.</li>
+                    soll. Die Nummerierung der LEDs beginnt unten am Schriftzug »LED Bar v2.0«. Dieser Wert wird intern
+                    auf den Bereich zwischen 0 und 9 begrenzt.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert von 0 bis 8. Dabei bedeutet 0, dass die LED aus ist und 8,
-                    dass die LED am hellsten leuchtet.</li>
+                    dass die LED am hellsten leuchtet. Dieser Wert wird intern auf den Bereich zwischen 0 und 8
+                    begrenzt.</li>
             </ul>
         </div>
         <div id="robActions_brickLight_on" class="help expert">
@@ -221,10 +225,10 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, wähle die Motoren aus, für die das Tempo
                     (Geschwindigkeit) eingestellt werden soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 100. Geschwindigkeit des ersten Motors in
-                    Prozent.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 100. Geschwindigkeit des zweiten Motors in
-                    Prozent.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Geschwindigkeit des ersten Motors
+                    in Prozent. Dieser Wert wird intern auf den Bereich zwischen -100 und 100 begrenzt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Geschwindigkeit des zweiten Motors
+                    in Prozent. Dieser Wert wird intern auf den Bereich zwischen -100 und 100 begrenzt.</li>
             </ul>
         </div>
         <div id="mbedActions_motors_stop" class="help expert">
@@ -249,8 +253,8 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, für den das Tempo eingestellt
-                    werden soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen 0 und 100.</li>
+                    werden soll. Dieser Wert wird intern auf den Bereich zwischen -100 und 100 begrenzt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100.</li>
             </ul>
         </div>
         <div id="mbedActions_motor_stop" class="help expert">
@@ -276,7 +280,8 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Geschwindigkeit des Motors. Wenn
-                    die Zahl negativ ist, wird die Drehrichtung umgekehrt.</li>
+                    die Zahl negativ ist, wird die Drehrichtung umgekehrt. Dieser Wert wird intern auf den Bereich
+                    zwischen -100 und 100 begrenzt.</li>
             </ul>
         </div>
         <div id="mbedActions_single_motor_stop" class="help expert">
@@ -378,7 +383,8 @@
                 <li class="typcn typcn-arrow-left">Zahl, zu schreibender Wer. »Analog« sind die Werte zwischen 0 und
                     1023. 0 bedeutet, dass es keine keine Spannung am Pin anliegt, und 1023 bedeutet, dass die vollen
                     3.3V anliegen. »Digital« sind entweder 0 oder 1. 0 bedeutet, dass keine Spannung anliegt und 1
-                    bedeutet, dass volle Spannung anliegt.</li>
+                    bedeutet, dass volle Spannung anliegt. Dieser Wert wird intern auf den Bereich zwischen 0 und 1023
+                    begrenzt.</li>
             </ul>
         </div>
         <div id="mbedActions_switch_led_matrix" class="help expert">

--- a/OpenRobertaServer/staticResources/help/progHelp_calliope_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_calliope_en.html
@@ -67,7 +67,8 @@
             <p>Input value:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
-                <li class="typcn typcn-arrow-left">Number, value between 0 and 9.</li>
+                <li class="typcn typcn-arrow-left">Number, value between 0 and 9. This value will be internally clipped
+                    to be between 0 and 9.</li>
             </ul>
         </div>
         <div id="mbedActions_display_getBrightness" class="help expert">
@@ -95,7 +96,7 @@
                 <li class="typcn typcn-arrow-left">Number, value between 0 and 4 for the y position of the LED. 0 stands
                     for the first LED in the column and 4 for the fifth and last LED in the column.</li>
                 <li class="typcn typcn-arrow-left">Number, value between 0 and 9, where 0 means the LED is off and 9 is
-                    the maximum brightness.</li>
+                    the maximum brightness. This value will be internally clipped to be between 0 and 9.</li>
             </ul>
         </div>
         <div id="mbedActions_display_getPixel" class="help expert">
@@ -180,9 +181,10 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Number, position of the LED that you want to change, value between 0
-                    and 9.</li>
+                    and 9. This value will be internally clipped to be between 0 and 9.</li>
                 <li class="typcn typcn-arrow-left">Number, brightness of the LED, value between 0 and 8, with 0 being
-                    off and 8 being the maximum brightness.</li>
+                    off and 8 being the maximum brightness. This value will be internally clipped to be between 0 and 8.
+                </li>
             </ul>
         </div>
         <div id="robActions_brickLight_on" class="help expert">
@@ -207,10 +209,10 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Motor; pick the motors you want to control.</li>
-                <li class="typcn typcn-arrow-left">number, speed you want the first motor to rotate at, between 0 and
-                    100.</li>
-                <li class="typcn typcn-arrow-left">number, speed you want the second motor to rotate at, between 0 and
-                    100.</li>
+                <li class="typcn typcn-arrow-left">number, speed you want the first motor to rotate at, between -100 and
+                    100. This value will be internally clipped to be between -100 and 100.</li>
+                <li class="typcn typcn-arrow-left">number, speed you want the second motor to rotate at, between -100
+                    and 100. This value will be internally clipped to be between -100 and 100.</li>
             </ul>
         </div>
         <div id="mbedActions_motors_stop" class="help expert">
@@ -230,8 +232,8 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Motor; pick the motor you want to control.</li>
-                <li class="typcn typcn-arrow-left">number, speed you want the motor to rotate at, between 0 and 100.
-                </li>
+                <li class="typcn typcn-arrow-left">number, speed you want the motor to rotate at, between -100 and 100.
+                    This value will be internally clipped to be between -100 and 100.</li>
             </ul>
         </div>
         <div id="mbedActions_motor_stop" class="help expert">
@@ -251,8 +253,8 @@
             <p>Input value:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
-                <li class="typcn typcn-arrow-left">number, speed you want the motor to rotate at, between 0 and 100.
-                </li>
+                <li class="typcn typcn-arrow-left">number, speed you want the motor to rotate at, between -100 and 100.
+                    This value will be internally clipped to be between -100 and 100.</li>
             </ul>
         </div>
         <div id="mbedActions_single_motor_stop" class="help expert">
@@ -276,7 +278,7 @@
                 <li class="typcn typcn-arrow-sorted-down">option, choose the port or pin the servo motor is connected
                     to.</li>
                 <li class="typcn typcn-arrow-sorted-down">number, angle or position that you want the servo arm to turn
-                    to. Value between 180 and 180.</li>
+                    to. Value between -180 and 180.</li>
             </ul><br>
         </div>
         <div id="mbedActions_motionkit_single_set" class="help expert">
@@ -343,7 +345,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">analog or digital.</li>
                 <li class="typcn typcn-arrow-sorted-down">In and output pin 0 to 3.</li>
-                <li class="typcn typcn-arrow-left">Number: value to write</li>
+                <li class="typcn typcn-arrow-left">Number: value to write. Number between 0 and 1023 for analog signals
+                    or either 0 or 1 for digital signals. This value will be internally clipped to be between 0 and
+                    1023.</li>
             </ul>
         </div>
         <div id="mbedActions_switch_led_matrix" class="help expert">

--- a/OpenRobertaServer/staticResources/help/progHelp_edison_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_edison_de.html
@@ -34,7 +34,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, steuert welcher Motor angesprochen
                     werden soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Tempo des Motors zwischen -100 und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo des Motors zwischen -100 und 100.<span
+                        style="color: rgb(51,51,51);"><span> </span>Dieser Wert wird intern auf den Bereich zwischen
+                        -100 und 100 begrenzt.</span></li>
             </ul>
         </div>
         <div id="robActions_motor_stop" class="help expert">
@@ -58,8 +60,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, vorwärts oder rückwärts, die Richtung, in die der
                     Roboter fahren soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Tempo mit dem die Strecke zuückgelegt werden soll, zwischen 1
-                    und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo mit dem die Strecke zurückgelegt werden soll, zwischen 1
+                    und 100.<span style="color: rgb(51,51,51);"><span> </span>Dieser Wert wird intern auf den Bereich
+                        zwischen 1 und 100 begrenzt.</span></li>
                 <li class="typcn typcn-arrow-left">Zahl, Strecke die zurück gelegt werden soll, in Zentimetern.</li>
             </ul>
         </div>
@@ -74,7 +77,8 @@
                 <li class="typcn typcn-arrow-sorted-down">vorwärts oder rückwärts, die Richtung in die dein Roboter
                     fahren soll.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Tempo mit dem sich der Roboter bewegen soll, zwischen 1 und
-                    100.</li>
+                    100.<span style="color: rgb(51,51,51);"><span> </span>Dieser Wert wird intern auf den Bereich
+                        zwischen 1 und 100 begrenzt.</span></li>
             </ul>
         </div>
         <div id="robActions_motorDiff_stop" class="help beginner">
@@ -89,8 +93,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, die Richtung in die sich dein
                     Roboter drehen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Tempo mit der sich dein Roboter drehen soll, zwischen 1 und 100
-                </li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo mit der sich dein Roboter drehen soll, zwischen 1 und
+                    100<span style="color: rgb(51,51,51);"><span> </span>Dieser Wert wird intern auf den Bereich
+                        zwischen 1 und 100 begrenzt.</span></li>
                 <li class="typcn typcn-arrow-left">Zahl, Grad um die sich dein Roboter drehen soll. Dabei ist 360 Grad
                     eine ganze Drehung.</li>
             </ul>
@@ -105,7 +110,8 @@
                 <li class="typcn typcn-arrow-sorted-down">Option, links oder rechts, die Richtung, in die sich dein
                     Roboter drehen soll.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter drehen soll, zwischen 1 und
-                    100.</li>
+                    100.<span style="color: rgb(51,51,51);"><span> </span>Dieser Wert wird intern auf den Bereich
+                        zwischen 1 und 100 begrenzt.</span></li>
             </ul>
         </div>
         <div id="robActions_motorDiff_curve_for" class="help beginner">
@@ -119,8 +125,12 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, vorwärts oder rückwärts, die Richtung in die dein
                     Roboter fahren soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, das Tempo für den linken Motor, zwischen 1 und 100.</li>
-                <li class="typcn typcn-arrow-left">Zahl, das Tempo für den rechten Motor, zwischen 1 und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, das Tempo für den linken Motor, zwischen 1 und 100.<span
+                        style="color: rgb(51,51,51);"><span> </span>Dieser Wert wird intern auf den Bereich zwischen 1
+                        und 100 begrenzt.</span></li>
+                <li class="typcn typcn-arrow-left">Zahl, das Tempo für den rechten Motor, zwischen 1 und 100.<span
+                        style="color: rgb(51,51,51);"><span> </span>Dieser Wert wird intern auf den Bereich zwischen 1
+                        und 100 begrenzt.</span></li>
                 <li class="typcn typcn-arrow-left">Zahl, Strecke in Zentimetern, die zurück gelegt werden soll.</li>
             </ul>
         </div>
@@ -135,8 +145,12 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, vorwärts oder rückwärts, die Richtung in die dein
                     Roboter fahren soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, das Tempo des linken Motors, zwischen 1 und 100.</li>
-                <li class="typcn typcn-arrow-left">Zahl, das Tempo des rechten Motors, zwischen 1 und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, das Tempo des linken Motors, zwischen 1 und 100.<span
+                        style="color: rgb(51,51,51);"><span> </span>Dieser Wert wird intern auf den Bereich zwischen 1
+                        und 100 begrenzt.</span></li>
+                <li class="typcn typcn-arrow-left">Zahl, das Tempo des rechten Motors, zwischen 1 und 100.<span
+                        style="color: rgb(51,51,51);"><span> </span>Dieser Wert wird intern auf den Bereich zwischen 1
+                        und 100 begrenzt.</span></li>
             </ul>
         </div>
         <div id="robActions_play_tone" class="help beginner">

--- a/OpenRobertaServer/staticResources/help/progHelp_edison_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_edison_en.html
@@ -32,7 +32,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, left or right, controls which motor is to be
                     addressed.</li>
-                <li class="typcn typcn-arrow-left">Number, speed of the motor between -100 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, speed of the motor between -100 and 100.<span
+                        style="color: rgb(51,51,51);"><span> </span>This value will be internally clipped to be between
+                        -100 and 100.</span></li>
             </ul>
         </div>
         <div id="robActions_motor_stop" class="help expert">
@@ -53,7 +55,8 @@
                 <li class="typcn typcn-arrow-sorted-down">Option, forwards or backwards, the direction in which the
                     robot is to move.</li>
                 <li class="typcn typcn-arrow-left">Number, speed at which the distance is to be covered, between 1 and
-                    100.</li>
+                    100.<span style="color: rgb(51,51,51);"><span> </span>This value will be internally clipped to be
+                        between 1 and 100.</span></li>
                 <li class="typcn typcn-arrow-left">Number, distance to be covered, in centimeters.</li>
             </ul>
         </div>
@@ -67,7 +70,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, forwards or backwards, the direction in which your
                     robot should move.</li>
-                <li class="typcn typcn-arrow-left">Number, speed at which the robot should move, between 1 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, speed at which the robot should move, between 1 and 100.<span
+                        style="color: rgb(51,51,51);"><span> </span>This value will be internally clipped to be between
+                        1 and 100.</span></li>
             </ul>
         </div>
         <div id="robActions_motorDiff_stop" class="help beginner">
@@ -82,8 +87,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, left or right, the direction in which you want your
                     robot to turn.</li>
-                <li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and 100.
-                </li>
+                <li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and
+                    100.<span style="color: rgb(51,51,51);"><span> </span>This value will be internally clipped to be
+                        between 1 and 100.</span></li>
                 <li class="typcn typcn-arrow-left">Number, degrees you want your robot to rotate. 360 degrees is a whole
                     turn.</li>
             </ul>
@@ -97,8 +103,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, left or right, the direction in which you want your
                     robot to turn.</li>
-                <li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and 100.
-                </li>
+                <li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and
+                    100.<span style="color: rgb(51,51,51);"><span> </span>This value will be internally clipped to be
+                        between 1 and 100.</span></li>
             </ul>
         </div>
         <div id="robActions_motorDiff_curve_for" class="help beginner">
@@ -112,8 +119,12 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, forward or backward, the direction your robot should
                     drive.</li>
-                <li class="typcn typcn-arrow-left">Number, the speed for the left motor, between 1 and 100.</li>
-                <li class="typcn typcn-arrow-left">Number, the speed for the richt motor, between 1 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, the speed for the left motor, between 1 and 100.<span
+                        style="color: rgb(51,51,51);"><span> </span>This value will be internally clipped to be between
+                        1 and 100.</span></li>
+                <li class="typcn typcn-arrow-left">Number, the speed for the richt motor, between 1 and 100.<span
+                        style="color: rgb(51,51,51);"><span> </span>This value will be internally clipped to be between
+                        1 and 100.</span></li>
                 <li class="typcn typcn-arrow-left">Number, distance in centimetres which is to be covered.</li>
             </ul>
         </div>
@@ -128,8 +139,12 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, forward or backward, the direction your robot should
                     go.</li>
-                <li class="typcn typcn-arrow-left">Number, the speed for the left motor, between 1 and 100.</li>
-                <li class="typcn typcn-arrow-left">Number, the speed for the right motor, between 1 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, the speed for the left motor, between 1 and 100.<span
+                        style="color: rgb(51,51,51);"><span> </span>This value will be internally clipped to be between
+                        1 and 100.</span></li>
+                <li class="typcn typcn-arrow-left">Number, the speed for the right motor, between 1 and 100.<span
+                        style="color: rgb(51,51,51);"><span> </span>This value will be internally clipped to be between
+                        1 and 100.</span></li>
             </ul>
         </div>
         <div id="robActions_play_tone" class="help beginner">

--- a/OpenRobertaServer/staticResources/help/progHelp_ev3_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_ev3_de.html
@@ -38,7 +38,7 @@
                 <li class="typcn typcn-arrow-sorted-down">Motor Port, wähle den Motor Port aus, an dem der Motor
                     angeschlossen ist.</li>
                 <li class="typcn typcn-arrow-left">Tempo, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
-                    sich der Motor rückwärts.</li>
+                    sich der Motor rückwärts. Der Wert wird intern auf den Bereich zwischen -100 und 100 begrenzt.</li>
             </ul><br>
         </div>
         <div id="robActions_motor_on_for" class="help expert">
@@ -54,7 +54,7 @@
                 <li class="typcn typcn-arrow-sorted-down">Motor Port, wähle den Motorport aus, an dem der Motor
                     angeschlossen ist.</li>
                 <li class="typcn typcn-arrow-left">Tempo, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
-                    sich der Motor rückwärts.</li>
+                    sich der Motor rückwärts. Der Wert wird intern auf den Bereich zwischen -100 und 100 begrenzt.</li>
                 <li class="typcn typcn-arrow-sorted-down">Umdrehungen oder Grad. 1 Umdrehung entspricht 360 Grad.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Anzahl der Umdrehungen bzw. Winkelgrade. Es sind nur positive
                     Zahlen zugelassen.</li>
@@ -92,10 +92,10 @@
             <p>Einstellmöglichkeiten und Eingabewert:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
-                <li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, für den dasTempo eingestellt
+                <li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, für den das Tempo eingestellt
                     werden soll.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
-                    sich der Motor rückwärts.</li>
+                    sich der Motor rückwärts. Der Wert wird intern auf den Bereich zwischen -100 und 100 begrenzt.</li>
             </ul><br>
         </div>
         <div id="robActions_motor_stop" class="help expert">
@@ -129,7 +129,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Richtung, wähle die gewünschte Fahrrichtung aus.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
-                    sich die Motoren rückwärts.</li>
+                    sich die Motoren rückwärts. Der Wert wird intern auf den Bereich zwischen -100 und 100 begrenzt.
+                </li>
             </ul><br>
         </div>
         <div id="robActions_motorDiff_on_for" class="help beginner">
@@ -146,7 +147,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Fahrtrichtung, wähle die gewünschte Richtung.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
-                    sich die Motoren rückwärts.</li>
+                    sich die Motoren rückwärts. Der Wert wird intern auf den Bereich zwischen -100 und 100 begrenzt.
+                </li>
                 <li class="typcn typcn-arrow-left">Zahl, Länge für die Strecke in cm.</li>
             </ul><br>
         </div>
@@ -166,8 +168,9 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Drehrichtung, wähle die gewünschte Drehrichtung aus.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
-                    sich die Motoren rückwärts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
+                    sich der Roboter in die entgegengesetzte Richtung. Der Wert wird intern auf den Bereich zwischen
+                    -100 und 100 begrenzt.</li>
             </ul><br>
             <div class="confluence-information-macro confluence-information-macro-note">
                 <div class="confluence-information-macro-body">
@@ -191,8 +194,9 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Drehrichtung, wähle die gewünschte Drehrichtung aus.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
-                    sich die Motoren rückwärts.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
+                    sich der Roboter in die entgegengesetzte Richtung. Der Wert wird intern auf den Bereich zwischen
+                    -100 und 100 begrenzt.</li>
                 <li class="typcn typcn-arrow-left">Gradzahl, um die der Roboter sich drehen soll. Negative Zahlen sind
                     nicht zugelassen.</li>
             </ul><br>
@@ -209,9 +213,11 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Drehrichtung, wähle die gewünschte Drehrichtung aus.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den linken Motor. Wenn die Zahl
-                    negativ ist, dreht sich der Motor rückwärts.</li>
+                    negativ ist, dreht sich der Motor rückwärts. Der Wert wird intern auf den Bereich zwischen -100 und
+                    100 begrenzt.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den rechten Motor. Wenn die Zahl
-                    negativ ist, dreht sich der Motor rückwärts.</li>
+                    negativ ist, dreht sich der Motor rückwärts. Der Wert wird intern auf den Bereich zwischen -100 und
+                    100 begrenzt.</li>
             </ul><br>
         </div>
         <div id="robActions_motorDiff_curve_for" class="help beginner">
@@ -227,9 +233,11 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Richtung, wähle die gewünschte Fahrtrichtung aus.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den linken Motor. Wenn die Zahl
-                    negativ ist, dreht sich der Motor rückwärts.</li>
+                    negativ ist, dreht sich der Motor rückwärts. Der Wert wird intern auf den Bereich zwischen -100 und
+                    100 begrenzt.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den rechten Motor. Wenn die Zahl
-                    negativ ist, dreht sich der Motor rückwärts.</li>
+                    negativ ist, dreht sich der Motor rückwärts. Der Wert wird intern auf den Bereich zwischen -100 und
+                    100 begrenzt.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Strecke in Zentimetern, die zurückgelegt werden soll.</li>
             </ul><br>
         </div>
@@ -320,7 +328,8 @@
             <p>Eingabewert:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
-                <li class="typcn typcn-arrow-left">Zahl für die Lautstärke.</li>
+                <li class="typcn typcn-arrow-left">Zahl für die Lautstärke. Der Wert wird intern auf den Bereich
+                    zwischen 0 und 100 begrenzt.</li>
             </ul><br>
         </div>
         <div id="robActions_play_getVolume" class="help expert">
@@ -370,9 +379,11 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Zeichenkette, der Text, den dein Roboter sagen soll.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Sprechgeschwindigkeit in Prozent, also meine Zahl zwischen 1
-                    und 100. Je höher die Zahl ist, desto schneller spricht der Roboter.</li>
+                    und 100. Je höher die Zahl ist, desto schneller spricht der Roboter. Der Wert wird intern auf den
+                    Bereich zwischen 0 und 100 begrenzt.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Stimmlage des Roboters in Prozent. Zahl zwischen 1 und 100. Je
-                    höher die Zahl, desto höher ist auch die Stimmlage des Roboters.</li>
+                    höher die Zahl, desto höher ist auch die Stimmlage des Roboters. Der Wert wird intern auf den
+                    Bereich zwischen 0 und 100 begrenzt.</li>
             </ul><br>
         </div>
         <div id="robActions_brickLight_on" class="help beginner">
@@ -454,7 +465,8 @@
                 Datentyp »Zahl«. Die Zahlenwerte liegen je nach gewählter Messmethode zwischen 0 und 255. Mit diesen
                 verschiedenen Einstellung kann dieser Block je nach Anforderung eingestellt werden.</p>
             <p>Im Modus »Farbe« sendet der Farbsensor Licht aus und erkennt, welche Grundfarbe unter dem Sensor erkannt
-                wurde. Die Grundfarbwerte sind BLACK, WHITE, GREY, RED, GREEN, BLUE, YELLOW, BROWN.</p>
+                wurde. Die Grundfarbwerte sind BLACK, WHITE, RED, GREEN, BLUE, YELLOW, BROWN. Die Farbe GREY teugt an,
+                dass die gemessene Farbe keiner der Standardfarben entspricht.</p>
             <p>Im Modus »Licht« sendet der Farbsensor mittels seiner roten LED Licht aus und misst die reflektierte
                 Lichtstärke auf einer Skala von 0 bis 100.</p>
             <p>Im Modus »RGB« sendet der Farbsensor rotes, grünes und blaues Licht aus und misst das reflektierte Licht

--- a/OpenRobertaServer/staticResources/help/progHelp_ev3_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_ev3_en.html
@@ -42,7 +42,7 @@
                 <li class="typcn typcn-arrow-sorted-down">motor port, choose the port where the motor is connected to.
                 </li>
                 <li class="typcn typcn-arrow-left">value, speed between -100 to 100. Negative values let the motor turn
-                    backwards.</li>
+                    backwards. This value will be internally clipped to be between -100 and 100. </li>
             </ul>
         </div>
         <div id="robActions_motor_on_for" class="help expert">
@@ -58,7 +58,8 @@
                 <li class="typcn typcn-arrow-sorted-down">motor port, choose the one where the motor that you want to
                     program is connected to.</li>
                 <li class="typcn typcn-arrow-left">number, spped between -100 and 100. 100 is the maximum speed.
-                    Negative values lets the motor rotate into the other direction.</li>
+                    Negative values lets the motor rotate into the other direction. This value will be internally
+                    clipped to be between -100 and 100. </li>
                 <li class="typcn typcn-arrow-sorted-down">rotation or degree. Choose the one which fits best. 1 rotation
                     is the same than 360 degrees.</li>
                 <li class="typcn typcn-arrow-left">number, rotations or degrees, only positive numbers are allowed.</li>
@@ -95,7 +96,7 @@
                 <li class="typcn typcn-arrow-sorted-down">motor port, choose the port where the motor is connected to.
                 </li>
                 <li class="typcn typcn-arrow-left">number, speed between -100 and 100. Negative values let the motor run
-                    backwards.</li>
+                    backwards. This value will be internally clipped to be between -100 and 100. </li>
             </ul>
         </div>
         <div id="robActions_motor_stop" class="help expert">
@@ -121,7 +122,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">direction, forwards or backwards. Choose the direction.</li>
                 <li class="typcn typcn-arrow-left"><span>number, speed between -100 to 100. 100 is the maximum speed.
-                        Negative values lets the motor rotate into the other direction.</span></li>
+                        Negative values lets the motor rotate into the other direction. This value will be internally
+                        clipped to be between -100 and 100. </span></li>
             </ul>
         </div>
         <div id="robActions_motorDiff_on_for" class="help beginner">
@@ -138,7 +140,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Drive, »forwards« or »backwards«. Select a direction.</li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100. If the number is negative, the
-                    motors will rotate backwards.</li>
+                    motors will rotate backwards. This value will be internally clipped to be between -100 and 100.
+                </li>
                 <li class="typcn typcn-arrow-left">Number, the distance to drive in cm.</li>
             </ul>
         </div>
@@ -161,7 +164,8 @@
                 <li class="typcn typcn-arrow-sorted-down">Turn, »right« or »left«. Select the desired direction for
                     turning.</li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100. If the number is negative, the
-                    motors will rotate backwards.</li>
+                    robot will turn the other way around. This value will be internally clipped to be between -100 and
+                    100. </li>
             </ul>
             <div class="confluence-information-macro confluence-information-macro-note">
                 <div class="confluence-information-macro-body">
@@ -185,7 +189,8 @@
                 <li class="typcn typcn-arrow-sorted-down">Turn, »right« or »left«. Select the desired direction for
                     turning.</li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100. If the number is negative, the
-                    motors will rotate backwards.</li>
+                    robot will turn the other way around. This value will be internally clipped to be between -100 and
+                    100.</li>
                 <li class="typcn typcn-arrow-left">Number, degrees the robot shall turn. Degree of 360 will perform a
                     full turn around. Negative numbers are not allowed.</li>
             </ul>
@@ -203,9 +208,11 @@
                 <li class="typcn typcn-arrow-sorted-down">Turning direction, »forwards« or »backwards«. Select your
                     desired moving direction.</li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
-                    is negative the motor will run backwards.</li>
+                    is negative the motor will run backwards. This value will be internally clipped to be between -100
+                    and 100.</li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
-                    is negative the motor will run backwards.</li>
+                    is negative the motor will run backwards. This value will be internally clipped to be between -100
+                    and 100.</li>
             </ul><br>
         </div>
         <div id="robActions_motorDiff_curve_for" class="help beginner">
@@ -222,9 +229,11 @@
                 <li class="typcn typcn-arrow-sorted-down">Turning direction, »forwards« or »backwards«. Select your
                     desired moving direction.</li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
-                    is negative the motor will run backwards.</li>
+                    is negative the motor will run backwards. This value will be internally clipped to be between -100
+                    and 100.</li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
-                    is negative the motor will run backwards.</li>
+                    is negative the motor will run backwards. This value will be internally clipped to be between -100
+                    and 100.</li>
                 <li class="typcn typcn-arrow-left">Number, the distance in cm to be driven.</li>
             </ul><br>
         </div>
@@ -312,7 +321,8 @@
             <p>Setting:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
-                <li class="typcn typcn-arrow-left">Number, volume for loudness. 0 = no tone, 100 = maximum volume.</li>
+                <li class="typcn typcn-arrow-left">Number, volume for loudness. 0 = no tone, 100 = maximum volume. This
+                    value will be internally clipped to be between 0 and 100.</li>
             </ul>
         </div>
         <div id="robActions_play_getVolume" class="help expert">
@@ -359,9 +369,11 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">String, text your want your robot to say.</li>
                 <li class="typcn typcn-arrow-left">Number, speaking rate in percent, i.e. my number between 1 and 100,
-                    the higher the number, the faster the robot speaks.</li>
+                    the higher the number, the faster the robot speaks. This value will be internally clipped to be
+                    between 0 and 100.</li>
                 <li class="typcn typcn-arrow-left">Number, voice pitch of the robot in percent. Number between 1 and
-                    100, the higher the number, the higher the voice pitch of the robot.</li>
+                    100, the higher the number, the higher the voice pitch of the robot. This value will be internally
+                    clipped to be between 0 and 100.</li>
             </ul><br>
         </div>
         <div id="robActions_brickLight_on" class="help beginner">
@@ -448,7 +460,8 @@
                 »number«. The numerical values are between 0 (black) to 100(white). With these various settings this
                 block can be configured according to the specific requirements.</p>
             <p>In mode »colour« the light sensor emits light and detects the basic colour under the sensor. Values for
-                basic colours are BLACK, WHITE, GREY, RED, GREEN, BLUE, YELLOW, BROWN.</p>
+                basic colours are BLACK, WHITE, RED, GREEN, BLUE, YELLOW, BROWN. The colour GREY means, that the
+                registered colour doesn't match any of the predefined ones.</p>
             <p>In mode »light« the light sensor emits light with its red LED and measures the light intensity of the
                 reflected light on a scale of 0 to 100.</p>
             <p>In the mode »RGB« the light sensor emits red, green and blue light and measures the reflected light

--- a/OpenRobertaServer/staticResources/help/progHelp_festobionic_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_festobionic_de.html
@@ -6,18 +6,23 @@
 <body>
     <div id="helpContent">
         <div id="robControls_start_ardu" class="help beginner">
-            <h3 id="BlockbeschreibungBionics4Education-»Programmstart«"><span
-                    style="color: rgb(0,0,0);">»Programmstart«</span><span style="color: rgb(0,0,0);"> </span></h3>
-            <p>Jedes Programm beginnt mit dem »Programmstart-Block«, welcher nicht gelöscht werden kann. Den ersten
-                Block, den man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am
-                Programmstart-Block. </p>
+            <h3 id="BlockbeschreibungBionics4Education-»Start«"><span style="color: rgb(0,0,0);">»Start«</span><span
+                    style="color: rgb(0,0,0);"> </span></h3>
+            <p>Jedes Programm beginnt mit dem »Start«-Block, welcher nicht gelöscht werden kann. Den ersten Block, den
+                man verwenden möchte, verbindet man direkt mit der »Sequenzverbindung« am »Wiederhole unendlich
+                oft«-Block.</p>
+            <p>Für Systeme, die auf einem Arduino oder einem ähnlichen Mikrocontroller basieren, ist hier immer eine
+                »Wiederhole unendlich oft«-Schleife mit dem Start-Block verbunden, die ebenfalls nicht entfernt werden
+                kann. Dies liegt daran, dass solche Mikrocontroller meistens für genau eine Aufgabe programmiert werden,
+                die dann immer wieder ausgeführt werden soll. Wenn du nur einen Durchlauf des Programm möchtest, kannst
+                du den Roboter am Ende der Schleife einfach für eine sehr lange Zeit warten lassen.</p>
             <p>Einstellmöglichkeiten:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
                 <li class="typcn typcn-minus"><span>Entferne die globale Variable.</span></li>
-            </ul><br>
-            <p>Wenn globale Variablen erzeugt wurden:
+            </ul>
+            <p class="auto-cursor-target">Wenn globale Variablen erzeugt wurden:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-pen">Text, Name der Variablen.</li>
@@ -620,8 +625,7 @@
             </ul><br>
         </div>
         <div id="math_random_float" class="help expert">
-            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Zufallszahl«[Experten-Block]">
-                »Zufallszahl« <span class="typcn typcn-star"></span></h3>
+            <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Zufallszahl«">»Zufallszahl« </h3>
             <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
                 bestimmt.</p>
             <p style="text-align: left;">Rückgabewert:
@@ -629,6 +633,45 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
             </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungBionics4Education-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in
+                Zeichenkette« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungBionics4Education-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in
+                Zeichen« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
         </div>
         <div id="text" class="help beginner notBob3">
             <h3 style="text-align: left;" id="BlockbeschreibungBionics4Education-»Text«">»Text«</h3>
@@ -686,6 +729,51 @@
                 <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
                 <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
             </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungBionics4Education-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl«
+                <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="BlockbeschreibungBionics4Education-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle
+                Zeichen ... an Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
         </div>
         <div id="robLists_create_with" class="help expert notWedo notBob3">
             <h3 id="BlockbeschreibungBionics4Education-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span

--- a/OpenRobertaServer/staticResources/help/progHelp_mbot_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_mbot_de.html
@@ -39,8 +39,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die dein mBot fahren soll, entweder
                     vorwärts oder rückwärts.</li>
-                <li class="typcn typcn-arrow-sorted-down">Zahl, Tempo, mit dem sich dein mBot bewegen soll, zwischen 1
-                    und 100, wobei 1 langsam ist und 100 schnell.</li>
+                <li class="typcn typcn-arrow-sorted-down">Zahl, Tempo, mit dem sich dein mBot bewegen soll, zwischen 0
+                    und 100, wobei 1 langsam ist und 100 schnell. Dieser Wert wird intern auf den Bereich zwischen 0 und
+                    100 begrenzt.</li>
                 <li class="typcn typcn-arrow-sorted-down">Zahl, Zeit, für die sich dein mBot bewegen soll, in
                     Millisekunden.</li>
             </ul>
@@ -54,8 +55,9 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die dein Roboter fahren soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter bewegen soll, zwischen 1 und
-                    100, wobei 1 langsam ist und 100 schnell.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter bewegen soll, zwischen 0 und
+                    100, wobei 1 langsam ist und 100 schnell. Dieser Wert wird intern auf den Bereich zwischen 0 und 100
+                    begrenzt.</li>
             </ul>
         </div>
         <div id="robActions_motorDiff_turn_for" class="help beginner">
@@ -66,8 +68,9 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die sich dein Roboter drehen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter drehen soll, zwischen 1 und
-                    100, wobei 1 langsam ist und 100 schnell.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter drehen soll, zwischen 0 und
+                    100, wobei 1 langsam ist und 100 schnell. Dieser Wert wird intern auf den Bereich zwischen 0 und 100
+                    begrenzt.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Zeit, für die sich dein Roboter drehen soll, in Millisekunden.
                 </li>
             </ul><br>
@@ -80,8 +83,9 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die sich dein Roboter drehen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter drehen soll, zwischen 1 und
-                    100, wobei 1 langsam ist und 100 schnell.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo, mit dem sich dein Roboter drehen soll, zwischen 0 und
+                    100, wobei 1 langsam ist und 100 schnell. Dieser Wert wird intern auf den Bereich zwischen 0 und 100
+                    begrenzt.</li>
             </ul>
         </div>
         <div id="robActions_motorDiff_curve_for" class="help beginner">
@@ -94,9 +98,10 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die dein Roboter fahren soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Tempo des linken Motors, zwischen 1 und 100.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Tempo des rechten Motors, zwischen 1 und 100, wobei 1 langsam
-                    ist und 100 schnell.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo des linken Motors, zwischen 0 und 100. Dieser Wert wird
+                    intern auf den Bereich zwischen 0 und 100 begrenzt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo des rechten Motors, zwischen 0 und 100, wobei 1 langsam
+                    ist und 100 schnell. Dieser Wert wird intern auf den Bereich zwischen 0 und 100 begrenzt.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Zeit, für die dein Roboter die Kurve fahren soll, in
                     Millisekunden.</li>
             </ul>
@@ -111,10 +116,10 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, Richtung, in die dein Roboter fahren soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Tempo des linken Motors, zwischen 1 und 100, wobei 1 langsam
-                    ist und 100 schnell.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Tempo des rechten Motors, zwischen 1 und 100, wobei 1 langsam
-                    ist und 100 schnell.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo des linken Motors, zwischen 0 und 100, wobei 1 langsam
+                    ist und 100 schnell. Dieser Wert wird intern auf den Bereich zwischen 0 und 100 begrenzt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Tempo des rechten Motors, zwischen 0 und 100, wobei 1 langsam
+                    ist und 100 schnell. Dieser Wert wird intern auf den Bereich zwischen 0 und 100 begrenzt.</li>
             </ul>
         </div>
         <div id="robActions_motorDiff_stop" class="help beginner">
@@ -131,7 +136,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, Motor, den du steuern möchtest.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Tempo des Motors, zwischen -100 und 100. Dabei läuft der Motor
-                    rückwärts, wenn das Tempo eine negative Zahl ist.</li>
+                    rückwärts, wenn das Tempo eine negative Zahl ist. Dieser Wert wird intern auf den Bereich zwischen
+                    -100 und 100 begrenzt.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Zeit, für die der Motor laufen soll.</li>
             </ul>
         </div>
@@ -146,7 +152,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, Motor, den du steuern möchtest.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Tempo des Motors, zwischen -100 und 100. Dabei läuft der Motor
-                    rückwärts, wenn das Tempo eine negative Zahl ist.</li>
+                    rückwärts, wenn das Tempo eine negative Zahl ist. Dieser Wert wird intern auf den Bereich zwischen
+                    -100 und 100 begrenzt.</li>
             </ul>
         </div>
         <div id="robActions_motor_stop" class="help expert">
@@ -215,7 +222,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, Port an dem die LED Matrix angeschlossen ist.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Helligkeit der LED Matrix, Zahl zwischen 0 und 9, wobei 0 aus
-                    bedeutet und 9 die maximale Helligkeit ist.</li>
+                    bedeutet und 9 die maximale Helligkeit ist. Dieser Wert wird intern auf den Bereich zwischen 0 und 9
+                    begrenzt.</li>
             </ul>
         </div>
         <div id="robActions_play_tone" class="help expert">

--- a/OpenRobertaServer/staticResources/help/progHelp_mbot_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_mbot_en.html
@@ -40,8 +40,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, direction in which your mBot should move, either
                     forward or backward.</li>
-                <li class="typcn typcn-arrow-left">Number, tempo with which your mBot should move. Between 1 and 100,
-                    where 1 means »very slow« and 100 »very fast«.</li>
+                <li class="typcn typcn-arrow-left">Number, tempo with which your mBot should move. Between 0 and 100,
+                    where 1 means »very slow« and 100 »very fast«. This value will be internally clipped to a value
+                    between 0 and 100.</li>
                 <li class="typcn typcn-arrow-left">Number, time your mBot should move for, in milliseconds.</li>
             </ul><br>
         </div>
@@ -53,8 +54,9 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should move.</li>
-                <li class="typcn typcn-arrow-left">Number, speed at which your robot should move, between 1 and 100,
-                    where 1 means »very slow« and 100 »very fast«.</li>
+                <li class="typcn typcn-arrow-left">Number, speed at which your robot should move, between 0 and 100,
+                    where 1 means »very slow« and 100 »very fast«. This value will be internally clipped to a value
+                    between 0 and 100.</li>
             </ul>
         </div>
         <div id="robActions_motorDiff_turn_for" class="help beginner">
@@ -65,8 +67,9 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should rotate.</li>
-                <li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and 100,
-                    where 1 means »very slow« and 100 »very fast«.</li>
+                <li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 0 and 100,
+                    where 1 means »very slow« and 100 »very fast«. This value will be internally clipped to a value
+                    between 0 and 100.</li>
                 <li class="typcn typcn-arrow-left">Number, time your robot should spin for, in milliseconds.</li>
             </ul>
         </div>
@@ -78,8 +81,9 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should rotate.</li>
-                <li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 1 and 100,
-                    where 1 means »very slow« and 100 »very fast«.</li>
+                <li class="typcn typcn-arrow-left">Number, speed at which your robot should rotate, between 0 and 100,
+                    where 1 means »very slow« and 100 »very fast«. This value will be internally clipped to a value
+                    between 0 and 100.</li>
             </ul>
         </div>
         <div id="robActions_motorDiff_curve_for" class="help beginner">
@@ -91,10 +95,12 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should move.</li>
-                <li class="typcn typcn-arrow-left">Number, speed of the left motor, between 1 and 100, where 1 means
-                    »very slow« and 100 »very fast«.</li>
-                <li class="typcn typcn-arrow-left">Number, speed of the right engine, between 1 and 100, where 1 means
-                    »very slow« and 100 »very fast«.</li>
+                <li class="typcn typcn-arrow-left">Number, speed of the left motor, between 0 and 100, where 1 means
+                    »very slow« and 100 »very fast«. This value will be internally clipped to a value between 0 and 100.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, speed of the right engine, between 0 and 100, where 1 means
+                    »very slow« and 100 »very fast«. This value will be internally clipped to a value between 0 and 100.
+                </li>
                 <li class="typcn typcn-arrow-left">Number, time in milliseconds your robot should take the curve for.
                 </li>
             </ul>
@@ -108,10 +114,12 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, direction in which your robot should move.</li>
-                <li class="typcn typcn-arrow-left">Number, speed of the left motor, between 1 and 100, where 1 means
-                    »very slow« and 100 »very fast«.</li>
-                <li class="typcn typcn-arrow-left">Number, speed of the right engine, between 1 and 100, where 1 means
-                    »very slow« and 100 »very fast«.</li>
+                <li class="typcn typcn-arrow-left">Number, speed of the left motor, between 0 and 100, where 1 means
+                    »very slow« and 100 »very fast«. This value will be internally clipped to a value between 0 and 100.
+                </li>
+                <li class="typcn typcn-arrow-left">Number, speed of the right engine, between 0 and 100, where 1 means
+                    »very slow« and 100 »very fast«. This value will be internally clipped to a value between 0 and 100.
+                </li>
             </ul><br>
         </div>
         <div id="robActions_motorDiff_stop" class="help beginner">
@@ -128,7 +136,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, motor you want to control.</li>
                 <li class="typcn typcn-arrow-left">Number, speed of the motor, between -100 and 100. The motor runs
-                    backwards if the speed is a negative number.</li>
+                    backwards if the speed is a negative number. This value will be internally clipped to a value
+                    between -100 and 100.</li>
                 <li class="typcn typcn-arrow-left">Number, time for which the motor should run.</li>
             </ul>
         </div>
@@ -142,7 +151,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, motor you want to control.</li>
                 <li class="typcn typcn-arrow-left">Number, speed of the motor, between -100 and 100. The motor runs
-                    backwards if the speed is a negative number.</li>
+                    backwards if the speed is a negative number. This value will be internally clipped to a value
+                    between -100 and 100.</li>
             </ul>
         </div>
         <div id="robActions_motor_stop" class="help expert">
@@ -207,7 +217,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">option, choose the port the LED matrix is connected to.</li>
                 <li class="typcn typcn-arrow-left">Number, brightness of the LED matrix, number between 0 and 9, where 0
-                    means off and 9 is the maximum brightness</li>
+                    means off and 9 is the maximum brightness. This value will be internally clipped to a value between
+                    0 and 9.</li>
             </ul>
         </div>
         <div id="robActions_play_tone" class="help expert">

--- a/OpenRobertaServer/staticResources/help/progHelp_microbit_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_microbit_de.html
@@ -68,7 +68,7 @@
                     Seiten des micro:bits. Hier sind ganze Zahlen zwischen 0 und 4 möglich.</li>
                 <li class="typcn typcn-arrow-left">Zahl, gewünschte Helligkeit der LED. je höher die Zahl, desto heller
                     leuchtet die LED; bei 0 wird die LED ausgeschaltet. Hier sind ganze Zahlen zwischen 0 und 9 möglich.
-                </li>
+                    Dieser Wert intern auf den Bereich zwischen 0 und 9 begrenzt.</li>
             </ul>
         </div>
         <div id="mbedActions_display_getPixel" class="help expert">
@@ -120,11 +120,12 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, wähle aus, ob du einen »digitalen« oder »analogen«
                     Wert auf deinem Pin ausgeben möchtest. Dabei bedeutet »digital« entweder 0 oder 1, »analog« heißt
-                    eine Zahl zwischen 0 und 1, also eine Prozentzahl der Gesamtspannung von 3,3,V.</li>
+                    eine Zahl zwischen 0 und 1023, also eine Prozentzahl der Gesamtspannung von 3,3,V.</li>
                 <li class="typcn typcn-arrow-sorted-down">Option, Pin auf dem du diesen Wert ausgeben möchtest. beachte
                     dabei, dass nicht alle Pins einen »analogen« Wert ausgeben können.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert den du auf dem Pin ausgeben möchtest. Bei »digital«
-                    entweder 0 oder 1, bei »analog« zwischen 0 und 1.</li>
+                    entweder 0 oder 1, bei »analog« zwischen 0 und 1023. Dieser Wert intern auf den Bereich zwischen 0
+                    und 1023 begrenzt.</li>
             </ul>
         </div>
         <div id="robSensors_key_getSample" class="help beginner">

--- a/OpenRobertaServer/staticResources/help/progHelp_microbit_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_microbit_en.html
@@ -65,7 +65,7 @@
                 <li class="typcn typcn-arrow-left">Number, y coordinate of the LED you want to control. The y-axis runs
                     parallel to the short side of your micro:bit. Possible inputs are integers between 0 and 4.</li>
                 <li class="typcn typcn-arrow-left">Number, desired brightness of the LED. 0 means off and 9 is the
-                    maximum brightness.</li>
+                    maximum brightness. This value will be internally clipped to be between 0 and 9.</li>
             </ul>
         </div>
         <div id="mbedActions_display_getPixel" class="help expert">
@@ -108,12 +108,13 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, select whether you want to output a »digital« or
-                    »analog« value on your pin. »Digital« means either 0 or 1, »analog« means a number between 0 and 1,
-                    i.e. a percentage of the total voltage of 3,3,V.</li>
+                    »analog« value on your pin. »Digital« means either 0 or 1, »analog« means a number between 0 and
+                    1023, i.e. a percentage of the total voltage of 3,3,V.</li>
                 <li class="typcn typcn-arrow-sorted-down">Option, pin on which you want to output this value. Note that
                     not all pins can output an "analog" value.</li>
                 <li class="typcn typcn-arrow-left">Number, the value that you want to write to the pin. With »digital«
-                    this means either 0 or 1 and with »analog« this means a number between 0 and 1.</li>
+                    this means either 0 or 1 and with »analog« this means a number between 0 and 1023. This value will
+                    be internally clipped to be between 0 and 1023.</li>
             </ul>
         </div>
         <div id="robSensors_key_getSample" class="help beginner">

--- a/OpenRobertaServer/staticResources/help/progHelp_nano33ble_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nano33ble_de.html
@@ -104,8 +104,12 @@
                 <li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 aus, das du in der
                     Roboterkonfiguration angelegt hast.</li>
                 <li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Spaltennummer, in der der Text beginnen soll. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 0 und 15
+                        begrenzt.</span></li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 0 und 1
+                        begrenzt.</span></li>
             </ul>
         </div>
         <div id="robActions_display_clear" class="help expert">
@@ -135,8 +139,12 @@
                 <li class="typcn typcn-arrow-sorted-down">Port, wähle ein LCD 1602 I²C aus, das du in der
                     Roboterkonfiguration angelegt hast.</li>
                 <li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Spaltennummer, in der der Text beginnen soll. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 0 und 15
+                        begrenzt.</span></li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 0 und 1
+                        begrenzt.</span></li>
             </ul>
         </div>
         <div id="robActions_display_clear_i2c" class="help beginner">
@@ -242,7 +250,9 @@
                 <li class="typcn typcn-arrow-sorted-down">analog/digital, wähle aus ob du einen digitalen oder analogen
                     Wert schreiben willst.</li>
                 <li class="typcn typcn-arrow-sorted-down">Pin, wähle den Pin aus auf den du schreiben möchtest.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Wert der geschrieben werden soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert der geschrieben werden soll. Entweder 0 oder 1 bei einem
+                    digitalen Signal oder zwischen 0 und 1023 bei einem analogen Signal. Dieser Wert wird intern auf den
+                    Bereich zwischen 0 und 1023 begrenzt.</li>
             </ul><br>
         </div>
         <div id="robSensors_out_getSample" class="help beginner">

--- a/OpenRobertaServer/staticResources/help/progHelp_nano33ble_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nano33ble_en.html
@@ -102,8 +102,12 @@
                 <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
                             the pins you connected</span> the display to.</span></li>
                 <li class="typcn typcn-arrow-left">Text, to be shown on the display.</li>
-                <li class="typcn typcn-arrow-left">number, column-id the text is going to be shown.</li>
-                <li class="typcn typcn-arrow-left">number, row-id, the text should start at.</li>
+                <li class="typcn typcn-arrow-left">number, column-id the text is going to be shown. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 0 and
+                        15.</span></li>
+                <li class="typcn typcn-arrow-left">number, row-id, the text should start at. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 0 and
+                        1.</span></li>
             </ul>
         </div>
         <div id="robActions_display_clear" class="help expert">
@@ -133,8 +137,12 @@
                 <li class="typcn typcn-arrow-sorted-down"><span>Port, choose the configuration, in which you set the
                         pins you connected</span> the display to.</li>
                 <li class="typcn typcn-arrow-left">Text, to be shown on the display.</li>
-                <li class="typcn typcn-arrow-left">number, column-id the text is going to be shown.</li>
-                <li class="typcn typcn-arrow-left">number, row-id, the text should start at.</li>
+                <li class="typcn typcn-arrow-left">number, column-id the text is going to be shown. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 0 and
+                        15.</span></li>
+                <li class="typcn typcn-arrow-left">number, row-id, the text should start at. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 0 and
+                        1.</span></li>
             </ul>
         </div>
         <div id="robActions_display_clear_i2c" class="help beginner">
@@ -243,7 +251,9 @@
                     an analog value to an actuator. (By changing this option the pickable actuators change)</li>
                 <li class="typcn typcn-arrow-sorted-down"><span><span>Port, choose the configuration, in which you set
                             the pins you connected</span> the actuator to.</span></li>
-                <li class="typcn typcn-arrow-left">Number, value to be written.</li>
+                <li class="typcn typcn-arrow-left">Number, value to be written. Either 0 or 1 when using digital or
+                    between 0 and 1023 when using analog signals. This value will be internally clipped between 0 and
+                    1023.</li>
             </ul><br>
         </div>
         <div id="robSensors_out_getSample" class="help beginner">

--- a/OpenRobertaServer/staticResources/help/progHelp_nao_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nao_de.html
@@ -15,8 +15,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-plus">Erzeuge eine neue globale Variable.</li>
                 <li class="typcn typcn-minus">Entferne die globale Variable.</li>
-                <li class="typcn typcn-input-checked">Zeige Sensordaten - während des Programmablaufs werden im Display
-                    die Werte der angeschlossenen Sensoren gezeigt.</li>
+                <li class="typcn typcn-input-checked">Autonomes Verhalten - Du kannst hier einstellen, ob sich dein
+                    Roboter selbstständig, also autonom, bewegen soll.</li>
             </ul>Wenn globale Variablen erzeugt wurden:<ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-pen">Text, Name der Variablen.</li>
                 <li class="typcn typcn-arrow-sorted-down">Typ der Variablen.</li>
@@ -110,7 +110,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Zahl, x-Koordinate für die neue Position,</li>
                 <li class="typcn typcn-arrow-left">Zahl, y-Koordinate für die neue Position.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Winkel um die sich dein Roboter drehen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Winkel um die sich dein Roboter drehen soll. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen -360 und 360
+                        begrenzt.</span></li>
             </ul>
         </div>
         <div id="naoActions_walk_async" class="help expert">
@@ -122,11 +124,14 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Zahl, Tempo für die Bewegung in x-Richtung. Zahl zwischen 1 und 100.
-                </li>
+                    <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 1 und 100
+                        begrenzt.</span></li>
                 <li class="typcn typcn-arrow-left">Zahl, Tempo für die Bewegung in y-Richtung. Zahl zwischen 1 und 100.
-                </li>
+                    <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 1 und 100
+                        begrenzt.</span></li>
                 <li class="typcn typcn-arrow-sorted-down">Zahl, Tempo für die Drehung deines Roboters. Zahl zwischen 1
-                    und 100.</li>
+                    und 100. <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 1 und
+                        100 begrenzt.</span></li>
             </ul>
         </div>
         <div id="naoActions_stop" class="help expert">
@@ -180,7 +185,8 @@
                 <li class="typcn typcn-arrow-left">Zahl, die z-Koordinate auf die dein Roboter zeigen oder schauen soll.
                 </li>
                 <li class="typcn typcn-arrow-left">Zahl, Tempo mit dem sich der Roboter bewegen soll. Zahl zwischen 1
-                    und 100.</li>
+                    und 100. <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 1 und
+                        100 begrenzt.</span></li>
             </ul>
         </div>
         <div id="robActions_sayText" class="help beginner">
@@ -204,8 +210,11 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Zeichenkette, Text den dein Roboter sagen soll.</li>
                 <li class="typcn typcn-arrow-left">Zahl, die Sprechgeschwindigkeit des Roboters, zwischen 1 und 100.
-                </li>
-                <li class="typcn typcn-arrow-left">Zahl, die Stimmlage des Roboters, zwischen 1 und 100.</li>
+                    <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 1 und 100
+                        begrenzt.</span></li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stimmlage des Roboters, zwischen 1 und 100. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 1 und 100
+                        begrenzt.</span></li>
             </ul>
         </div>
         <div id="naoActions_getLanguage" class="help expert">
@@ -244,7 +253,8 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Zahl, die gewünschte Lautstärke deines Roboters, zwischen 0 und 100.
-                </li>
+                    <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 0 und 100
+                        begrenzt.</span></li>
             </ul>
         </div>
         <div id="naoActions_learnFace" class="help expert">
@@ -324,7 +334,9 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, wähle die LED aus, die du steuern möchtest.</li>
-                <li class="typcn typcn-arrow-left">Zahl, die Intensität der LED in Prozent, zwischen 0 und 100.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Intensität der LED in Prozent, zwischen 0 und 100. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 0 und 100
+                        begrenzt.</span></li>
             </ul>
         </div>
         <div id="naoActions_ledOff" class="help beginner">
@@ -1065,8 +1077,7 @@
             </ul><br>
         </div>
         <div id="math_random_float" class="help expert">
-            <h3 style="text-align: left;" id="ProgrammierungNAO-»Zufallszahl«[Experten-Block]">»Zufallszahl« <span
-                    class="typcn typcn-star"></span></h3>
+            <h3 style="text-align: left;" id="ProgrammierungNAO-»Zufallszahl«">»Zufallszahl« </h3>
             <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
                 bestimmt.</p>
             <p style="text-align: left;">Rückgabewert:
@@ -1074,6 +1085,45 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
             </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierungNAO-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierungNAO-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
         </div>
         <div id="text" class="help beginner notBob3">
             <h3 style="text-align: left;" id="ProgrammierungNAO-»Text«">»Text«</h3>
@@ -1131,6 +1181,51 @@
                 <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
                 <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
             </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierungNAO-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierungNAO-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an
+                Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
         </div>
         <div id="robLists_create_with" class="help expert notWedo notBob3">
             <h3 id="ProgrammierungNAO-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span

--- a/OpenRobertaServer/staticResources/help/progHelp_nao_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nao_en.html
@@ -111,7 +111,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Number, x-coordinate for the new position.</li>
                 <li class="typcn typcn-arrow-left">Number, y-coordinate for the new position.</li>
-                <li class="typcn typcn-arrow-left">Number, select the angle by which the robot should turn.</li>
+                <li class="typcn typcn-arrow-left">Number, select the angle by which the robot should turn. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between -360 and
+                        360.</span></li>
             </ul>
         </div>
         <div id="naoActions_walk_async" class="help expert">
@@ -173,7 +175,8 @@
                 <li class="typcn typcn-arrow-left">Number, die y coordinate of the spot.</li>
                 <li class="typcn typcn-arrow-left">Number,die z coordinate of the spot.</li>
                 <li class="typcn typcn-arrow-left">Number, the speed with which the robot shall move. Number between 1
-                    and 100.</li>
+                    and 100. <span style="color: rgb(51,51,51);">This value will be internally clipped to be between 0
+                        and 100.</span></li>
             </ul>
         </div>
         <div id="robActions_sayText" class="help beginner">
@@ -196,8 +199,12 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">String, text your robot shall say.</li>
-                <li class="typcn typcn-arrow-left">Number,the voice speed of your robot, between 1 and 100.</li>
-                <li class="typcn typcn-arrow-left">Number, the voice pitch of your robot, between 1 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number,the voice speed of your robot, between 1 and 100. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 1 and
+                        100.</span></li>
+                <li class="typcn typcn-arrow-left">Number, the voice pitch of your robot, between 1 and 100. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 1 and
+                        100.</span></li>
             </ul>
         </div>
         <div id="naoActions_getLanguage" class="help expert">
@@ -234,7 +241,9 @@
             <p>Input values:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
-                <li class="typcn typcn-arrow-left">Number, the desired volume of the robot, between 1 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, the desired volume of the robot, between 1 and 100. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 1 and
+                        100.</span></li>
             </ul>
         </div>
         <div id="naoActions_learnFace" class="help expert">
@@ -308,7 +317,9 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, choose the LED you want to control.</li>
-                <li class="typcn typcn-arrow-left">Number, the intensity of the LED, between 0 and 100.</li>
+                <li class="typcn typcn-arrow-left">Number, the intensity of the LED, between 0 and 100. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 0 and
+                        100.</span></li>
             </ul>
         </div>
         <div id="naoActions_ledOff" class="help beginner">

--- a/OpenRobertaServer/staticResources/help/progHelp_nxt_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nxt_de.html
@@ -40,7 +40,8 @@
                 <li class="typcn typcn-arrow-sorted-down">Motor Port, wähle den Motor Port aus, an dem der Motor
                     angeschlossen ist.</li>
                 <li class="typcn typcn-arrow-left">Tempo, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
-                    sich der Motor rückwärts.</li>
+                    sich der Motor rückwärts. <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den
+                        Bereich zwischen -100 und 100 begrenzt.</span></li>
             </ul><br>
         </div>
         <div id="robActions_motor_on_for" class="help expert">
@@ -56,7 +57,8 @@
                 <li class="typcn typcn-arrow-sorted-down">Motor Port, wähle den Motorport aus, an dem der Motor
                     angeschlossen ist.</li>
                 <li class="typcn typcn-arrow-left">Tempo, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
-                    sich der Motor rückwärts.</li>
+                    sich der Motor rückwärts. <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den
+                        Bereich zwischen -100 und 100 begrenzt.</span></li>
                 <li class="typcn typcn-arrow-sorted-down">Umdrehungen oder Grad. 1 Umdrehung entspricht 360 Grad.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Anzahl der Umdrehungen bzw. Winkelgrade. Es sind nur positive
                     Zahlen zugelassen.</li>
@@ -97,7 +99,8 @@
                 <li class="typcn typcn-arrow-sorted-down">Motor, wähle den Motor Port aus, für den dasTempo eingestellt
                     werden soll.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, dreht
-                    sich der Motor rückwärts.</li>
+                    sich der Motor rückwärts. <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den
+                        Bereich zwischen -100 und 100 begrenzt.</span></li>
             </ul><br>
         </div>
         <div id="robActions_motor_stop" class="help expert">
@@ -130,7 +133,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, wähle die gewünschte Fahrrichtung aus.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
-                    sich die Motoren rückwärts.</li>
+                    sich die Motoren rückwärts. <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den
+                        Bereich zwischen -100 und 100 begrenzt.</span></li>
             </ul><br>
         </div>
         <div id="robActions_motorDiff_on_for" class="help beginner">
@@ -147,7 +151,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, wähle die gewünschte Fahrtrichtung.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
-                    sich die Motoren rückwärts.</li>
+                    sich die Motoren rückwärts. <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den
+                        Bereich zwischen -100 und 100 begrenzt.</span></li>
                 <li class="typcn typcn-arrow-left">Zahl, Länge für die Strecke in cm.</li>
             </ul><br>
         </div>
@@ -170,7 +175,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, wähle die gewünschte Drehrichtung aus.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
-                    sich die Motoren rückwärts.</li>
+                    sich die Motoren rückwärts. <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den
+                        Bereich zwischen -100 und 100 begrenzt.</span></li>
             </ul><br>
             <div class="confluence-information-macro confluence-information-macro-note">
                 <div class="confluence-information-macro-body">
@@ -195,7 +201,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Option, wähle die gewünschte Drehrichtung aus.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100. Wenn die Zahl negativ ist, drehen
-                    sich die Motoren rückwärts.</li>
+                    sich die Motoren rückwärts. <span style="color: rgb(51,51,51);">Dieser Wert wird intern auf den
+                        Bereich zwischen -100 und 100 begrenzt.</span></li>
                 <li class="typcn typcn-arrow-left">Zahl, Gradzahl um die der Roboter sich drehen soll. Negative Zahlen
                     sind nicht zugelassen.</li>
             </ul><br>
@@ -212,9 +219,11 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Drehrichtung, wähle die gewünschte Drehrichtung aus.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den linken Motor. Wenn die Zahl
-                    negativ ist, dreht sich der Motor rückwärts.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den link rechten Motor. Wenn die
-                    Zahl negativ ist, dreht sich der Motor rückwärts.</li>
+                    negativ ist, dreht sich der Motor rückwärts. <span style="color: rgb(51,51,51);">Dieser Wert wird
+                        intern auf den Bereich zwischen -100 und 100 begrenzt.</span></li>
+                <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den rechten Motor. Wenn die Zahl
+                    negativ ist, dreht sich der Motor rückwärts. <span style="color: rgb(51,51,51);">Dieser Wert wird
+                        intern auf den Bereich zwischen -100 und 100 begrenzt.</span></li>
             </ul><br>
         </div>
         <div id="robActions_motorDiff_curve_for" class="help beginner">
@@ -230,9 +239,11 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Richtung, wähle die gewünschte Fahrtrichtung aus.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den linken Motor. Wenn die Zahl
-                    negativ ist, dreht sich der Motor rückwärts.</li>
+                    negativ ist, dreht sich der Motor rückwärts. <span style="color: rgb(51,51,51);">Dieser Wert wird
+                        intern auf den Bereich zwischen -100 und 100 begrenzt.</span></li>
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 für den rechten Motor. Wenn die Zahl
-                    negativ ist, dreht sich der Motor rückwärts.</li>
+                    negativ ist, dreht sich der Motor rückwärts. <span style="color: rgb(51,51,51);">Dieser Wert wird
+                        intern auf den Bereich zwischen -100 und 100 begrenzt.</span></li>
                 <li class="typcn typcn-arrow-left">Zahl, Strecke in Zentimetern, die zurückgelegt werden soll.</li>
             </ul><br>
         </div>
@@ -249,8 +260,12 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Text, der im Display erscheinen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Spaltenummer, in der der Text beginnen soll.</li>
-                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll.</li>
+                <li class="typcn typcn-arrow-left">Zahl, Spaltennummer, in der der Text beginnen soll. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen 0 und 15
+                        begrenzt.</span></li>
+                <li class="typcn typcn-arrow-left">Zahl, Zeilennummer, in der der Text beginnen soll. <span
+                        style="color: rgb(51,51,51);">Dieser Wert wird intern auf den Bereich zwischen </span><span
+                        style="letter-spacing: 0.0px;">1 und 8 begrenzt.</span></li>
             </ul><br>
         </div>
         <div id="robActions_display_clear" class="help beginner">
@@ -296,7 +311,8 @@
             <p>Eingabewert:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
-                <li class="typcn typcn-arrow-left">Zahl für die Lautstärke.</li>
+                <li class="typcn typcn-arrow-left">Zahl für die Lautstärke. <span style="color: rgb(51,51,51);">Dieser
+                        Wert wird intern auf den Bereich zwischen 0 und 100 begrenzt.</span></li>
             </ul><br>
         </div>
         <div id="robActions_play_getVolume" class="help expert">

--- a/OpenRobertaServer/staticResources/help/progHelp_nxt_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_nxt_en.html
@@ -41,7 +41,8 @@
                 <li class="typcn typcn-arrow-sorted-down">motor port, choose the port where the motor is connected to.
                 </li>
                 <li class="typcn typcn-arrow-left">value, speed between -100 to 100. Negative values let the motor turn
-                    backwards.</li>
+                    backwards. <span style="color: rgb(51,51,51);">This value will be internally clipped to be between
+                        -100 and 100.</span></li>
             </ul><br>
         </div>
         <div id="robActions_motor_on_for" class="help expert">
@@ -57,7 +58,9 @@
                 <li class="typcn typcn-arrow-sorted-down">motor port, choose the one where the motor that you want to
                     program is connected to.</li>
                 <li class="typcn typcn-arrow-left">number, spped between -100 and 100. 100 is the maximum speed.
-                    Negative values lets the motor rotate into the other direction.</li>
+                    Negative values lets the motor rotate into the other direction. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between -100 and
+                        100.</span></li>
                 <li class="typcn typcn-arrow-sorted-down">rotation or degree. Choose the one which fits best. 1 rotation
                     is the same than 360 degrees.</li>
                 <li class="typcn typcn-arrow-left">number, rotations or degrees, only positive numbers are allowed.</li>
@@ -94,7 +97,8 @@
                 <li class="typcn typcn-arrow-sorted-down">motor port, choose the port where the motor is connected to.
                 </li>
                 <li class="typcn typcn-arrow-left">number, speed between -100 and 100. Negative values let the motor run
-                    backwards.</li>
+                    backwards. <span style="color: rgb(51,51,51);">This value will be internally clipped to be between
+                        -100 and 100.</span></li>
             </ul><br>
         </div>
         <div id="robActions_motor_stop" class="help expert">
@@ -121,7 +125,9 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">direction, forwards or backwards. Choose the direction.</li>
                 <li class="typcn typcn-arrow-left"><span>number, speed between -100 to 100. 100 is the maximum speed.
-                        Negative values lets the motor rotate into the other direction.</span></li>
+                        Negative values lets the motor rotate into the other direction. <span
+                            style="color: rgb(51,51,51);">This value will be internally clipped to be between -100 and
+                            100.</span></span></li>
             </ul><br>
         </div>
         <div id="robActions_motorDiff_on_for" class="help beginner">
@@ -138,7 +144,8 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-sorted-down">Drive, »forwards« or »backwards«. Select a direction.</li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100. If the number is negative, the
-                    motors will rotate backwards.</li>
+                    motors will rotate backwards. <span style="color: rgb(51,51,51);">This value will be internally
+                        clipped to be between -100 and 100.</span></li>
                 <li class="typcn typcn-arrow-left">Number, the distance to drive in cm.</li>
             </ul><br>
         </div>
@@ -160,7 +167,8 @@
                 <li class="typcn typcn-arrow-sorted-down">Turn, »right« or »left«. Select the desired direction for
                     turning.</li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100. If the number is negative, the
-                    motors will rotate backwards.</li>
+                    motors will rotate backwards. <span style="color: rgb(51,51,51);">This value will be internally
+                        clipped to be between -100 and 100.</span></li>
             </ul><br>
             <div class="confluence-information-macro confluence-information-macro-note">
                 <div class="confluence-information-macro-body">
@@ -184,7 +192,8 @@
                 <li class="typcn typcn-arrow-sorted-down">Turn, »right« or »left«. Select the desired direction for
                     turning.</li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100. If the number is negative, the
-                    motors will rotate backwards.</li>
+                    motors will rotate backwards. <span style="color: rgb(51,51,51);">This value will be internally
+                        clipped to be between -100 and 100.</span></li>
                 <li class="typcn typcn-arrow-left">Number, degrees the robot shall turn. Degree of 360 will perform a
                     full turn around. Negative numbers are not allowed.</li>
             </ul><br>
@@ -202,9 +211,11 @@
                 <li class="typcn typcn-arrow-sorted-down">Turning direction, »forwards« or »backwards«. Select your
                     desired moving direction.</li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
-                    is negative the motor will run backwards.</li>
+                    is negative the motor will run backwards. <span style="color: rgb(51,51,51);">This value will be
+                        internally clipped to be between -100 and 100.</span></li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
-                    is negative the motor will run backwards.</li>
+                    is negative the motor will run backwards. <span style="color: rgb(51,51,51);">This value will be
+                        internally clipped to be between -100 and 100.</span></li>
             </ul>
         </div>
         <div id="robActions_motorDiff_curve_for" class="help beginner">
@@ -221,9 +232,11 @@
                 <li class="typcn typcn-arrow-sorted-down">Turning direction, »forwards« or »backwards«. Select your
                     desired moving direction.</li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
-                    is negative the motor will run backwards.</li>
+                    is negative the motor will run backwards. <span style="color: rgb(51,51,51);">This value will be
+                        internally clipped to be between -100 and 100.</span></li>
                 <li class="typcn typcn-arrow-left">Number, speed between -100 and 100 for the left motor. If the number
-                    is negative the motor will run backwards.</li>
+                    is negative the motor will run backwards. <span style="color: rgb(51,51,51);">This value will be
+                        internally clipped to be between -100 and 100.</span></li>
                 <li class="typcn typcn-arrow-left">Number, the distance in cm to be driven.</li>
             </ul>
         </div>
@@ -239,8 +252,12 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">String, input of a text string to be shown in the display.</li>
-                <li class="typcn typcn-arrow-left">Number, column for the text to start.</li>
-                <li class="typcn typcn-arrow-left">Number, line for the text to start.</li>
+                <li class="typcn typcn-arrow-left">Number, column for the text to start. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 0 and
+                        15.</span></li>
+                <li class="typcn typcn-arrow-left">Number, row for the text to start in. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 1 and
+                        8.</span></li>
             </ul><br>
         </div>
         <div id="robActions_display_clear" class="help beginner">
@@ -268,7 +285,9 @@
             </ul><br>
         </div>
         <div id="mbedActions_play_note" class="help beginner">
-            <h3 id="ProgrammingBlocksNXT-»Playnote...«">»Play note ... «</h3>
+            <h3 id="ProgrammingBlocksNXT-»Playnote...«"><span
+                    style="color: rgb(85,85,85);font-size: 16.0px;letter-spacing: -0.006em;">»Play note ... «</span>
+            </h3>
             <p>With this block your robot can play a note. You can choose the note itself as well as the duration of the
                 note.</p>
             <p>Options:
@@ -286,7 +305,9 @@
             <p>Setting:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
-                <li class="typcn typcn-arrow-left">Number, volume for loudness. 0 = no tone, 100 = maximum volume.</li>
+                <li class="typcn typcn-arrow-left">Number, volume for loudness. 0 = no tone, 100 = maximum volume. <span
+                        style="color: rgb(51,51,51);">This value will be internally clipped to be between 0 and
+                        100.</span></li>
             </ul><br>
         </div>
         <div id="robActions_play_getVolume" class="help expert">

--- a/OpenRobertaServer/staticResources/help/progHelp_sensebox_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_sensebox_de.html
@@ -54,9 +54,11 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Zeichenkette, Text, den du auf dem Display darstellen möchtest.</li>
                 <li class="typcn typcn-arrow-left">Zahl, Spalte in der der Text dargestellt werden soll. Zahl zwischen 0
-                    und 100.</li>
+                    und 127.<span style="color: rgb(51,51,51);"><span> </span>Dieser Wert wird intern auf den Bereich
+                        zwischen 0 und 127 begrenzt.</span></li>
                 <li class="typcn typcn-arrow-left">Zahl, Zeile in der der Text dargestellt werden soll. Zahl zwischen 0
-                    und 50.</li>
+                    und 63.<span style="color: rgb(51,51,51);"><span> </span>Dieser Wert wird intern auf den Bereich
+                        zwischen 0 und 63 begrenzt.</span></li>
             </ul>
         </div>
         <div id="robActions_display_clear_i2c" class="help beginner">
@@ -163,7 +165,9 @@
                 <li class="typcn typcn-arrow-sorted-down">Option, wähle den Aktor aus, an dem du die Spannung anlegen
                     möchtest.</li>
                 <li class="typcn typcn-arrow-left">Zahl, wähle die Spannung, die du anlegen möchtest. Wenn du digital
-                    ausgewählt hast entweder 0 oder 1, bei einem analogen Wert eine Zahl zwischen 0 und 1023.</li>
+                    ausgewählt hast entweder 0 oder 1, bei einem analogen Wert eine Zahl zwischen 0 und 1023. Wenn der
+                    analoge Modus verwendet wird, <span style="color: rgb(51,51,51);"><span> </span>wird dieser Wert
+                        intern auf den Bereich zwischen 0 und 1023 begrenzt.</span></li>
             </ul>
         </div>
         <div id="robSensors_out_getSample" class="help expert">

--- a/OpenRobertaServer/staticResources/help/progHelp_sensebox_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_sensebox_en.html
@@ -50,9 +50,11 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">String, text you want to display on the display.</li>
                 <li class="typcn typcn-arrow-left">Number, column in which the text should be displayed. Number between
-                    0 and 100.</li>
+                    0 and 127.<span style="color: rgb(51,51,51);"><span> </span>This value will be internally clipped to
+                        be between 0 and 127.</span></li>
                 <li class="typcn typcn-arrow-left">Number, line in which the text is to be displayed. Number between 0
-                    and 50.</li>
+                    and 63.<span style="color: rgb(51,51,51);"><span> </span>This value will be internally clipped to be
+                        between 0 and 63.</span></li>
             </ul>
         </div>
         <div id="robActions_display_clear_i2c" class="help beginner">
@@ -152,7 +154,8 @@
                 <li class="typcn typcn-arrow-sorted-down">Option, choose the actuator to apply the voltage to.</li>
                 <li class="typcn typcn-arrow-left">Number, choose the voltage that you want to apply. If you chose
                     digital choose either 0 or 1 as a value, if you chose analoge, choose between 0 and 1023 as a value.
-                </li>
+                    When using analog mode, <span style="color: rgb(51,51,51);"><span>t</span>his value will be
+                        internally clipped to be between 0 and 1023.</span></li>
             </ul>
         </div>
         <div id="robSensors_out_getSample" class="help expert">

--- a/OpenRobertaServer/staticResources/help/progHelp_wedo_de.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_wedo_de.html
@@ -35,7 +35,8 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 (positive Zahlen drehen im
-                    Uhrzeigersinn, negative Zahlen drehen gegen den Uhrzeigersinn)</li>
+                    Uhrzeigersinn, negative Zahlen drehen gegen den Uhrzeigersinn). Dieser Wert wird intern auf den
+                    Bereich zwischen -100 und 100 begrenzt.</li>
                 <li class="typcn typcn-arrow-left">Zahl, gewünschte Dauer in Millisekunden (ms)</li>
             </ul>
         </div>
@@ -51,7 +52,8 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Zahl, Wert zwischen -100 und 100 (positive Zahlen drehen im
-                    Uhrzeigersinn, negative Zahlen drehen gegen den Uhrzeigersinn)</li>
+                    Uhrzeigersinn, negative Zahlen drehen gegen den Uhrzeigersinn). Dieser Wert wird intern auf den
+                    Bereich zwischen -100 und 100 begrenzt.</li>
             </ul>
         </div>
         <div id="robActions_motor_stop" class="help expert">
@@ -707,8 +709,7 @@
             </ul><br>
         </div>
         <div id="math_random_float" class="help expert">
-            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Zufallszahl«[Experten-Block]">»Zufallszahl« <span
-                    class="typcn typcn-star"></span></h3>
+            <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Zufallszahl«">»Zufallszahl« </h3>
             <p style="text-align: left;">Mit dem Block »Zufallszahl« wird eine Zufallszahl zwischen 0,0 und 1,0
                 bestimmt.</p>
             <p style="text-align: left;">Rückgabewert:
@@ -716,6 +717,45 @@
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-right">Zahl, eine positive Zufallszahl kleiner oder gleich 1.</li>
             </ul>
+        </div>
+        <div id="math_cast_toString"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeWeDo-»wandle...uminZeichenkette«[Experten-Block]">»wandle ... um in Zeichenkette«
+                <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zahl in eine Zeichenkette um, die diese
+                    Zahl enthält. Als </span><span style="letter-spacing: -0.084px;">Beispiel</span><span
+                    style="letter-spacing: -0.006em;"> wird die Zahl 123 in die Zeichenkette »123« umgewandelt.</span>
+            </p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, die Zahl die in eine Zeichenkette umgewandelt werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichenkette, die Zeichenkette bestehend aus der gewählten Zahl.
+                </li>
+            </ul><br>
+        </div>
+        <div id="math_cast_toChar"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeWeDo-»wandle...uminZeichen«[Experten-Block]">»wandle ... um in Zeichen« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine einzelne Zahl den dazugehörigen
+                    ASCII-Buchstaben um. Falls es zu dieser Zahl kein dazugehöriges ASCII-Zeichen gibt, wird eine leere
+                    Zeichenkette weitergegeben. So wird z.B. die Zahl 97 in den Buchstaben »a« umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zahl, der ASCII-Code, der in das dazugehörige Zeichen umgewandelt
+                    werden soll. Zahl zwischen 0 und 255.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zeichen, das Zeichen das dem gewählten ASCII-Code entspricht.</li>
+            </ul><br>
         </div>
         <div id="text" class="help beginner notBob3">
             <h3 style="text-align: left;" id="ProgrammierBlöckeWeDo-»Text«">»Text«</h3>
@@ -773,6 +813,51 @@
                 <li class="typcn typcn-arrow-left">Text, Zeichenkette, an die Text angehängt werden soll</li>
                 <li class="typcn typcn-arrow-left">Text, Zeichenkette, die an einen Text angehängt werden soll</li>
             </ul>
+        </div>
+        <div id="text_cast_string_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeWeDo-»wandle...uminZahl«[Experten-Block]">»wandle ... um in Zahl« <span
+                    class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt eine Zeichenkette in eine Zahl um, falls
+                    dies möglich ist. Wenn eine Zeichenkette also nur Zahlen enthält, kann dieser Block die Zeichenkette
+                    in eine Zahl umwandeln. Wenn der Block keine Zahlen enthält, gibt dieser Block »NaN« in der
+                    Simulation des Open Roberta Labs weiter, kann aber auch ein anderes Verhalten aufweisen, welches von
+                    der verwendeten Programmiersprache des Roboters abhängt. </span><span
+                    style="letter-spacing: -0.006em;">Falls die Zeichenkette zwar mit Zahlen beginnt, aber danach
+                    weitere Zeichen enthält, die keine Zahlen sind, gibt dieser Block nur die Zahlen weiter und stoppt,
+                    sobald das erste Zeichen in der Zeichenkette steht. Also als Beispiel macht dieser Block aus der
+                    Zeichenkette »52abcd« die Zahl 52.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, die nur aus Zahlen besteht und in eine Zahl umgewandelt
+                    werden soll.</li>
+            </ul><br>
+            <p><span style="letter-spacing: -0.006em;">Rückgabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, die zahl aus der die Zeichenkette bestand.</li>
+            </ul><br>
+        </div>
+        <div id="text_cast_char_toNumber"
+            class="help expert notWedo notNxt notBotnroll notNao notBob3 notSensebox notMbot notEdison notFestbionics notArduino">
+            <h3 id="ProgrammierBlöckeWeDo-»wandleZeichen...anPosition...inZahl«[Experten-Block]">»wandle Zeichen ... an
+                Position ... in Zahl« <span class="typcn typcn-star"></span></h3>
+            <p><span style="letter-spacing: -0.006em;">Dieser Block wandelt einen Buchstaben oder ein Zeichen aus einer
+                    Zeichenkette in die dazugehörige ASCII-Nummer um. Jedes Zeichen hat dabei eine dazugehörige Nummer
+                    in der ASCII-Tabelle. So wird z.B. ein kleines »a« in die Zahl 97 umgewandelt.</span></p>
+            <p><span style="letter-spacing: -0.006em;">Optionen und Eingabewerte:</span>
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-left">Zeichenkette, aus dieser wird ein einzelnes Zeichen ausgewählt.</li>
+                <li class="typcn typcn-arrow-left">Zahl, die Stelle des Zeichens das umgewandelt werden soll. Beachte
+                    das die Nummerierung bei 0 anfängt.</li>
+            </ul><br>
+            <p>Rückgabewerte:
+            </p>
+            <ul style="margin-top: 0; margin-bottom: 10px">
+                <li class="typcn typcn-arrow-right">Zahl, der ASCII-Code des ausgewählten Zeichens.</li>
+            </ul><br>
         </div>
         <div id="robLists_create_with" class="help expert notWedo notBob3">
             <h3 id="ProgrammierBlöckeWeDo-»ErzeugeListe«[Experten-Block]">»Erzeuge Liste« <span

--- a/OpenRobertaServer/staticResources/help/progHelp_wedo_en.html
+++ b/OpenRobertaServer/staticResources/help/progHelp_wedo_en.html
@@ -30,7 +30,7 @@
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
                 <li class="typcn typcn-arrow-left">Number, between -100 and 100 to control the speed and direction of
-                    the motor</li>
+                    the motor. This value will be internally clipped to a value between -100 and 100.</li>
                 <li class="typcn typcn-arrow-left">Number, time in milliseconds. 1000 milliseconds equal 1 second</li>
             </ul>
         </div>
@@ -41,8 +41,8 @@
             <p>Input:
             </p>
             <ul style="margin-top: 0; margin-bottom: 10px">
-                <li class="typcn typcn-arrow-left">Number, between -100 and 100, controlls the speed and direction of
-                    the motor.</li>
+                <li class="typcn typcn-arrow-left">Number, between -100 and 100, controls the speed and direction of the
+                    motor. This value will be internally clipped to a value between -100 and 100.</li>
             </ul>
         </div>
         <div id="robActions_motor_stop" class="help expert">


### PR DESCRIPTION
# Description

Add an indicator to the block help texts if a block internally clippes the input value. This is done by a simple sentence for the input variable that will be clipped.

Fixes #145 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested locally by looking at the help texts in both English and German.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules