### PR TITLE
Issue #1414: Stop Robotino when colliding

### DIFF
--- a/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.actuators.js
+++ b/OpenRobertaServer/staticResources/js/app/simulation/simulationLogic/robot.actuators.js
@@ -557,6 +557,11 @@ define(["require", "exports", "interpreter.constants", "simulation.math", "guiSt
             var mY = Math.sin(robot.pose.theta) * tempXVel + Math.cos(robot.pose.theta) * tempYVel;
             var l = Math.sqrt(mX * mX + mY * mY);
             var a = (Math.atan2(mY, mX) + 2 * Math.PI) % (2 * Math.PI);
+            if (robot.interpreter.getRobotBehaviour().getBlocking() && this.bumpedAngle.length > 0) {
+                this.xVel = 0;
+                this.yVel = 0;
+                this.thetaVel = 0;
+            }
             for (var i = 0; i < this.bumpedAngle.length; i++) {
                 if (Math.min(Math.abs(this.bumpedAngle[i] - a), 2 * Math.PI - Math.abs(this.bumpedAngle[i] - a)) < Math.PI) {
                     var x = l * Math.cos(this.bumpedAngle[i]);

--- a/OpenRobertaWeb/src/app/simulation/simulationLogic/robot.actuators.ts
+++ b/OpenRobertaWeb/src/app/simulation/simulationLogic/robot.actuators.ts
@@ -602,6 +602,11 @@ export class RobotinoChassis extends ChassisMobile {
         let mY = Math.sin(robot.pose.theta) * tempXVel + Math.cos(robot.pose.theta) * tempYVel;
         let l = Math.sqrt(mX * mX + mY * mY);
         let a = (Math.atan2(mY, mX) + 2 * Math.PI) % (2 * Math.PI);
+        if (robot.interpreter.getRobotBehaviour().getBlocking() && this.bumpedAngle.length > 0) {
+            this.xVel = 0;
+            this.yVel = 0;
+            this.thetaVel = 0;
+        }
         for (let i = 0; i < this.bumpedAngle.length; i++) {
             if (Math.min(Math.abs(this.bumpedAngle[i] - a), 2 * Math.PI - Math.abs(this.bumpedAngle[i] - a)) < Math.PI) {
                 let x = l * Math.cos(this.bumpedAngle[i]);


### PR DESCRIPTION
# Description

For Issue 1414, it is required for the robotino robot to abort blocking blocks (This applies to the drive: x, y, distance and the drive to: x, y, speed, block) commands in case of collision.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes