### PR TITLE
Issue/1440 Fix DivisionByZero DiffDriveFor + minor changes

### DIFF
--- a/OpenRobertaServer/src/test/resources/crossCompilerTests/_expected/robotSpecific/targetLanguage/mbot2/action.py
+++ b/OpenRobertaServer/src/test/resources/crossCompilerTests/_expected/robotSpecific/targetLanguage/mbot2/action.py
@@ -17,20 +17,34 @@ _colors = {
             "black": (0,0,0)
         }
 
-def _diffDriveFor(rpmL, rpmR, distance):
-    speedL = rpmL * _circumference / 60
-    speedR = rpmR * _circumference / 60
-    r = (speedL + speedR) * _trackWidth / 2
-    w = speedR / speedL / _trackWidth
-    timeToWait = abs(distance / (r * w))
+def diffDriveFor(rpmL, rpmR, distance):
+    timeToWait = getTimeToWait(rpmL, rpmR, distance)
+    if distance < 0:
+        rpmL = -rpmL
+        rpmR = -rpmR
     if _diffPortsSwapped:
-        mbot2.drive_speed(-rpmR, RpmL)
+        mbot2.drive_speed(-rpmR, rpmL)
     else:
         mbot2.drive_speed(rpmL, -rpmR)
     time.sleep(timeToWait)
     mbot2.EM_stop()
 
-def _RGBAsString(rgb):
+def getTimeToWait(rpmL, rpmR, distance):
+    absoluteDistance = abs(distance)
+    speedL = rpmL * _circumference / 60
+    speedR = rpmR * _circumference / 60
+
+    resultingSpeed = (speedL + speedR) / 2
+    angVel = (speedR - speedL) / (_trackWidth)
+    if angVel != 0 and resultingSpeed != 0:
+        radius = resultingSpeed / angVel
+        absoluteDistance = radius * math.sin(absoluteDistance/radius)
+    if resultingSpeed != 0:
+        return abs(absoluteDistance / resultingSpeed)
+    else:
+        return 0
+
+def RGBAsString(rgb):
     r, g, b = rgb
     color_diffs = []
     for color in _colors:
@@ -58,8 +72,8 @@ def ____move():
     mbot2.EM_turn((5), 30, "EM1")
 
 def ____drive():
-    _diffDriveFor(30, 30, 10)
-    _diffDriveFor(-(30), -(30), 10)
+    diffDriveFor(30, 30, 10)
+    diffDriveFor(-(30), -(30), 10)
     mbot2.drive_speed(30, -(30))
     mbot2.drive_speed(-(30),30)
     mbot2.EM_stop()
@@ -67,8 +81,8 @@ def ____drive():
     mbot2.turn(-(20), 30)
     mbot2.drive_speed(30, 30)
     mbot2.drive_speed(-(30), -(30))
-    _diffDriveFor(10, 30, 20)
-    _diffDriveFor(-(10), -(30), 20)
+    diffDriveFor(10, 30, 20)
+    diffDriveFor(-(10), -(30), 20)
     mbot2.drive_speed(10, -(30))
     mbot2.drive_speed(-(10),30)
 
@@ -112,7 +126,7 @@ def ____lights():
     mbuild.ultrasonic2.set_bri(50, 7, 1)
     mbuild.ultrasonic2.set_bri(50, 8, 1)
     mbuild.ultrasonic2.set_bri(50, "all", 1)
-    mbuild.quad_rgb_sensor.set_led(_RGBAsString((204, 0, 0)), 1)
+    mbuild.quad_rgb_sensor.set_led(RGBAsString((204, 0, 0)), 1)
     mbuild.quad_rgb_sensor.off_led(1)
 
 def run():

--- a/OpenRobertaServer/src/test/resources/crossCompilerTests/_expected/robotSpecific/targetLanguage/mbot2/sensors.py
+++ b/OpenRobertaServer/src/test/resources/crossCompilerTests/_expected/robotSpecific/targetLanguage/mbot2/sensors.py
@@ -49,9 +49,9 @@ def ____sensors():
     ___booleanVar = cyberpi.controller.is_press("B")
     ___numVar = cyberpi.get_bri()
     ___numVar = cyberpi.get_rotation("x")
-    ___numVar = cyberpi.get_acc("x")/ 9,80665
-    ___numVar = cyberpi.get_acc("y")/ 9,80665
-    ___numVar = cyberpi.get_acc("z")/ 9,80665
+    ___numVar = cyberpi.get_acc("x")/ 9.80665
+    ___numVar = cyberpi.get_acc("y")/ 9.80665
+    ___numVar = cyberpi.get_acc("z")/ 9.80665
     ___numVar = ((cyberpi.timer.get() - _timer1)*1000)
     ___numVar = ((cyberpi.timer.get() - _timer2)*1000)
     ___numVar = ((cyberpi.timer.get() - _timer3)*1000)
@@ -74,8 +74,8 @@ def ____sensors():
     _timer3 = cyberpi.timer.get()
     _timer4 = cyberpi.timer.get()
     _timer5 = cyberpi.timer.get()
-    mbot2.EM_reset_angle("EM1") 
-    mbot2.EM_reset_angle("EM2") 
+    mbot2.EM_reset_angle("EM1")
+    mbot2.EM_reset_angle("EM2")
 
 def ____wait_until():
     global _timer1, _timer2, _timer3, _timer4, _timer5, ___numVar, ___colourVar, ___numList, ___booleanVar
@@ -98,7 +98,7 @@ def ____wait_until():
         if cyberpi.get_rotation("x") > 90:
             break
     while True:
-        if cyberpi.get_acc("x")/ 9,80665 > 30:
+        if cyberpi.get_acc("x")/ 9.80665 > 30:
             break
     while True:
         if ((cyberpi.timer.get() - _timer1)*1000) > 500:

--- a/OpenRobertaServer/src/test/resources/crossCompilerTests/_expected/robotSpecific/targetLanguage/mbot2/text_colours_functions.py
+++ b/OpenRobertaServer/src/test/resources/crossCompilerTests/_expected/robotSpecific/targetLanguage/mbot2/text_colours_functions.py
@@ -13,7 +13,7 @@ _colors = {
             "black": (0,0,0)
         }
 
-def _RGBAsString(rgb):
+def RGBAsString(rgb):
     r, g, b = rgb
     color_diffs = []
     for color in _colors:
@@ -35,7 +35,7 @@ def ____colours():
     global ___colorVar, ___stringVar, ___booleanVar, ___numberVar, ___numberList, ___booleanList, ___stringList, ___colorList
     cyberpi.display.set_brush((204, 0, 0)[0], (204, 0, 0)[1], (204, 0, 0)[2])
     cyberpi.led.on((255, 102, 0)[0], (255, 102, 0)[1], (255, 102, 0)[2], 1)
-    mbuild.quad_rgb_sensor.set_led(_RGBAsString((255, 255, 0)), 1)
+    mbuild.quad_rgb_sensor.set_led(RGBAsString((255, 255, 0)), 1)
     cyberpi.led.on((51, 204, 0)[0], (51, 204, 0)[1], (51, 204, 0)[2], 1)
     cyberpi.led.on((51, 255, 255)[0], (51, 255, 255)[1], (51, 255, 255)[2], 1)
     cyberpi.led.on((51, 102, 255)[0], (51, 102, 255)[1], (51, 102, 255)[2], 1)
@@ -43,9 +43,9 @@ def ____colours():
     cyberpi.led.on((255, 255, 255)[0], (255, 255, 255)[1], (255, 255, 255)[2], 1)
     cyberpi.led.on((0, 0, 0)[0], (0, 0, 0)[1], (0, 0, 0)[2], 1)
     cyberpi.led.on((0, 102, 0)[0], (0, 102, 0)[1], (0, 102, 0)[2], 1)
-    mbuild.quad_rgb_sensor.set_led(_RGBAsString((51, 51, 153)), 1)
+    mbuild.quad_rgb_sensor.set_led(RGBAsString((51, 51, 153)), 1)
     cyberpi.led.on((255, 20, 150)[0], (255, 20, 150)[1], (255, 20, 150)[2], 1)
-    mbuild.quad_rgb_sensor.set_led(_RGBAsString((255, 20, 150)), 1)
+    mbuild.quad_rgb_sensor.set_led(RGBAsString((255, 20, 150)), 1)
     cyberpi.display.set_brush((255, 20, 150)[0], (255, 20, 150)[1], (255, 20, 150)[2])
     cyberpi.console.println((255, 255, 255))
     cyberpi.console.println((204, 204, 204))

