### PR TITLE
Fix Blockly XML clipboard being remembered between robots

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/roberta/controller/robot.controller.js
+++ b/OpenRobertaServer/staticResources/js/app/roberta/controller/robot.controller.js
@@ -313,6 +313,7 @@ define(["require", "exports", "util", "log", "message", "guiState.controller", "
         }
         else {
             further = opt_continue || false;
+            Blockly.clipboardXml_ = null;
         }
         if (further || (GUISTATE_C.isProgramSaved() && GUISTATE_C.isConfigurationSaved())) {
             if (robot === GUISTATE_C.getRobot()) {

--- a/OpenRobertaWeb/src/app/roberta/controller/robot.controller.js
+++ b/OpenRobertaWeb/src/app/roberta/controller/robot.controller.js
@@ -2,12 +2,10 @@ import * as UTIL from 'util';
 import * as LOG from 'log';
 import * as MSG from 'message';
 import * as GUISTATE_C from 'guiState.controller';
-import * as GUISTATE from 'guiState.model';
 import * as ROBOT from 'robot.model';
 import * as PROGRAM_C from 'program.controller';
 import * as CONFIGURATION_C from 'configuration.controller';
 import * as WEBVIEW_C from 'webview.controller';
-import * as SOCKET_C from 'socket.controller';
 import * as CODEEDITOR_C from 'sourceCodeEditor.controller';
 import * as PROGCODE_C from 'progCode.controller';
 import * as $ from 'jquery';
@@ -371,6 +369,7 @@ function switchRobot(robot, opt_continue, opt_callback) {
         further = true;
     } else {
         further = opt_continue || false;
+        Blockly.clipboardXml_ = null;
     }
     if (further || (GUISTATE_C.isProgramSaved() && GUISTATE_C.isConfigurationSaved())) {
         if (robot === GUISTATE_C.getRobot()) {


### PR DESCRIPTION
# Description

This PR fixes an issue in which the user was able to copy Blockly blocks between different robot system. This causes Server Errors most of the time. To stop this, the current clipboard of the workspace gets reset if the robot is being swapped to a different robot group.


Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested in Open-Roberta lab doing swaps in between robots and copy and pasting using CTRL-C CTRL-V.