### PR TITLE
Fixes the missing roughcast.png file

### DIFF
--- a/RobotNAO/src/main/resources/simulation/protos/Roughcast.proto
+++ b/RobotNAO/src/main/resources/simulation/protos/Roughcast.proto
@@ -1,0 +1,24 @@
+#VRML_SIM R2022a utf8
+# license: Apache License 2.0
+# license url: http://www.apache.org/licenses/LICENSE-2.0
+# A rough plaster material. Useful with the `Wall` PROTO.
+
+PROTO Roughcast [
+  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
+  field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
+]
+{
+  PBRAppearance {
+    baseColor IS colorOverride
+    roughness 1
+    metalness 0
+    normalMap ImageTexture {
+      url [
+        "textures/roughcast/roughcast_normal.png"
+      ]
+    }
+    IBLStrength IS IBLStrength
+    textureTransform IS textureTransform
+  }
+}

--- a/RobotNAO/src/main/resources/simulation/protos/textures/roughcast/README.md
+++ b/RobotNAO/src/main/resources/simulation/protos/textures/roughcast/README.md
@@ -1,0 +1,1 @@
+This folder contains the texture

--- a/RobotNAO/src/main/resources/simulation/protos/textures/roughcast/README.md
+++ b/RobotNAO/src/main/resources/simulation/protos/textures/roughcast/README.md
@@ -1,1 +1,0 @@
-This folder contains the texture


### PR DESCRIPTION
This PR should fix the missing roughcast.png texture file as displayed by the browser:
![image](https://user-images.githubusercontent.com/1264964/174958089-216d8431-2ed4-41e3-bf87-4953b24082a7.png)