--- a/RobotCyberpi/src/main/java/de/fhg/iais/roberta/visitor/Mbot2Methods.java
+++ b/RobotCyberpi/src/main/java/de/fhg/iais/roberta/visitor/Mbot2Methods.java
@@ -2,5 +2,5 @@ package de.fhg.iais.roberta.visitor;
 
 public enum Mbot2Methods {
     DIFFDRIVEFOR, //for the steerfor/ drivefor block
-    RGBASSTRING
+    RGBASSTRING,
 }

--- a/RobotCyberpi/src/main/java/de/fhg/iais/roberta/visitor/Mbot2PythonVisitor.java
+++ b/RobotCyberpi/src/main/java/de/fhg/iais/roberta/visitor/Mbot2PythonVisitor.java
@@ -529,7 +529,7 @@ public final class Mbot2PythonVisitor extends AbstractPythonVisitor implements I
 
     @Override
     public Void visitAccelerometerSensor(AccelerometerSensor accelerometerSensor) {
-        this.sb.append("cyberpi.get_acc(\"").append(accelerometerSensor.getSlot().toLowerCase()).append("\")").append("/ 9,80665");
+        this.sb.append("cyberpi.get_acc(\"").append(accelerometerSensor.getSlot().toLowerCase()).append("\")").append("/ 9.80665");
         return null;
     }
 

--- a/RobotCyberpi/src/main/resources/helperMethodsMbot2.yml
+++ b/RobotCyberpi/src/main/resources/helperMethodsMbot2.yml
@@ -4,22 +4,36 @@ include: "classpath:/common.methods.yml"
 
 DIFFDRIVEFOR:
   PYTHON: |
-    def _diffDriveFor(rpmL, rpmR, distance):
-        speedL = rpmL * _circumference / 60
-        speedR = rpmR * _circumference / 60
-        r = (speedL + speedR) * _trackWidth / 2
-        w = speedR / speedL / _trackWidth
-        timeToWait = abs(distance / (r * w))
+    def diffDriveFor(rpmL, rpmR, distance):
+        timeToWait = getTimeToWait(rpmL, rpmR, distance)
+        if distance < 0:
+            rpmL = -rpmL
+            rpmR = -rpmR
         if _diffPortsSwapped:
-            mbot2.drive_speed(-rpmR, RpmL)
+            mbot2.drive_speed(-rpmR, rpmL)
         else:
             mbot2.drive_speed(rpmL, -rpmR)
         time.sleep(timeToWait)
         mbot2.EM_stop()
 
+    def getTimeToWait(rpmL, rpmR, distance):
+        absoluteDistance = abs(distance)
+        speedL = rpmL * _circumference / 60
+        speedR = rpmR * _circumference / 60
+
+        resultingSpeed = (speedL + speedR) / 2
+        angVel = (speedR - speedL) / (_trackWidth)
+        if angVel != 0 and resultingSpeed != 0:
+            radius = resultingSpeed / angVel
+            absoluteDistance = radius * math.sin(absoluteDistance/radius)
+        if resultingSpeed != 0:
+            return abs(absoluteDistance / resultingSpeed)
+        else:
+            return 0
+
 RGBASSTRING:
   PYTHON: |
-    def _RGBAsString(rgb):
+    def RGBAsString(rgb):
         r, g, b = rgb
         color_diffs = []
         for color in _colors:

--- a/RobotCyberpi/src/main/resources/mbot2.properties
+++ b/RobotCyberpi/src/main/resources/mbot2.properties
@@ -19,7 +19,6 @@ robot.configuration = true
 robot.configuration.type = new
 robot.connection = token
 robot.helperMethods = classpath:/helperMethodsMbot2.yml
-robot.haswlan = true
 #robot.plugin.worker.validate.configuration = de.fhg.iais.roberta.worker.validate.Mbot2ConfigurationValidatorWorker
 robot.plugin.worker.validate.and.collect = de.fhg.iais.roberta.worker.Mbot2ValidatorAndCollectorWorker
 robot.plugin.worker.generate = de.fhg.iais.roberta.worker.Mbot2PythonGeneratorWorker


### PR DESCRIPTION
# Description

- This PR changes the calculation for the time it takes the mBot2 to travel a certain distance given the speed of each wheel.
- The methods have been adjusted to be more readable
- Division by zero gets caught to avoid runtime Errors

There are also two minor changes in this PR

- The Mbot2 no longer has the robot menu option to setup Wi-fi 
-  Acceleration sensor used 9,8 instead of 9.8 causing runtime errors this has been replaced

# How Has This Been Tested?

- Integrationstests have been adjusted and tested
- Tested on the real robot using the connector program with different combinations of speeds and distances
