### PR TITLE
Issue #1643 Fix Random 0.0-1.0

### DIFF
--- a/OpenRobertaServer/src/test/resources/crossCompilerTests/_expected/robotSpecific/targetLanguage/nxt/math_lists.nxc
+++ b/OpenRobertaServer/src/test/resources/crossCompilerTests/_expected/robotSpecific/targetLanguage/nxt/math_lists.nxc
@@ -103,7 +103,7 @@ void ____math() {
     NumOut(___numberVar, (MAXLINES - ___numberVar) * MAXLINES, ( ( ___numberVar ) % ( ___numberVar ) ));
     NumOut(___numberVar, (MAXLINES - ___numberVar) * MAXLINES, MIN(MAX(___numberVar, ___numberVar), ___numberVar));
     NumOut(___numberVar, (MAXLINES - ___numberVar) * MAXLINES, Random((___numberVar) - (___numberVar)) + (___numberVar));
-    NumOut(___numberVar, (MAXLINES - ___numberVar) * MAXLINES, Random(100) / 100);
+    NumOut(___numberVar, (MAXLINES - ___numberVar) * MAXLINES, Random(100) / 100.0);
 }
 
 void ____lists() {

--- a/RobotNXT/src/main/java/de/fhg/iais/roberta/visitor/codegen/NxtNxcVisitor.java
+++ b/RobotNXT/src/main/java/de/fhg/iais/roberta/visitor/codegen/NxtNxcVisitor.java
@@ -1037,7 +1037,7 @@ public final class NxtNxcVisitor extends AbstractCppVisitor implements INxtVisit
 
     @Override
     public Void visitMathRandomFloatFunct(MathRandomFloatFunct mathRandomFloatFunct) {
-        this.src.add("Random(100) / 100");
+        this.src.add("Random(100) / 100.0");
         return null;
     }
 


### PR DESCRIPTION
Random(100) / 100 always evaluates to 0 due to integer division. The provided patch forces a floating point division.
Tested on NXT with nbc 1.2.1.r4 and original Lego firmware 1.29
