### PR TITLE
Adjusted simValidators to show erros when necessary 

### DIFF
--- a/RobotArdu/src/main/java/de/fhg/iais/roberta/visitor/validate/MbotSimValidatorAndCollectorVisitor.java
+++ b/RobotArdu/src/main/java/de/fhg/iais/roberta/visitor/validate/MbotSimValidatorAndCollectorVisitor.java
@@ -1,14 +1,12 @@
 package de.fhg.iais.roberta.visitor.validate;
 
 import com.google.common.collect.ClassToInstanceMap;
-
 import de.fhg.iais.roberta.bean.IProjectBean;
 import de.fhg.iais.roberta.components.ConfigurationAst;
 import de.fhg.iais.roberta.syntax.actors.arduino.mbot.ReceiveIRAction;
 import de.fhg.iais.roberta.syntax.actors.arduino.mbot.SendIRAction;
 import de.fhg.iais.roberta.syntax.sensor.generic.IRSeekerSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.LightSensor;
-import de.fhg.iais.roberta.typecheck.NepoInfo;
 import de.fhg.iais.roberta.visitor.hardware.IMbotVisitor;
 
 public class MbotSimValidatorAndCollectorVisitor extends MbotValidatorAndCollectorVisitor implements IMbotVisitor<Void> {
@@ -18,7 +16,7 @@ public class MbotSimValidatorAndCollectorVisitor extends MbotValidatorAndCollect
 
     @Override
     public Void visitIRSeekerSensor(IRSeekerSensor irSeekerSensor) {
-        irSeekerSensor.addInfo(NepoInfo.warning("SIM_BLOCK_NOT_SUPPORTED"));
+        addErrorToPhrase(irSeekerSensor, "SIM_BLOCK_NOT_SUPPORTED");
         return null;
     }
 
@@ -30,14 +28,14 @@ public class MbotSimValidatorAndCollectorVisitor extends MbotValidatorAndCollect
 
     @Override
     public Void visitSendIRAction(SendIRAction sendIRAction) {
-        addErrorToPhrase(sendIRAction, "SIM_BLOCK_NOT_SUPPORTED");
+        addWarningToPhrase(sendIRAction, "SIM_BLOCK_NOT_SUPPORTED");
         return null;
     }
 
     @Override
     public Void visitReceiveIRAction(ReceiveIRAction receiveIRAction) {
         super.visitReceiveIRAction(receiveIRAction);
-        receiveIRAction.addInfo(NepoInfo.warning("SIM_BLOCK_NOT_SUPPORTED"));
+        addErrorToPhrase(receiveIRAction, "SIM_BLOCK_NOT_SUPPORTED");
         return null;
     }
 }

--- a/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/validate/Ev3SimValidatorAndCollectorVisitor.java
+++ b/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/validate/Ev3SimValidatorAndCollectorVisitor.java
@@ -1,7 +1,6 @@
 package de.fhg.iais.roberta.visitor.validate;
 
 import com.google.common.collect.ClassToInstanceMap;
-
 import de.fhg.iais.roberta.bean.IProjectBean;
 import de.fhg.iais.roberta.components.ConfigurationAst;
 import de.fhg.iais.roberta.syntax.action.communication.BluetoothReceiveAction;
@@ -18,25 +17,25 @@ public class Ev3SimValidatorAndCollectorVisitor extends Ev3ValidatorAndCollector
 
     @Override
     public Void visitBluetoothReceiveAction(BluetoothReceiveAction bluetoothReceiveAction) {
-        addWarningToPhrase(bluetoothReceiveAction, "SIM_BLOCK_NOT_SUPPORTED");
+        addErrorToPhrase(bluetoothReceiveAction, "SIM_BLOCK_NOT_SUPPORTED");
         return super.visitBluetoothReceiveAction(bluetoothReceiveAction);
     }
 
     @Override
     public Void visitCompassSensor(CompassSensor compassSensor) {
-        addWarningToPhrase(compassSensor, "SIM_BLOCK_NOT_SUPPORTED");
+        addErrorToPhrase(compassSensor, "SIM_BLOCK_NOT_SUPPORTED");
         return null;
     }
 
     @Override
     public Void visitSoundSensor(SoundSensor soundSensor) {
-        addWarningToPhrase(soundSensor, "SIM_BLOCK_NOT_SUPPORTED");
+        addErrorToPhrase(soundSensor, "SIM_BLOCK_NOT_SUPPORTED");
         return null;
     }
 
     @Override
     public Void visitHTColorSensor(HTColorSensor htColorSensor) {
-        addWarningToPhrase(htColorSensor, "SIM_BLOCK_NOT_SUPPORTED");
+        addErrorToPhrase(htColorSensor, "SIM_BLOCK_NOT_SUPPORTED");
         return null;
     }
 

--- a/RobotNAO/src/main/java/de/fhg/iais/roberta/visitor/validate/NaoSimValidatorAndCollectorVisitor.java
+++ b/RobotNAO/src/main/java/de/fhg/iais/roberta/visitor/validate/NaoSimValidatorAndCollectorVisitor.java
@@ -1,41 +1,10 @@
 package de.fhg.iais.roberta.visitor.validate;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import com.google.common.collect.ClassToInstanceMap;
-
 import de.fhg.iais.roberta.bean.IProjectBean;
 import de.fhg.iais.roberta.components.ConfigurationAst;
 import de.fhg.iais.roberta.mode.action.nao.Move;
-import de.fhg.iais.roberta.syntax.action.nao.Animation;
-import de.fhg.iais.roberta.syntax.action.nao.ApplyPosture;
-import de.fhg.iais.roberta.syntax.action.nao.Autonomous;
-import de.fhg.iais.roberta.syntax.action.nao.ForgetFace;
-import de.fhg.iais.roberta.syntax.action.nao.GetLanguage;
-import de.fhg.iais.roberta.syntax.action.nao.GetVolume;
-import de.fhg.iais.roberta.syntax.action.nao.Hand;
-import de.fhg.iais.roberta.syntax.action.nao.LearnFace;
-import de.fhg.iais.roberta.syntax.action.nao.LedOff;
-import de.fhg.iais.roberta.syntax.action.nao.LedReset;
-import de.fhg.iais.roberta.syntax.action.nao.MoveJoint;
-import de.fhg.iais.roberta.syntax.action.nao.PlayFile;
-import de.fhg.iais.roberta.syntax.action.nao.PointLookAt;
-import de.fhg.iais.roberta.syntax.action.nao.RandomEyesDuration;
-import de.fhg.iais.roberta.syntax.action.nao.RastaDuration;
-import de.fhg.iais.roberta.syntax.action.nao.RecordVideo;
-import de.fhg.iais.roberta.syntax.action.nao.SetIntensity;
-import de.fhg.iais.roberta.syntax.action.nao.SetLeds;
-import de.fhg.iais.roberta.syntax.action.nao.SetMode;
-import de.fhg.iais.roberta.syntax.action.nao.SetStiffness;
-import de.fhg.iais.roberta.syntax.action.nao.SetVolume;
-import de.fhg.iais.roberta.syntax.action.nao.Stop;
-import de.fhg.iais.roberta.syntax.action.nao.TakePicture;
-import de.fhg.iais.roberta.syntax.action.nao.TurnDegrees;
-import de.fhg.iais.roberta.syntax.action.nao.WalkAsync;
-import de.fhg.iais.roberta.syntax.action.nao.WalkDistance;
-import de.fhg.iais.roberta.syntax.action.nao.WalkTo;
+import de.fhg.iais.roberta.syntax.action.nao.*;
 import de.fhg.iais.roberta.syntax.action.speech.SayTextAction;
 import de.fhg.iais.roberta.syntax.action.speech.SayTextWithSpeedAndPitchAction;
 import de.fhg.iais.roberta.syntax.action.speech.SetLanguageAction;
@@ -43,20 +12,14 @@ import de.fhg.iais.roberta.syntax.lang.functions.MathCastCharFunct;
 import de.fhg.iais.roberta.syntax.lang.functions.MathCastStringFunct;
 import de.fhg.iais.roberta.syntax.lang.functions.TextCharCastNumberFunct;
 import de.fhg.iais.roberta.syntax.lang.functions.TextStringCastNumberFunct;
-import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
-import de.fhg.iais.roberta.syntax.sensor.generic.GyroSensor;
-import de.fhg.iais.roberta.syntax.sensor.generic.TimerSensor;
-import de.fhg.iais.roberta.syntax.sensor.generic.TouchSensor;
-import de.fhg.iais.roberta.syntax.sensor.generic.UltrasonicSensor;
-import de.fhg.iais.roberta.syntax.sensor.nao.DetectFaceSensor;
-import de.fhg.iais.roberta.syntax.sensor.nao.DetectMarkSensor;
-import de.fhg.iais.roberta.syntax.sensor.nao.DetectedFaceInformation;
-import de.fhg.iais.roberta.syntax.sensor.nao.ElectricCurrentSensor;
-import de.fhg.iais.roberta.syntax.sensor.nao.FsrSensor;
-import de.fhg.iais.roberta.syntax.sensor.nao.NaoMarkInformation;
-import de.fhg.iais.roberta.syntax.sensor.nao.RecognizeWord;
+import de.fhg.iais.roberta.syntax.sensor.generic.*;
+import de.fhg.iais.roberta.syntax.sensor.nao.*;
 import de.fhg.iais.roberta.visitor.INaoVisitor;
 import de.fhg.iais.roberta.visitor.NaoSimMethods;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class NaoSimValidatorAndCollectorVisitor extends NaoValidatorAndCollectorVisitor implements INaoVisitor<Void> {
 
@@ -297,7 +260,7 @@ public class NaoSimValidatorAndCollectorVisitor extends NaoValidatorAndCollector
 
     @Override
     public Void visitDetectMarkSensor(DetectMarkSensor detectedMark) {
-        addWarningToPhrase(detectedMark, "SIM_BLOCK_NOT_SUPPORTED");
+        addErrorToPhrase(detectedMark, "SIM_BLOCK_NOT_SUPPORTED");
         return super.visitDetectMarkSensor(detectedMark);
     }
 
@@ -357,7 +320,7 @@ public class NaoSimValidatorAndCollectorVisitor extends NaoValidatorAndCollector
 
     @Override
     public Void visitTimerSensor(TimerSensor timerSensor) {
-        addWarningToPhrase(timerSensor, "BLOCK_NOT_SUPPORTED");
+        addErrorToPhrase(timerSensor, "BLOCK_NOT_SUPPORTED");
         return super.visitTimerSensor(timerSensor);
     }
 

--- a/RobotNXT/src/main/java/de/fhg/iais/roberta/visitor/validate/NxtSimValidatorAndCollectorVisitor.java
+++ b/RobotNXT/src/main/java/de/fhg/iais/roberta/visitor/validate/NxtSimValidatorAndCollectorVisitor.java
@@ -1,7 +1,6 @@
 package de.fhg.iais.roberta.visitor.validate;
 
 import com.google.common.collect.ClassToInstanceMap;
-
 import de.fhg.iais.roberta.bean.IProjectBean;
 import de.fhg.iais.roberta.components.ConfigurationAst;
 import de.fhg.iais.roberta.syntax.action.communication.BluetoothCheckConnectAction;
@@ -21,14 +20,14 @@ public final class NxtSimValidatorAndCollectorVisitor extends NxtValidatorAndCol
     @Override
     public Void visitBluetoothCheckConnectAction(BluetoothCheckConnectAction bluetoothCheckConnectAction) {
         super.visitBluetoothCheckConnectAction(bluetoothCheckConnectAction);
-        addWarningToPhrase(bluetoothCheckConnectAction, "SIM_BLOCK_NOT_SUPPORTED");
+        addErrorToPhrase(bluetoothCheckConnectAction, "SIM_BLOCK_NOT_SUPPORTED");
         return null;
     }
 
     @Override
     public Void visitBluetoothReceiveAction(BluetoothReceiveAction bluetoothReceiveAction) {
         super.visitBluetoothReceiveAction(bluetoothReceiveAction);
-        addWarningToPhrase(bluetoothReceiveAction, "SIM_BLOCK_NOT_SUPPORTED");
+        addErrorToPhrase(bluetoothReceiveAction, "SIM_BLOCK_NOT_SUPPORTED");
         return null;
     }
 
@@ -43,7 +42,7 @@ public final class NxtSimValidatorAndCollectorVisitor extends NxtValidatorAndCol
     public Void visitColorSensor(ColorSensor colorSensor) {
         super.visitColorSensor(colorSensor);
         if ( colorSensor.getMode().equals("AMBIENTLIGHT") ) {
-            addWarningToPhrase(colorSensor, "SIM_BLOCK_NOT_SUPPORTED");
+            addErrorToPhrase(colorSensor, "SIM_BLOCK_NOT_SUPPORTED");
         }
         return null;
     }
@@ -51,7 +50,7 @@ public final class NxtSimValidatorAndCollectorVisitor extends NxtValidatorAndCol
     @Override
     public Void visitConnectConst(ConnectConst connectConst) {
         super.visitConnectConst(connectConst);
-        addWarningToPhrase(connectConst, "SIM_BLOCK_NOT_SUPPORTED");
+        addErrorToPhrase(connectConst, "SIM_BLOCK_NOT_SUPPORTED");
         return null;
     }
 
@@ -59,7 +58,7 @@ public final class NxtSimValidatorAndCollectorVisitor extends NxtValidatorAndCol
     public Void visitLightSensor(LightSensor lightSensor) {
         super.visitLightSensor(lightSensor);
         if ( lightSensor.getMode().equals("AMBIENTLIGHT") ) {
-            addWarningToPhrase(lightSensor, "SIM_BLOCK_NOT_SUPPORTED");
+            addErrorToPhrase(lightSensor, "SIM_BLOCK_NOT_SUPPORTED");
         }
         return null;
     }
@@ -67,7 +66,7 @@ public final class NxtSimValidatorAndCollectorVisitor extends NxtValidatorAndCol
     @Override
     public Void visitHTColorSensor(HTColorSensor htColorSensor) {
         super.visitHTColorSensor(htColorSensor);
-        addWarningToPhrase(htColorSensor, "SIM_BLOCK_NOT_SUPPORTED");
+        addErrorToPhrase(htColorSensor, "SIM_BLOCK_NOT_SUPPORTED");
         return null;
     }
 }


### PR DESCRIPTION
for blocks that are not supported in the the simulation
in the systems Ev3, Mbot, Nao and Nxt

# Description

most simValidatorAndCollectorVisitors only threw warnings if a block was not supported. This causes issues when a sensor block is used together with a supported action block. 
All blocks that can be used with a variable or an action block now cause errors instead of warnings

Fixes #1344 