### PR TITLE
Fixing bracket placement for naoCalour_rgb block in the simulation.

### DIFF
--- a/RobotNAO/src/main/java/de/fhg/iais/roberta/visitor/codegen/NaoPythonSimVisitor.java
+++ b/RobotNAO/src/main/java/de/fhg/iais/roberta/visitor/codegen/NaoPythonSimVisitor.java
@@ -101,7 +101,7 @@ public final class NaoPythonSimVisitor extends AbstractPythonVisitor implements 
         rgbColor.G.accept(this);
         this.sb.append(", 0), 255), min(max(");
         rgbColor.B.accept(this);
-        this.sb.append(", 0), 255), 16))");
+        this.sb.append(", 0), 255)), 16)");
         return null;
     }
 


### PR DESCRIPTION
# Description
Fixes wrong bracket placement for visistRgbColor visit-Method in the NAO SIM python code generation.

This was already fixed for the NAO-Python generator but not for the simulation. The naoColour_rgb block now works as expected in the simulation.

Fixes #1339
