### PR TITLE
Source code editor: scrollbars are covered by text area

### DIFF
--- a/OpenRobertaServer/staticResources/css/roberta.css
+++ b/OpenRobertaServer/staticResources/css/roberta.css
@@ -3095,6 +3095,8 @@ td[lkey="Blockly.Msg.POPUP_DOWNLOAD_STEP_A_SENSEBOX"] {
     line-height: 18px;
     font-size: 13px;
     padding: 0px;
+    z-index: 5;
+    color: transparent;
 }
 
 #codeDiv pre {


### PR DESCRIPTION
# Description

Rearrange the layers of the code editor so that the scrollbars are no longer overlapped by the code. The textarea element (creates the scrollbars) is moved in front of the pre element (contains the visible code with syntax highlighting). This way the text now runs behind the scrollbars. To not hide the syntax highlighting, the code in the textarea element is set to transparent color.

In roberta.css, two css commands have been added under the css selector '#sourceCodeEditor textarea'.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS 13.2.1 with Firefox 111.0, Chrome 111.0.5563.64 and Safari 16.3 (18614.4.6.1.6).

Also tested on Ubuntu 22.04.2 with Firefox 111.0.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules