### PR TITLE
Fix configuration error when importing on Robotino

### DIFF
--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/components/Project.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/components/Project.java
@@ -1,6 +1,7 @@
 package de.fhg.iais.roberta.components;
 
 import java.io.StringWriter;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -19,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ClassToInstanceMap;
 import com.google.common.collect.MutableClassToInstanceMap;
 
+import de.fhg.iais.roberta.bean.CompilerSetupBean;
 import de.fhg.iais.roberta.bean.IProjectBean;
 import de.fhg.iais.roberta.bean.NNBean;
 import de.fhg.iais.roberta.blockly.generated.BlockSet;
@@ -247,6 +249,12 @@ public final class Project {
     public String getCompiledHex() {
         return this.compiledHex;
     }
+    
+    public String getBinaryURL(){
+        String tokenAsUrl = URLEncoder.encode(token);
+        String tempDirectoryAsUrl = URLEncoder.encode(getWorkerResult(CompilerSetupBean.class).getTempDir());
+        return "rest/projectWorkflow/getBinary/" + tempDirectoryAsUrl + "/" + tokenAsUrl + "/" + this.programName + "/" + getBinaryFileExtension();
+    } 
 
     public void setCompiledHex(String compiledHex) {
         this.compiledHex = compiledHex;

--- a/OpenRobertaServer/src/main/java/de/fhg/iais/roberta/generated/restEntities/ProjectNepoResponse.java
+++ b/OpenRobertaServer/src/main/java/de/fhg/iais/roberta/generated/restEntities/ProjectNepoResponse.java
@@ -23,6 +23,7 @@ public class ProjectNepoResponse extends BaseResponse {
     protected String progXML;
     protected Map<String, JSONObject> confAnnos;
     protected String compiledCode;
+    protected String binaryUrl;
     protected JSONObject configuration;
 
     /**
@@ -69,6 +70,7 @@ public class ProjectNepoResponse extends BaseResponse {
         String progXML,
         Map<String, JSONObject> confAnnos,
         String compiledCode,
+        String binaryUrl,
         JSONObject configuration) {
         ProjectNepoResponse entity = new ProjectNepoResponse();
         entity.setCmd(cmd);
@@ -92,6 +94,7 @@ public class ProjectNepoResponse extends BaseResponse {
         entity.setProgXML(progXML);
         entity.setConfAnnos(confAnnos);
         entity.setCompiledCode(compiledCode);
+        entity.setBinaryURL(binaryUrl);
         entity.setConfiguration(configuration);
         entity.immutable();
         return entity;
@@ -162,6 +165,8 @@ public class ProjectNepoResponse extends BaseResponse {
                     }
                 } else if ( "compiledCode".equals(key) ) {
                     setCompiledCode(jsonO.getString(key));
+                } else if ("binaryUrl".equals(key)){
+                    setBinaryURL(jsonO.getString(key));
                 } else if ( "configuration".equals(key) ) {
                     setConfiguration(jsonO.optJSONObject(key));
                 } else {
@@ -349,6 +354,14 @@ public class ProjectNepoResponse extends BaseResponse {
         this.compiledCode = compiledCode;
         return this;
     }
+    
+    public ProjectNepoResponse setBinaryURL(String binaryUrl) {
+        if ( this.immutable ) {
+            throw new RuntimeException("compiledCode assigned to an immutable object: " + toString());
+        }
+        this.binaryUrl = binaryUrl;
+        return this;
+    }
 
     /**
      * GET configuration. Object must be immutable. Never return null or an undefined/default value.
@@ -450,6 +463,8 @@ public class ProjectNepoResponse extends BaseResponse {
                 }
             }
             jsonO.put("compiledCode", this.compiledCode);
+            jsonO.put("binaryUrl", this.binaryUrl);
+
             if ( this.configuration != null ) {
                 jsonO.put("configuration", this.configuration);
             }

--- a/OpenRobertaServer/src/main/java/de/fhg/iais/roberta/javaServer/restServices/all/controller/ProjectWorkflowRestController.java
+++ b/OpenRobertaServer/src/main/java/de/fhg/iais/roberta/javaServer/restServices/all/controller/ProjectWorkflowRestController.java
@@ -1,12 +1,23 @@
 package de.fhg.iais.roberta.javaServer.restServices.all.controller;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -129,6 +140,8 @@ public class ProjectWorkflowRestController {
             response.setConfiguration(project.getConfigurationJSON());
             // TODO auto connection robots return COMPILERWORKFLOW_SUCCESS or COMPILERWORKFLOW_PROGRAM_GENERATION_SUCCESS
             // TODO which is not mapped to anything in the frontend, ROBOT_PUSH_RUN is mapped to the message that was used before workflows
+            response.setBinaryURL(project.getBinaryURL());
+
             if ( project.getResult() == Key.COMPILERWORKFLOW_SUCCESS || project.getResult() == Key.COMPILERWORKFLOW_PROGRAM_GENERATION_SUCCESS ) {
                 project.setResult(Key.ROBOT_PUSH_RUN);
             }
@@ -146,6 +159,29 @@ public class ProjectWorkflowRestController {
             }
         }
     }
+
+    @GET
+    @Path("/getBinary/{tempDirectory}/{token}/{programName}/{ending}")
+    public Response getBinaryFile(
+        @PathParam("tempDirectory") String tempDirectory,
+        @PathParam("token") String token,
+        @PathParam("programName") String programName,
+        @PathParam("ending") String ending
+    ) throws FileNotFoundException {
+
+        token = URLDecoder.decode(token);
+        tempDirectory = URLDecoder.decode(tempDirectory);
+
+        String srcFile = tempDirectory + token + "/" + programName + "/target/" + programName + "." + ending;
+        File binaryFile = new File(srcFile);
+
+        InputStream fileInputStream = new FileInputStream(binaryFile);
+        return Response
+            .ok(fileInputStream)
+            .header("Content-Disposition", "attachment; filename=\"" + binaryFile.getName() + "\"")
+            .build();
+    }
+
 
     @POST
     @Path("/stop")

--- a/OpenRobertaServer/staticResources/js/app/roberta/controller/progRun.controller.js
+++ b/OpenRobertaServer/staticResources/js/app/roberta/controller/progRun.controller.js
@@ -187,7 +187,8 @@ define(["require", "exports", "util", "log", "message", "program.controller", "p
                 MSG.displayInformation(result, result.message, result.message, GUISTATE_C.getProgramName(), GUISTATE_C.getRobot());
             }
             else {
-                createDownloadLink(filename, result.compiledCode);
+                //TODO HIER EINFUEGEN???
+                createDownloadLink(filename, result.compiledCode, result.binaryUrl);
                 var textH = $('#popupDownloadHeader').text();
                 $('#popupDownloadHeader').text(textH.replace('$', $.trim(GUISTATE_C.getRobotRealName())));
                 for (var i = 1; Blockly.Msg['POPUP_DOWNLOAD_STEP_' + i]; i++) {
@@ -260,7 +261,7 @@ define(["require", "exports", "util", "log", "message", "program.controller", "p
                 //Internet Explorer (all ver.) does not support playing WAV files in the browser
                 //If the user uses IE11 the file will not be played, but downloaded instead
                 //See: https://caniuse.com/#feat=wav, https://www.w3schools.com/html/html5_audio.asp
-                createDownloadLink(GUISTATE_C.getProgramName() + '.wav', wavFileContent);
+                createDownloadLink(GUISTATE_C.getProgramName() + '.wav', wavFileContent, null);
             }
             else {
                 //All non-IE browsers can play WAV files in the browser, see: https://www.w3schools.com/html/html5_audio.asp
@@ -453,7 +454,7 @@ define(["require", "exports", "util", "log", "message", "program.controller", "p
      * @param content
      *            for the blob (for CONTENT_AS_BLOB)
      */
-    function createDownloadLink(fileName, content) {
+    function createDownloadLink(fileName, content, url) {
         if (!('msSaveOrOpenBlob' in navigator)) {
             $('#trA').removeClass('hidden');
         }
@@ -474,12 +475,14 @@ define(["require", "exports", "util", "log", "message", "program.controller", "p
                 downloadLink = document.createElement('a');
                 downloadLink.download = fileName;
                 downloadLink.innerHTML = fileName;
-                downloadLink.href = window.URL.createObjectURL(contentAsBlob);
+                //downloadLink.href = window.URL.createObjectURL(contentAsBlob);
+                downloadLink.href = window.location.href + '' + url;
             }
         }
         else {
             downloadLink = document.createElement('a');
-            downloadLink.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(content));
+            //downloadLink.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(content));
+            downloadLink.setAttribute('href', window.location.href + '' + url);
             downloadLink.setAttribute('download', fileName);
             downloadLink.style.display = 'none';
         }

--- a/OpenRobertaWeb/src/app/roberta/controller/progRun.controller.js
+++ b/OpenRobertaWeb/src/app/roberta/controller/progRun.controller.js
@@ -10,6 +10,8 @@ import * as WEBVIEW_C from 'webview.controller';
 import * as $ from 'jquery';
 import * as Blockly from 'blockly';
 import * as GUISTATE from 'guiState.model';
+import { robot, server } from 'guiState.model';
+import * as COMM from 'comm';
 
 var blocklyWorkspace;
 var interpreter;
@@ -218,8 +220,8 @@ function runForAutoConnection(result) {
             }, 5000);
             MSG.displayInformation(result, result.message, result.message, GUISTATE_C.getProgramName(), GUISTATE_C.getRobot());
         } else {
-            createDownloadLink(filename, result.compiledCode);
-
+            //TODO HIER EINFUEGEN???
+            createDownloadLink(filename, result.compiledCode, result.binaryUrl);
             var textH = $('#popupDownloadHeader').text();
             $('#popupDownloadHeader').text(textH.replace('$', $.trim(GUISTATE_C.getRobotRealName())));
             for (var i = 1; Blockly.Msg['POPUP_DOWNLOAD_STEP_' + i]; i++) {
@@ -300,7 +302,7 @@ function runForJSPlayConnection(result) {
             //Internet Explorer (all ver.) does not support playing WAV files in the browser
             //If the user uses IE11 the file will not be played, but downloaded instead
             //See: https://caniuse.com/#feat=wav, https://www.w3schools.com/html/html5_audio.asp
-            createDownloadLink(GUISTATE_C.getProgramName() + '.wav', wavFileContent);
+            createDownloadLink(GUISTATE_C.getProgramName() + '.wav', wavFileContent, null);
         } else {
             //All non-IE browsers can play WAV files in the browser, see: https://www.w3schools.com/html/html5_audio.asp
             $('#OKButtonModalFooter').addClass('hidden');
@@ -509,7 +511,7 @@ function timeout(callback, durationInMilliSec) {
  * @param content
  *            for the blob (for CONTENT_AS_BLOB)
  */
-function createDownloadLink(fileName, content) {
+function createDownloadLink(fileName, content, url) {
     if (!('msSaveOrOpenBlob' in navigator)) {
         $('#trA').removeClass('hidden');
     } else {
@@ -528,11 +530,13 @@ function createDownloadLink(fileName, content) {
             downloadLink = document.createElement('a');
             downloadLink.download = fileName;
             downloadLink.innerHTML = fileName;
-            downloadLink.href = window.URL.createObjectURL(contentAsBlob);
+            //downloadLink.href = window.URL.createObjectURL(contentAsBlob);
+            downloadLink.href = window.location.href + '' + url;
         }
     } else {
         downloadLink = document.createElement('a');
-        downloadLink.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(content));
+        //downloadLink.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(content));
+        downloadLink.setAttribute('href', window.location.href + '' + url);
         downloadLink.setAttribute('download', fileName);
         downloadLink.style.display = 'none';
     }

--- a/RobotRobotino/src/main/java/de/fhg/iais/roberta/worker/validate/AbstractRobotinoValidatorAndCollectorWorker.java
+++ b/RobotRobotino/src/main/java/de/fhg/iais/roberta/worker/validate/AbstractRobotinoValidatorAndCollectorWorker.java
@@ -19,7 +19,7 @@ import de.fhg.iais.roberta.worker.AbstractValidatorAndCollectorWorker;
 
 public abstract class AbstractRobotinoValidatorAndCollectorWorker extends AbstractValidatorAndCollectorWorker {
 
-    private static final List<String> NON_BLOCKING_PROPERTIES = Collections.unmodifiableList(Arrays.asList("BN", "BU", "M1", "M2", "M3"));
+    private static final List<String> NON_BLOCKING_PROPERTIES = Collections.unmodifiableList(Arrays.asList("BN", "BU", "M1", "M2", "M3", "+", "-"));
 
     @Override
     abstract protected CommonNepoValidatorAndCollectorVisitor getVisitor(


### PR DESCRIPTION
This is mainly a workaround for an error connected to Robotino and its configuration validation.

The key of fixed ports is changed to its value once exported. This is an issue for every fixed port but is only checked on the Robotino. This PR excludes both the value and key of the optical sensor's fixed ports and possible keys to work around this issue.