### PR TITLE
Issue #1254: fix function "reset to factory defaults" for robots with arduinoAgentOrToken connection.

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/roberta/controller/progRun.controller.js
+++ b/OpenRobertaServer/staticResources/js/app/roberta/controller/progRun.controller.js
@@ -464,6 +464,11 @@ define(["require", "exports", "util", "log", "message", "program.controller", "p
                     runForAutoConnection(result);
                 });
             }
+            else if (GUISTATE_C.getConnection() == connectionType.AGENTORTOKEN) {
+                PROGRAM.resetProgram(function (result) {
+                    runForAgentConnection(result);
+                });
+            }
             else {
                 PROGRAM.resetProgram(function (result) {
                     runForToken(result);

--- a/OpenRobertaWeb/src/app/roberta/controller/progRun.controller.js
+++ b/OpenRobertaWeb/src/app/roberta/controller/progRun.controller.js
@@ -506,6 +506,10 @@ function reset2DefaultFirmware() {
             PROGRAM.resetProgram(function (result) {
                 runForAutoConnection(result);
             });
+        } else if (GUISTATE_C.getConnection() == connectionType.AGENTORTOKEN) {
+            PROGRAM.resetProgram(function (result) {
+                runForAgentConnection(result);
+            });
         } else {
             PROGRAM.resetProgram(function (result) {
                 runForToken(result);

--- a/RobotArdu/src/main/java/de/fhg/iais/roberta/worker/NIBOResetFirmwareWorker.java
+++ b/RobotArdu/src/main/java/de/fhg/iais/roberta/worker/NIBOResetFirmwareWorker.java
@@ -1,0 +1,33 @@
+package de.fhg.iais.roberta.worker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.fhg.iais.roberta.components.Project;
+import de.fhg.iais.roberta.factory.IRobotFactory;
+import de.fhg.iais.roberta.util.Key;
+import de.fhg.iais.roberta.util.PluginProperties;
+import de.fhg.iais.roberta.util.Util;
+import de.fhg.iais.roberta.visitor.codegen.NIBOHexPrefix;
+
+public class NIBOResetFirmwareWorker implements IWorker {
+    private static final Logger LOG = LoggerFactory.getLogger(NIBOResetFirmwareWorker.class);
+
+    @Override
+    public void execute(Project project) {
+        IRobotFactory factory = project.getRobotFactory();
+        PluginProperties properties = factory.getPluginProperties();
+
+        Key resultKey;
+        String path = properties.getCompilerResourceDir() + "/" + project.getCompiledProgramPath() + "." + project.getBinaryFileExtension();
+
+        try {
+            project.setCompiledHex(Util.getBase64EncodedHex(path, NIBOHexPrefix.getHexPrefixForRobot(project.getRobot())));
+            resultKey = Key.FIRMWARE_RESET_SUCCESS;
+        } catch ( IllegalArgumentException e ) {
+            LOG.error("Reading default firmware for NIBO robots failed", e);
+            resultKey = Key.FIRMWARE_RESET_ERROR;
+        }
+        project.setResult(resultKey);
+    }
+}

--- a/RobotArdu/src/main/java/de/fhg/iais/roberta/worker/transfer/NIBOTransferWorker.java
+++ b/RobotArdu/src/main/java/de/fhg/iais/roberta/worker/transfer/NIBOTransferWorker.java
@@ -2,13 +2,15 @@ package de.fhg.iais.roberta.worker.transfer;
 
 import de.fhg.iais.roberta.components.Project;
 import de.fhg.iais.roberta.util.Key;
+import de.fhg.iais.roberta.util.Util;
+import de.fhg.iais.roberta.visitor.codegen.NIBOHexPrefix;
 import de.fhg.iais.roberta.worker.IWorker;
 
-public class Bob3TransferWorker implements IWorker {
+public class NIBOTransferWorker implements IWorker {
 
     @Override
     public void execute(Project project) {
-        // Create agent does not require execution of run call and transferring the binary
+        // Check whether the robot is connected with create agent program...
         if ( project.getRobotCommunicator().getState(project.getToken()) == null ) {
             project.setResult(Key.ROBOT_PUSH_RUN);
         } else { // otherwise it uses Connector Program
@@ -16,5 +18,4 @@ public class Bob3TransferWorker implements IWorker {
             project.setResult(run);
         }
     }
-
 }

--- a/RobotArdu/src/main/resources/bob3.properties
+++ b/RobotArdu/src/main/resources/bob3.properties
@@ -43,8 +43,8 @@ robot.plugin.worker.collect.method = de.fhg.iais.roberta.worker.collect.Bob3Used
 robot.plugin.worker.generate = de.fhg.iais.roberta.worker.codegen.Bob3CxxGeneratorWorker
 robot.plugin.worker.setup = de.fhg.iais.roberta.worker.compile.ArduinoCompilerSetupWorker
 robot.plugin.worker.compile = de.fhg.iais.roberta.worker.compile.ArduinoCompilerWorker
-robot.plugin.worker.transfer = de.fhg.iais.roberta.worker.transfer.Bob3TransferWorker
-robot.plugin.worker.resetFirmware=de.fhg.iais.roberta.worker.ResetFirmwareWorker
+robot.plugin.worker.transfer = de.fhg.iais.roberta.worker.transfer.NIBOTransferWorker
+robot.plugin.worker.resetFirmware=de.fhg.iais.roberta.worker.NIBOResetFirmwareWorker
 robot.plugin.worker.transform.two2three=de.fhg.iais.roberta.worker.Two2ThreeTransformerWorker
 robot.plugin.worker.transform.three2threeone=de.fhg.iais.roberta.worker.Three2ThreeOneTransformerWorker
 

--- a/RobotArdu/src/main/resources/rob3rta.properties
+++ b/RobotArdu/src/main/resources/rob3rta.properties
@@ -43,8 +43,8 @@ robot.plugin.worker.collect.method = de.fhg.iais.roberta.worker.collect.Bob3Used
 robot.plugin.worker.generate = de.fhg.iais.roberta.worker.codegen.Rob3rtaCxxGeneratorWorker
 robot.plugin.worker.setup = de.fhg.iais.roberta.worker.compile.ArduinoCompilerSetupWorker
 robot.plugin.worker.compile = de.fhg.iais.roberta.worker.compile.ArduinoCompilerWorker
-robot.plugin.worker.transfer = de.fhg.iais.roberta.worker.transfer.Bob3TransferWorker
-robot.plugin.worker.resetFirmware=de.fhg.iais.roberta.worker.ResetFirmwareWorker
+robot.plugin.worker.transfer = de.fhg.iais.roberta.worker.transfer.NIBOTransferWorker
+robot.plugin.worker.resetFirmware=de.fhg.iais.roberta.worker.NIBOResetFirmwareWorker
 robot.plugin.worker.transform.two2three=de.fhg.iais.roberta.worker.Two2ThreeTransformerWorker
 robot.plugin.worker.transform.three2threeone=de.fhg.iais.roberta.worker.Three2ThreeOneTransformerWorker
 


### PR DESCRIPTION
# Description

This PR implements the following changes:

- update Bob3TransferWorker to get encoded hex of the factory default program for reset requests.
- update progRun.controller::reset2DefaultFirmware() to transfer program for arduinoAgentOrToken connection robots.

Fixes #1254 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested on affected NIBO robots (Bob3, Rob3rta).

For each robot:
- Connected robot to computer.
- Clicked on "reset to factory defaults".
- Checked whether robot is programmed as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes