### PR TITLE
Issue #1041: 'ForEach colour'-block functions correctly now and fixes freezing of simulation

### DIFF
--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/lang/codegen/AbstractStackMachineVisitor.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/lang/codegen/AbstractStackMachineVisitor.java
@@ -423,7 +423,7 @@ public abstract class AbstractStackMachineVisitor<V> extends BaseVisitor<V> impl
                 o = makeNode(C.EXPR).put(C.EXPR, C.NUM_CONST).put(C.VALUE, 0);
                 break;
             case COLOR:
-                o = makeNode(C.EXPR).put(C.EXPR, C.LED_COLOR_CONST).put(C.VALUE, 3);
+                o = makeNode(C.EXPR).put(C.EXPR, C.COLOR_CONST).put(C.VALUE, 3);
                 break;
             case NULL:
             case CONNECTION:

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.js
@@ -615,6 +615,7 @@ define(["require", "exports", "simulation.scene", "simulation.constants", "util"
         for (var i = 0; i < numRobots; i++) {
             actionValues.push({});
         }
+        globalID = requestAnimationFrame(render);
         var now = new Date().getTime();
         var dtSim = now - time;
         var dtRobot = Math.min(15, Math.abs(dtSim - renderTime) / numRobots);
@@ -678,7 +679,6 @@ define(["require", "exports", "simulation.scene", "simulation.constants", "util"
         scene.updateSensorValues(!pause);
         scene.drawRobots();
         renderTime = new Date().getTime() - renderTimeStart;
-        globalID = requestAnimationFrame(render);
     }
     function allInterpretersTerminated() {
         for (var i = 0; i < interpreters.length; i++) {

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.js
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.js
@@ -650,6 +650,7 @@ function render() {
     for (var i = 0; i < numRobots; i++) {
         actionValues.push({});
     }
+    globalID = requestAnimationFrame(render);
     var now = new Date().getTime();
     var dtSim = now - time;
     var dtRobot = Math.min(15, Math.abs(dtSim - renderTime) / numRobots);
@@ -718,7 +719,6 @@ function render() {
     scene.updateSensorValues(!pause);
     scene.drawRobots();
     renderTime = new Date().getTime() - renderTimeStart;
-    globalID = requestAnimationFrame(render);
 }
 
 function allInterpretersTerminated() {


### PR DESCRIPTION
This PR fixes the issues stated in the openroberta-lab#1041:
- The 'ForEach colour'-block uses now the COLOR_CONST instead of the LED_COLOR_CONST

additionally this PR fixes the issue that the simulation freezed when an error occured