### PR TITLE
Issue 1486: fixes disabled nested Nepo-block causes error

### DIFF
--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/validate/AbstractValidatorAndCollectorVisitor.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/validate/AbstractValidatorAndCollectorVisitor.java
@@ -194,7 +194,7 @@ public abstract class AbstractValidatorAndCollectorVisitor extends BaseVisitor<V
     }
 
     private final void mkEmptyOrDisabledCheck(Phrase superPhrase, Phrase subPhrase) {
-        if ( subPhrase instanceof EmptyExpr || subPhrase.getProperty().isDisabled() ) {
+        if ( subPhrase instanceof EmptyExpr || (subPhrase instanceof Expr && subPhrase.getProperty().isDisabled()) ) {
             addErrorToPhrase(superPhrase, "ERROR_MISSING_PARAMETER");
         } else if ( subPhrase instanceof ExprList ) {
             for ( Expr expr : ((ExprList) subPhrase).get() ) {


### PR DESCRIPTION
# Description
This PR fixes [the Issue](https://github.com/OpenRoberta/openroberta-lab/issues/1486) that an error occurred when disabling a nested Nepo-block, which is not an instance of Expr, and trying generating the code.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

By running the integration tests and the following program
[disabledBlocksTest.xml.txt](https://github.com/OpenRoberta/openroberta-lab/files/12675075/disabledBlocksTest.xml.txt)