### PR TITLE
Adapted keystrokes for Mac users

### DIFF
--- a/OpenRobertaServer/staticResources/css/roberta.css
+++ b/OpenRobertaServer/staticResources/css/roberta.css
@@ -28,7 +28,7 @@ dl.grid dd {
 }
 
 dl.grid dt {
-    min-width: 100px;
+    min-width: 130px;
 }
 
 @font-face {

--- a/OpenRobertaServer/staticResources/index.html
+++ b/OpenRobertaServer/staticResources/index.html
@@ -82,32 +82,32 @@ limitations under the License.
                     </a>
                         <ul class='dropdown-menu'>
                             <li class='menuRunProg'><a href='#'><span id='menuRunProg' class='typcn typcn-media-play'
-                                lkey='Blockly.Msg.MENU_START_BRICK'>run on brick</span><span class='kbd text-muted'>Ctrl+R</span></a></li>
+                                lkey='Blockly.Msg.MENU_START_BRICK'>run on brick</span><span class='kbd text-muted'>Ctrl&#8239;+&#8201;R</span></a></li>
                             <li><a href='#' id='menuRunSim' class='typcn typcn-simulation' lkey='Blockly.Msg.MENU_START_SIM'>run in simulation</a></li>
                             <li id='robotDefaultFirmware' class='hidden menuRunProg'><a href='#' id='menuDefaultFirmware' class='typcn typcn-arrow-sync'
                                 lkey='Blockly.Msg.MENU_RESET_FIRMWARE'>reset to the factory defaults</a></li>
                             <li><a href='#' id='menuNewProg' class='typcn typcn-document-add' lkey='Blockly.Msg.MENU_NEW'>neu ...</a></li>
                             <li class='login'><a href='#'><span id='menuListProg' class='typcn typcn-th-list' lkey='Blockly.Msg.MENU_LIST_PROG'>Liste
-                                        ...</span><span class='kbd text-muted'>Ctrl+M</span></a></li>
+                                        ...</span><span class='kbd text-muted'>Ctrl&#8239;+&#8201;M</span></a></li>
                             <li><a href='#' id='menuRunMulipleSim' class='typcn typcn-open' lkey='Blockly.Msg.MENU_RUN_MULT_SIM'>run
                                 multiple robot simulation</a></li>
                             <li><a href='#' id='menuListExamples' class='typcn typcn-th-list' lkey='Blockly.Msg.MENU_LIST_PROG_EXAMPLES'>Beispielprogramme
                                 ...</a></li>
                             <li class='login'><a href='#'><span id='menuSaveProg' class='typcn typcn-cloud-storage' lkey='Blockly.Msg.MENU_SAVE'>speichern</span><span
-                                class='kbd text-muted'>Ctrl+S</span></a></li>
+                                class='kbd text-muted'>Ctrl/Cmd&#8239;+&#8201;S</span></a></li>
                             <li class='login'><a href='#'><span id='menuSaveAsProg' class='typcn typcn-cloud-storage' lkey='Blockly.Msg.MENU_SAVE_AS'>speichern
-                                        unter ...</span><span class='kbd text-muted'>Ctrl+Shift+S</span></a></li>
+                                        unter ...</span><span class='kbd text-muted'>Ctrl/Cmd&#8239;+&#8201;Shift&#8239;+&#8201;S</span></a></li>
                             <li class=''><a href='#' id='menuShowCode' class='typcn typcn-code' lkey='Blockly.Msg.MENU_SHOW_CODE'>show code </a></li>
                             <li class=''><a href='#' id='menuSourceCodeEditor' class='typcn typcn-edit' lkey='Blockly.Msg.MENU_SOURCE_CODE_EDITOR'>open
                                 source code editor</a></li>
                             <li class=''><a href='#' id='menuLinkProg' class='typcn typcn-link' lkey='Blockly.Msg.MENU_CREATE_LINK'>erstelle
                                 Programmlink ...</a></li>
                             <li class=''><a href='#'><span id='menuExportProg' class='typcn typcn-download' lkey='Blockly.Msg.MENU_EXPORT_PROG'>export
-                                        program</span><span class='kbd text-muted'>Ctrl+E</span></a></li>
+                                        program</span><span class='kbd text-muted'>Ctrl/Cmd&#8239;+&#8201;E</span></a></li>
                             <li class='login'><a href='#'><span id='menuExportAllProgs' class='typcn typcn-download' lkey='Blockly.Msg.MENU_EXPORT_ALL_PROGS'>
                                         export all my programs</span></a></li>
                             <li class=''><a href='#'><span id='menuImportProg' class='typcn typcn-upload' lkey='Blockly.Msg.MENU_IMPORT_PROG'>import
-                                        program ...</span><span class='kbd text-muted'>Ctrl+I</span></a></li>
+                                        program ...</span><span class='kbd text-muted'>Ctrl/Cmd&#8239;+&#8201;I</span></a></li>
                             <li class='hidden'><a href='#' id='menuAttachProg' class='' lkey='Blockly.Msg.MENU_ATTACH'>anhängen ...</a></li>
                             <li class='hidden'><a href='#' id='menuPropertiesProg' class='' lkey='Blockly.Msg.MENU_PROPERTIES'>Eigenschaften</a></li>
                             <li class='divider'></li>
@@ -441,24 +441,26 @@ limitations under the License.
                         </ul>
                     </div>
                     <div class='btn-group'>
-                        <a class='btn editor btn-default' data-edit='bold' title='Bold (Ctrl/Cmd+B)'><i class='editor fa fa-bold'></i></a> <a
-                        class='btn editor btn-default' data-edit='italic' title='Italic (Ctrl/Cmd+I)'><i class='editor fa fa-italic'></i></a> <a
+                        <a class='btn editor btn-default' data-edit='bold' title='Bold (Ctrl/Cmd&#8239;+&#8201;B)'><i class='editor fa fa-bold'></i></a> <a
+                        class='btn editor btn-default' data-edit='italic' title='Italic (Ctrl/Cmd&#8239;+&#8201;I)'><i class='editor fa fa-italic'></i></a> <a
                         class='btn editor btn-default' data-edit='strikethrough' title='Strikethrough'><i class='editor fa fa-strikethrough'></i></a> <a
-                        class='btn editor btn-default' data-edit='underline' title='Underline (Ctrl/Cmd+U)'><i class='editor fa fa-underline'></i></a>
+                        class='btn editor btn-default' data-edit='underline' title='Underline (Ctrl/Cmd&#8239;+&#8201;U)'><i class='editor fa fa-underline'></i></a>
                     </div>
                     <div class='btn-group'>
-                        <a class='btn editor btn-default' data-edit='justifyleft' title='Align Left (Ctrl/Cmd+L)'><i class='editor fa fa-align-left'></i></a> <a
-                        class='btn editor btn-default' data-edit='justifycenter' title='Center (Ctrl/Cmd+E)'><i class='editor fa fa-align-center'></i></a> <a
-                        class='btn editor btn-default' data-edit='justifyright' title='Align Right (Ctrl/Cmd+R)'><i class='editor fa fa-align-right'></i></a>
-                        <a class='btn editor btn-default' data-edit='justifyfull' title='Justify (Ctrl/Cmd+J)'><i class='editor fa fa-align-justify'></i></a>
+                        <a class='btn editor btn-default' data-edit='justifyleft' title='Align Left (Ctrl/Cmd&#8239;+&#8201;L)'><i class='editor fa fa-align-left'></i></a>
+                        <a
+                            class='btn editor btn-default' data-edit='justifycenter' title='Center (Ctrl/Cmd&#8239;+&#8201;E)'><i
+                            class='editor fa fa-align-center'></i></a> <a
+                        class='btn editor btn-default' data-edit='justifyright' title='Align Right (Ctrl&#8239;+&#8201;R)'><i class='editor fa fa-align-right'></i></a>
+                        <a class='btn editor btn-default' data-edit='justifyfull' title='Justify (Ctrl/Cmd&#8239;+&#8201;J)'><i class='editor fa fa-align-justify'></i></a>
                     </div>
                     <div class='btn-group'>
                         <a class='btn editor btn-default' data-edit='insertunorderedlist' title='Bullet list'><i class='editor fa fa-list-ul'></i></a> <a
                         class='btn editor btn-default' data-edit='insertorderedlist' title='Number list'><i class='editor fa fa-list-ol'></i></a>
                     </div>
                     <div class='btn-group'>
-                        <a class='btn editor btn-default' data-edit='undo' title='Undo (Ctrl/Cmd+Z)'><i class='editor fa fa-undo'></i></a> <a
-                        class='btn editor btn-default' data-edit='redo' title='Redo (Ctrl/Cmd+Y)'><i class='editor fa fa-repeat'></i></a>
+                        <a class='btn editor btn-default' data-edit='undo' title='Undo (Ctrl/Cmd&#8239;+&#8201;Z)'><i class='editor fa fa-undo'></i></a> <a
+                        class='btn editor btn-default' data-edit='redo' title='Redo (Ctrl/Cmd&#8239;+&#8201;Y)'><i class='editor fa fa-repeat'></i></a>
                     </div>
                 </div>
                 <div id='infoContainer'>
@@ -1230,17 +1232,17 @@ limitations under the License.
                 </div>
                 <div class='modal-body' id='shortcuts'>
                     <dl class='grid'>
-                        <dt>Ctrl + E</dt>
+                        <dt>Ctrl/Cmd&#8239;+&#8201;E</dt>
                         <dd lkey='Blockly.Msg.MENU_EXPORT_PROG'></dd>
-                        <dt>Ctrl + I</dt>
+                        <dt>Ctrl/Cmd&#8239;+&#8201;I</dt>
                         <dd lkey='Blockly.Msg.MENU_IMPORT_PROG'></dd>
-                        <dt>Ctrl + M</dt>
+                        <dt>Ctrl&#8239;+&#8201;M</dt>
                         <dd lkey='Blockly.Msg.MENU_LIST_PROG'></dd>
-                        <dt>Ctrl + S</dt>
+                        <dt>Ctrl/Cmd&#8239;+&#8201;S</dt>
                         <dd lkey='Blockly.Msg.MENU_SAVE'></dd>
-                        <dt>Ctrl + Shift + S</dt>
+                        <dt>Ctrl/Cmd&#8239;+&#8201;Shift&#8239;+&#8201;S</dt>
                         <dd lkey='Blockly.Msg.MENU_SAVE_AS'></dd>
-                        <dt>Ctrl + R</dt>
+                        <dt>Ctrl&#8239;+&#8201;R</dt>
                         <dd lkey='Blockly.Msg.MENU_SHORTCUT_RUN'></dd>
                     </dl>
                 </div>

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.objects.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.objects.js
@@ -335,10 +335,11 @@ define(["require", "exports", "jquery", "util", "simulation.roberta", "simulatio
                         this.x += this.SHIFT;
                         break;
                     case 'c':
-                        if (e.ctrlKey) {
+                        if (e.ctrlKey || e.metaKey) {
                             var id = this.myScene.uniqueObjectId;
                             var shape = SimObjectShape.Rectangle;
                             this.myScene.objectToCopy = SimObjectFactory.copy(this);
+                            e.preventDefault(); // Prevent the default copy behavior of Safari, which may beep or otherwise indicate an error due to the lack of a selection. See https://github.com/google/blockly/pull/4925.
                         }
                         break;
                     default:
@@ -687,10 +688,11 @@ define(["require", "exports", "jquery", "util", "simulation.roberta", "simulatio
                     default:
                     // nothing to do so far
                 }
-                if (e.key === 'c' && e.ctrlKey) {
+                if (e.key === 'c' && (e.ctrlKey || e.metaKey)) {
                     var id = this.myScene.uniqueObjectId;
                     var shape = SimObjectShape.Circle;
                     this.myScene.objectToCopy = SimObjectFactory.copy(this);
+                    e.preventDefault(); // Prevent the default copy behavior of Safari, which may beep or otherwise indicate an error due to the lack of a selection. See https://github.com/google/blockly/pull/4925.
                 }
                 this.updateCorners();
                 $('#robotLayer').attr('tabindex', 0);
@@ -938,10 +940,11 @@ define(["require", "exports", "jquery", "util", "simulation.roberta", "simulatio
                     default:
                     // nothing to do so far
                 }
-                if (e.key === 'c' && e.ctrlKey) {
+                if (e.key === 'c' && (e.ctrlKey || e.metaKey)) {
                     var id = this.myScene.uniqueObjectId;
                     var shape = SimObjectShape.Triangle;
                     this.myScene.objectToCopy = SimObjectFactory.copy(this);
+                    e.preventDefault(); // Prevent the default copy behavior of Safari, which may beep or otherwise indicate an error due to the lack of a selection. See https://github.com/google/blockly/pull/4925.
                 }
                 this.updateCorners();
                 $('#robotLayer').attr('tabindex', 0);

--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.scene.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/simulation.scene.js
@@ -349,7 +349,7 @@ define(["require", "exports", "util", "jquery", "simulation.objects", "robot.bas
             });
         };
         SimulationScene.prototype.handleKeyEvent = function (e) {
-            if (e.key === 'v' && e.ctrlKey) {
+            if (e.key === 'v' && (e.ctrlKey || e.metaKey)) {
                 this.pasteObject(this.sim.lastMousePosition);
                 e.stopImmediatePropagation();
             }

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.objects.ts
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.objects.ts
@@ -354,10 +354,11 @@ export class RectangleSimulationObject extends BaseSimulationObject {
                     this.x += this.SHIFT;
                     break;
                 case 'c':
-                    if (e.ctrlKey) {
+                    if (e.ctrlKey || e.metaKey) {
                         let id: number = this.myScene.uniqueObjectId;
                         let shape: SimObjectShape = SimObjectShape.Rectangle;
                         this.myScene.objectToCopy = SimObjectFactory.copy(this);
+                        e.preventDefault(); // Prevent the default copy behavior of Safari, which may beep or otherwise indicate an error due to the lack of a selection. See https://github.com/google/blockly/pull/4925.
                     }
                     break;
                 default:
@@ -715,10 +716,11 @@ export class CircleSimulationObject extends BaseSimulationObject {
                 default:
                 // nothing to do so far
             }
-            if (e.key === 'c' && e.ctrlKey) {
+            if (e.key === 'c' && (e.ctrlKey || e.metaKey)) {
                 let id: number = this.myScene.uniqueObjectId;
                 let shape: SimObjectShape = SimObjectShape.Circle;
                 this.myScene.objectToCopy = SimObjectFactory.copy(this);
+                e.preventDefault(); // Prevent the default copy behavior of Safari, which may beep or otherwise indicate an error due to the lack of a selection. See https://github.com/google/blockly/pull/4925.
             }
             this.updateCorners();
             $('#robotLayer').attr('tabindex', 0);
@@ -966,10 +968,11 @@ export class TriangleSimulationObject extends BaseSimulationObject {
                 default:
                 // nothing to do so far
             }
-            if (e.key === 'c' && e.ctrlKey) {
+            if (e.key === 'c' && (e.ctrlKey || e.metaKey)) {
                 let id: number = this.myScene.uniqueObjectId;
                 let shape: SimObjectShape = SimObjectShape.Triangle;
                 this.myScene.objectToCopy = SimObjectFactory.copy(this);
+                e.preventDefault(); // Prevent the default copy behavior of Safari, which may beep or otherwise indicate an error due to the lack of a selection. See https://github.com/google/blockly/pull/4925.
             }
             this.updateCorners();
             $('#robotLayer').attr('tabindex', 0);

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.scene.ts
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/simulation.scene.ts
@@ -365,7 +365,7 @@ export class SimulationScene {
     }
 
     handleKeyEvent(e) {
-        if (e.key === 'v' && e.ctrlKey) {
+        if (e.key === 'v' && (e.ctrlKey || e.metaKey)) {
             this.pasteObject(this.sim.lastMousePosition);
             e.stopImmediatePropagation();
         }


### PR DESCRIPTION
# Description

Add the possibility to use Cmd+C and Cmd+V for copy and paste as it is conventional for Mac users. For this the actions in simulation.scene.ts and simulation.objects.ts are extended. The new ways are displayed in the menus of the Lab user interface.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on macOS 13.2.1 with Chrome 111.0.5563.110, Firefox 111.0.1 and Safari 16.3 (18614.4.6.1.6).

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules