### PR TITLE
Issue#1611, move visitWaitStmt to AbstractPythonVisitor

### DIFF
--- a/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/lang/codegen/prog/AbstractPythonVisitor.java
+++ b/OpenRobertaRobot/src/main/java/de/fhg/iais/roberta/visitor/lang/codegen/prog/AbstractPythonVisitor.java
@@ -72,6 +72,7 @@ import de.fhg.iais.roberta.syntax.lang.stmt.StmtList;
 import de.fhg.iais.roberta.syntax.lang.stmt.StmtTextComment;
 import de.fhg.iais.roberta.syntax.lang.stmt.TernaryExpr;
 import de.fhg.iais.roberta.syntax.lang.stmt.TextAppendStmt;
+import de.fhg.iais.roberta.syntax.lang.stmt.WaitStmt;
 import de.fhg.iais.roberta.typecheck.BlocklyType;
 import de.fhg.iais.roberta.util.dbc.DbcException;
 import de.fhg.iais.roberta.util.syntax.FunctionNames;
@@ -1034,4 +1035,21 @@ public abstract class AbstractPythonVisitor extends AbstractLanguageVisitor {
         this.src.add("main()");
         decrIndentation();
     }
+
+    /**
+     * Visits the Blockly wait-until-block ("robControls_wait_for")
+     *
+     * @param waitStmt to be visited
+     * @return null
+     */
+    public Void visitWaitStmt(WaitStmt waitStmt) {
+        this.src.add("while True:");
+        incrIndentation();
+        visitStmtList(waitStmt.statements);
+        addWaitStatementTimeout();
+        decrIndentation();
+        return null;
+    }
+   
+    protected abstract void addWaitStatementTimeout();
 }

--- a/RobotCyberpi/src/main/java/de/fhg/iais/roberta/visitor/Mbot2PythonVisitor.java
+++ b/RobotCyberpi/src/main/java/de/fhg/iais/roberta/visitor/Mbot2PythonVisitor.java
@@ -46,7 +46,6 @@ import de.fhg.iais.roberta.syntax.lang.expr.ColorConst;
 import de.fhg.iais.roberta.syntax.lang.expr.Expr;
 import de.fhg.iais.roberta.syntax.lang.expr.RgbColor;
 import de.fhg.iais.roberta.syntax.lang.stmt.StmtList;
-import de.fhg.iais.roberta.syntax.lang.stmt.WaitStmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.WaitTimeStmt;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.EncoderReset;
@@ -236,6 +235,11 @@ public final class Mbot2PythonVisitor extends AbstractPythonVisitor implements I
         nlIndent();
 
         this.src.add("main()");
+    }
+
+    @Override
+    protected void addWaitStatementTimeout() {
+
     }
 
     @Override
@@ -765,15 +769,6 @@ public final class Mbot2PythonVisitor extends AbstractPythonVisitor implements I
 
     @Override
     public Void visitPlayFileAction(PlayFileAction playFileAction) {
-        return null;
-    }
-
-    @Override
-    public Void visitWaitStmt(WaitStmt waitStmt) {
-        this.src.add("while True:");
-        incrIndentation();
-        visitStmtList(waitStmt.statements);
-        decrIndentation();
         return null;
     }
 

--- a/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/codegen/Ev3PythonVisitor.java
+++ b/RobotEV3/src/main/java/de/fhg/iais/roberta/visitor/codegen/Ev3PythonVisitor.java
@@ -47,7 +47,6 @@ import de.fhg.iais.roberta.syntax.lang.expr.ColorConst;
 import de.fhg.iais.roberta.syntax.lang.functions.MathRandomFloatFunct;
 import de.fhg.iais.roberta.syntax.lang.functions.MathRandomIntFunct;
 import de.fhg.iais.roberta.syntax.lang.stmt.StmtList;
-import de.fhg.iais.roberta.syntax.lang.stmt.WaitStmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.WaitTimeStmt;
 import de.fhg.iais.roberta.syntax.sensor.generic.ColorSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.CompassCalibrate;
@@ -104,14 +103,9 @@ public final class Ev3PythonVisitor extends AbstractPythonVisitor implements IEv
     }
 
     @Override
-    public Void visitWaitStmt(WaitStmt waitStmt) {
-        this.src.add("while True:");
-        incrIndentation();
-        visitStmtList(waitStmt.statements);
+    protected void addWaitStatementTimeout() {
         nlIndent();
         this.src.add("hal.waitFor(15)");
-        decrIndentation();
-        return null;
     }
 
     @Override

--- a/RobotEdison/src/main/java/de/fhg/iais/roberta/visitor/codegen/EdisonPythonVisitor.java
+++ b/RobotEdison/src/main/java/de/fhg/iais/roberta/visitor/codegen/EdisonPythonVisitor.java
@@ -38,7 +38,6 @@ import de.fhg.iais.roberta.syntax.lang.functions.TextCharCastNumberFunct;
 import de.fhg.iais.roberta.syntax.lang.functions.TextStringCastNumberFunct;
 import de.fhg.iais.roberta.syntax.lang.methods.MethodIfReturn;
 import de.fhg.iais.roberta.syntax.lang.stmt.StmtList;
-import de.fhg.iais.roberta.syntax.lang.stmt.WaitStmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.WaitTimeStmt;
 import de.fhg.iais.roberta.syntax.sensor.generic.GetSampleSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.IRSeekerSensor;
@@ -548,21 +547,9 @@ public class EdisonPythonVisitor extends AbstractPythonVisitor implements IEdiso
         return null;
     }
 
-    /**
-     * Visits the Blockly wait-until-block ("robControls_wait_for")
-     *
-     * @param waitStmt to be visited
-     * @return null
-     */
-    @Override
-    public Void visitWaitStmt(WaitStmt waitStmt) {
-        this.src.add("while True:");
-        incrIndentation();
-        visitStmtList(waitStmt.statements);
+    protected void addWaitStatementTimeout() {
         nlIndent();
         this.src.add("pass");
-        decrIndentation();
-        return null;
     }
 
     @Override

--- a/RobotMbed/src/main/java/de/fhg/iais/roberta/visitor/codegen/MicrobitPythonVisitor.java
+++ b/RobotMbed/src/main/java/de/fhg/iais/roberta/visitor/codegen/MicrobitPythonVisitor.java
@@ -33,7 +33,6 @@ import de.fhg.iais.roberta.syntax.lang.blocksequence.MainTask;
 import de.fhg.iais.roberta.syntax.lang.expr.EmptyExpr;
 import de.fhg.iais.roberta.syntax.lang.stmt.StmtList;
 import de.fhg.iais.roberta.syntax.lang.stmt.StmtTextComment;
-import de.fhg.iais.roberta.syntax.lang.stmt.WaitStmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.WaitTimeStmt;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.CompassSensor;
@@ -87,16 +86,6 @@ public class MicrobitPythonVisitor extends AbstractPythonVisitor implements IMic
                 super.visitEmptyExpr(emptyExpr);
                 break;
         }
-        return null;
-    }
-
-    @Override
-    public Void visitWaitStmt(WaitStmt waitStmt) {
-        this.src.add("while True:");
-        incrIndentation();
-        visitStmtList(waitStmt.statements);
-        decrIndentation();
-        //        nlIndent();
         return null;
     }
 
@@ -301,6 +290,10 @@ public class MicrobitPythonVisitor extends AbstractPythonVisitor implements IMic
         nlIndent();
 
         super.generateProgramSuffix(withWrapping);
+    }
+
+    @Override
+    protected void addWaitStatementTimeout() {
     }
 
     @Override

--- a/RobotNAO/src/main/java/de/fhg/iais/roberta/visitor/codegen/NaoPythonSimVisitor.java
+++ b/RobotNAO/src/main/java/de/fhg/iais/roberta/visitor/codegen/NaoPythonSimVisitor.java
@@ -55,7 +55,6 @@ import de.fhg.iais.roberta.syntax.lang.stmt.ExprStmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.RepeatStmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.Stmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.StmtList;
-import de.fhg.iais.roberta.syntax.lang.stmt.WaitStmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.WaitTimeStmt;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.DetectMarkSensor;
@@ -103,14 +102,9 @@ public final class NaoPythonSimVisitor extends AbstractPythonVisitor implements 
     }
 
     @Override
-    public Void visitWaitStmt(WaitStmt waitStmt) {
-        this.src.add("while robot.step(robot.timeStep) != -1:");
-        incrIndentation();
-        visitStmtList(waitStmt.statements);
+    protected void addWaitStatementTimeout() {
         nlIndent();
         this.src.add("wait(robot, 1)");
-        decrIndentation();
-        return null;
     }
 
     @Override

--- a/RobotNAO/src/main/java/de/fhg/iais/roberta/visitor/codegen/NaoPythonVisitor.java
+++ b/RobotNAO/src/main/java/de/fhg/iais/roberta/visitor/codegen/NaoPythonVisitor.java
@@ -54,7 +54,6 @@ import de.fhg.iais.roberta.syntax.lang.functions.TextStringCastNumberFunct;
 import de.fhg.iais.roberta.syntax.lang.stmt.ExprStmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.Stmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.StmtList;
-import de.fhg.iais.roberta.syntax.lang.stmt.WaitStmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.WaitTimeStmt;
 import de.fhg.iais.roberta.syntax.sensor.generic.AccelerometerSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.DetectMarkSensor;
@@ -108,14 +107,9 @@ public final class NaoPythonVisitor extends AbstractPythonVisitor implements INa
     }
 
     @Override
-    public Void visitWaitStmt(WaitStmt waitStmt) {
-        this.src.add("while True:");
-        incrIndentation();
-        visitStmtList(waitStmt.statements);
+    protected void addWaitStatementTimeout() {
         nlIndent();
         this.src.add("h.wait(15)");
-        decrIndentation();
-        return null;
     }
 
     @Override

--- a/RobotRobotino/src/main/java/de/fhg/iais/roberta/visitor/RobotinoPythonVisitor.java
+++ b/RobotRobotino/src/main/java/de/fhg/iais/roberta/visitor/RobotinoPythonVisitor.java
@@ -25,7 +25,6 @@ import de.fhg.iais.roberta.syntax.configuration.ConfigurationComponent;
 import de.fhg.iais.roberta.syntax.lang.blocksequence.MainTask;
 import de.fhg.iais.roberta.syntax.lang.expr.VarDeclaration;
 import de.fhg.iais.roberta.syntax.lang.stmt.StmtList;
-import de.fhg.iais.roberta.syntax.lang.stmt.WaitStmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.WaitTimeStmt;
 import de.fhg.iais.roberta.syntax.sensor.generic.DetectMarkSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.InfraredSensor;
@@ -334,14 +333,9 @@ public final class RobotinoPythonVisitor extends AbstractPythonVisitor implement
     }
 
     @Override
-    public Void visitWaitStmt(WaitStmt waitStmt) {
-        this.src.add("while True:");
-        incrIndentation();
-        visitStmtList(waitStmt.statements);
+    protected void addWaitStatementTimeout() {
         nlIndent();
         this.src.add("time.sleep(0.2)");
-        decrIndentation();
-        return null;
     }
 
     @Override

--- a/RobotSpike/src/main/java/de/fhg/iais/roberta/visitor/SpikePythonVisitor.java
+++ b/RobotSpike/src/main/java/de/fhg/iais/roberta/visitor/SpikePythonVisitor.java
@@ -32,7 +32,6 @@ import de.fhg.iais.roberta.syntax.lang.blocksequence.MainTask;
 import de.fhg.iais.roberta.syntax.lang.expr.ColorConst;
 import de.fhg.iais.roberta.syntax.lang.expr.RgbColor;
 import de.fhg.iais.roberta.syntax.lang.stmt.StmtList;
-import de.fhg.iais.roberta.syntax.lang.stmt.WaitStmt;
 import de.fhg.iais.roberta.syntax.lang.stmt.WaitTimeStmt;
 import de.fhg.iais.roberta.syntax.sensor.generic.ColorSensor;
 import de.fhg.iais.roberta.syntax.sensor.generic.GestureSensor;
@@ -624,15 +623,6 @@ public final class SpikePythonVisitor extends AbstractPythonVisitor implements I
     }
 
     @Override
-    public Void visitWaitStmt(WaitStmt waitStmt) {
-        this.src.add("while True:");
-        incrIndentation();
-        visitStmtList(waitStmt.statements);
-        decrIndentation();
-        return null;
-    }
-
-    @Override
     public Void visitWaitTimeStmt(WaitTimeStmt waitTimeStmt) {
         this.src.add("wait_for_seconds(");
         waitTimeStmt.time.accept(this);
@@ -740,6 +730,11 @@ public final class SpikePythonVisitor extends AbstractPythonVisitor implements I
         nlIndent();
 
         this.src.add("main()");
+    }
+
+    @Override
+    protected void addWaitStatementTimeout() {
+
     }
 
     private String getPortFromConfig(String name) {


### PR DESCRIPTION
enhancement: #1611
PythonVisitor now has visitWaitStmt, function does not have to be overwritten by each python visitor.
Adding abstract function to implement waitstatement for each robot type -> drawer pattern